### PR TITLE
adds hooks and signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # HotMesh
 ![alpha release](https://img.shields.io/badge/release-alpha-yellow)
 
-Elevate Redis from an in-memory data store to a game-changing [service mesh](./docs/faq.md#what-is-hotmesh). Turn your unpredictable functions into unbreakable workflows.
+Elevate Redis from an in-memory data cache to a game-changing [service mesh](./docs/faq.md#what-is-hotmesh). Turn your unpredictable functions into unbreakable workflows.
 
 ## Install
 [![npm version](https://badge.fury.io/js/%40hotmeshio%2Fhotmesh.svg)](https://badge.fury.io/js/%40hotmeshio%2Fhotmesh)
@@ -13,7 +13,7 @@ npm install @hotmeshio/hotmesh
 ## Design
 The HotMesh SDK is designed to keep your code front-and-center. Write functions as you normally would, then use HotMesh to make them durable.
 
-1. Start by defining **activities**. Activities are those functions that will be invoked by your workflow. They are commonly used to read and write to databases and invoke external services. They can be written in any style, using any framework, and can even be legacy functions you've already written. The only requirement is that they return a Promise. *Note how the `saludar` example throws an error 50% of the time. It doesn't matter how unpredictable your functions are, HotMesh will retry as necessary until they succeed.*
+1. Start by defining **activities**. Activities can be written in any style, using any framework, and can even be legacy functions you've already written. The only requirement is that they return a Promise. *Note how the `saludar` example throws an error 50% of the time. It doesn't matter how unpredictable your functions are, HotMesh will retry as necessary until they succeed.*
     ```javascript
     //activities.ts
 
@@ -47,7 +47,7 @@ The HotMesh SDK is designed to keep your code front-and-center. Write functions 
     }
     ```
 
-3. Although you could call your workflow directly (it's just a vanilla function), it's only durable when invoked and orchestrated via HotMesh. By using a HotMesh **client** to trigger the function, it's guaranteed to return a result.
+3. Although you could call your workflow directly (it's just a vanilla function), it's only durable when invoked and orchestrated via HotMesh.
     ```javascript
     //client.ts
 
@@ -75,7 +75,7 @@ The HotMesh SDK is designed to keep your code front-and-center. Write functions 
     }
     ```
 
-4. The last step is to create a **worker** and link it to your workflow function. Workers listen for tasks on their assigned channel, executing the targeted workflow function until it succeeds.
+4. Finally, create a **worker** and link your workflow function. Workers listen for tasks on their assigned Redis stream and invoke your workflow function each time they receive an event.
     ```javascript
     //worker.ts
 

--- a/modules/errors.ts
+++ b/modules/errors.ts
@@ -36,11 +36,13 @@ class DurableWaitForSignalError extends Error {
 class DurableSleepError extends Error {
   code: number;
   duration: number; //seconds
-  index: number;    //execution order in the workflow 
-  constructor(message: string, duration: number, index: number) {
+  index: number;    //execution order in the workflow
+  dimension: string; //hook dimension (e.g., ',0,1,0') (uses empty string for `null`)
+  constructor(message: string, duration: number, index: number, dimension: string) {
     super(message);
     this.duration = duration;
     this.index = index;
+    this.dimension = dimension;
     this.code = 595;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Unbreakable Workflows",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -45,6 +45,7 @@
     "test:durable": "NODE_ENV=test jest ./tests/durable/*/index.test.ts --detectOpenHandles --forceExit --verbose",
     "test:durable:hello": "NODE_ENV=test jest ./tests/durable/helloworld/index.test.ts --detectOpenHandles --forceExit --verbose",
     "test:durable:goodbye": "NODE_ENV=test jest ./tests/durable/goodbye/index.test.ts --detectOpenHandles --forceExit --verbose",
+    "test:durable:hook": "NODE_ENV=test jest ./tests/durable/hook/index.test.ts --detectOpenHandles --forceExit --verbose",
     "test:durable:retry": "NODE_ENV=test jest ./tests/durable/retry/index.test.ts --detectOpenHandles --forceExit --verbose",
     "test:durable:fatal": "NODE_ENV=test jest ./tests/durable/fatal/index.test.ts --detectOpenHandles --forceExit --verbose",
     "test:durable:sleep": "NODE_ENV=test jest ./tests/durable/sleep/index.test.ts --detectOpenHandles --forceExit --verbose",

--- a/services/durable/search.ts
+++ b/services/durable/search.ts
@@ -5,6 +5,8 @@ import { KeyService, KeyType } from '../../modules/key';
 
 export class Search {
   jobId: string;
+  searchSessionId: string;
+  searchSessionIndex: number = 0;
   hotMeshClient: HotMesh;
   store: StoreService<RedisClient, RedisMulti> | null;
 
@@ -14,19 +16,34 @@ export class Search {
     return `_${key}`;
   }
 
-  constructor(workflowId: string, hotMeshClient: HotMesh) {
+  constructor(workflowId: string, hotMeshClient: HotMesh, searchSessionId: string) {
     const keyParams = {
       appId: hotMeshClient.appId,
       jobId: ''
     }
     const hotMeshPrefix = KeyService.mintKey(hotMeshClient.namespace, KeyType.JOB_STATE, keyParams);
     this.jobId = `${hotMeshPrefix}${workflowId}`;
+    this.searchSessionId = searchSessionId;
     this.hotMeshClient = hotMeshClient;
     this.store = hotMeshClient.engine.store as StoreService<RedisClient, RedisMulti>;
   }
 
+  /**
+   * increments the index to return a unique search session guid when
+   * calling any method that produces side effects (changes the value)
+   */
+  getSearchSessionGuid(): string {
+    //return the search session as it would exist in the search session index
+    return `${this.searchSessionId}-${this.searchSessionIndex++}-`;
+  }
+
   async set(key: string, value: string): Promise<void> {
-    await this.store.exec('HSET', this.jobId, this.safeKey(key), value.toString());
+    const ssGuid = this.getSearchSessionGuid();
+    const ssGuidValue = Number(await this.store.exec('HINCRBYFLOAT', this.jobId, ssGuid, '1') as string);
+    if (ssGuidValue === 1) {
+      //only allowed to set a value the first time
+      await this.store.exec('HSET', this.jobId, this.safeKey(key), value.toString());
+    }
   }
 
   async get(key: string): Promise<string> {
@@ -39,16 +56,28 @@ export class Search {
   }
 
   async del(key: string): Promise<void> {
-    await this.store.exec('HDEL', this.jobId, this.safeKey(key));
+    const ssGuid = this.getSearchSessionGuid();
+    const ssGuidValue = Number(await this.store.exec('HINCRBYFLOAT', this.jobId, ssGuid, '1') as string);
+    if (ssGuidValue === 1) {
+      await this.store.exec('HDEL', this.jobId, this.safeKey(key));
+    }
   }
 
   async incr(key: string, val: number): Promise<number> {
-    return Number(await this.store.exec('HINCRBYFLOAT', this.jobId, this.safeKey(key), val.toString()) as string);
+    const ssGuid = this.getSearchSessionGuid();
+    const ssGuidValue = Number(await this.store.exec('HINCRBYFLOAT', this.jobId, ssGuid, '1') as string);
+    if (ssGuidValue === 1) {
+      return Number(await this.store.exec('HINCRBYFLOAT', this.jobId, this.safeKey(key), val.toString()) as string);
+    }
   }
 
   async mult(key: string, val: number): Promise<number> {
-    const log = Math.log(val);
-    const logTotal = Number(await this.store.exec('HINCRBYFLOAT', this.jobId, this.safeKey(key), log.toString()) as string);
-    return Math.exp(logTotal);
+    const ssGuid = this.getSearchSessionGuid();
+    const ssGuidValue = Number(await this.store.exec('HINCRBYFLOAT', this.jobId, ssGuid, '1') as string);
+    if (ssGuidValue === 1) {
+      const log = Math.log(val);
+      const logTotal = Number(await this.store.exec('HINCRBYFLOAT', this.jobId, this.safeKey(key), log.toString()) as string);
+      return Math.exp(logTotal);
+    }
   }
 }

--- a/services/durable/workflow.ts
+++ b/services/durable/workflow.ts
@@ -1,14 +1,24 @@
 import ms from 'ms';
 
+import {
+  DurableIncompleteSignalError,
+  DurableSleepError,
+  DurableWaitForSignalError } from '../../modules/errors';
+import { KeyService, KeyType } from '../../modules/key';
 import { asyncLocalStorage } from './asyncLocalStorage';
-import { WorkerService } from './worker';
 import { ClientService as Client } from './client';
 import { ConnectionService as Connection } from './connection';
-import { ActivityConfig, ProxyType, WorkflowConfig, WorkflowOptions, WorkflowSearchOptions } from "../../types/durable";
-import { JobOutput, JobState } from '../../types';
-import { ACTIVITY_PUBLISHES_TOPIC, ACTIVITY_SUBSCRIBES_TOPIC, SLEEP_SUBSCRIBES_TOPIC, WFS_SUBSCRIBES_TOPIC } from './factory';
-import { DurableIncompleteSignalError, DurableSleepError, DurableWaitForSignalError } from '../../modules/errors';
+import { DEFAULT_COEFFICIENT } from './factory';
 import { Search } from './search';
+import { WorkerService } from './worker';
+import { HotMeshService as HotMesh } from '../hotmesh';
+import {
+  ActivityConfig,
+  HookOptions,
+  ProxyType,
+  WorkflowOptions } from "../../types/durable";
+import { JobOutput, JobState } from '../../types/job';
+import { StreamStatus } from '../../types/stream';
 
 export class WorkflowService {
 
@@ -17,15 +27,13 @@ export class WorkflowService {
    */
   static async executeChild<T>(options: WorkflowOptions): Promise<T> {
     const store = asyncLocalStorage.getStore();
-    if (!store) {
-      throw new Error('durable-store-not-found');
-    }
     const workflowId = store.get('workflowId');
+    const workflowDimension = store.get('workflowDimension') ?? '';
     const workflowTrace = store.get('workflowTrace');
     const workflowSpan = store.get('workflowSpan');
     const COUNTER = store.get('counter');
     const execIndex = COUNTER.counter = COUNTER.counter + 1;
-    const childJobId = `${workflowId}-$${options.workflowName}-${execIndex}`;
+    const childJobId = `${workflowId}-$${options.workflowName}${workflowDimension}-${execIndex}`;
     const parentWorkflowId = `${workflowId}-f`;
 
     const client = new Client({
@@ -39,7 +47,7 @@ export class WorkflowService {
     );
 
     try {
-      return await handle.result() as T;
+      return await handle.result(true) as T;
     } catch (error) {
       handle = await client.workflow.start({
         ...options,
@@ -71,51 +79,117 @@ export class WorkflowService {
 
   static async search(): Promise<Search> {
     const store = asyncLocalStorage.getStore();
-    if (!store) {
-      throw new Error('durable-store-not-found');
-    }
     const workflowId = store.get('workflowId');
+    const workflowDimension = store.get('workflowDimension') ?? '';
     const workflowTopic = store.get('workflowTopic');
+    const namespace = store.get('namespace');
+    const COUNTER = store.get('counter');
+    const execIndex = COUNTER.counter = COUNTER.counter + 1;
+    //this ID is used as a item key with a hash (dash prefix ensures no collision)
+    const hotMeshClient = await WorkerService.getHotMesh(workflowTopic, { namespace });
+    const searchSessionId = `-search${workflowDimension}-${execIndex}`;
+    return new Search(workflowId, hotMeshClient, searchSessionId);
+  }
 
-    const hotMeshClient = await WorkerService.getHotMesh(workflowTopic);
-    return new Search(workflowId, hotMeshClient);
+  /**
+   * those methods that may only be called once must be protected by flagging
+   * their execution with a unique key (the key is stored in the workflow state)
+   */
+  static async isSideEffectAllowed(hotMeshClient: HotMesh, prefix:string): Promise<boolean> {
+    const store = asyncLocalStorage.getStore();
+    const workflowId = store.get('workflowId');
+    const workflowDimension = store.get('workflowDimension') ?? '';
+    const COUNTER = store.get('counter');
+    const execIndex = COUNTER.counter = COUNTER.counter + 1;
+    //this ID is used as a item key with a hash (dash prefix ensures no collision)
+    const sessionId = `-${prefix}${workflowDimension}-${execIndex}-`;
+    //this ID is used as a item key with a hash (dash prefix ensures no collision)
+    const keyParams = {
+      appId: hotMeshClient.appId,
+      jobId: ''
+    }
+    const hotMeshPrefix = KeyService.mintKey(hotMeshClient.namespace, KeyType.JOB_STATE, keyParams);
+    const workflowGuid = `${hotMeshPrefix}${workflowId}`;
+    const guidValue = Number(await hotMeshClient.engine.store.exec('HINCRBYFLOAT', workflowGuid, sessionId, '1') as string);
+    return guidValue === 1;
+  }
+
+  /**
+   * send signal data into any other paused thread (which is paused and
+   * awaiting the signal) from within a hook-thread or the main-thread
+   */
+  static async signal(signalId: string, data: Record<any, any>): Promise<string> {
+    const store = asyncLocalStorage.getStore();
+    const namespace = store.get('namespace');
+    const hotMeshClient = await WorkerService.getHotMesh(`${namespace}.wfs.signal`, { namespace });
+    if (await WorkflowService.isSideEffectAllowed(hotMeshClient, 'signal')) {
+      return await hotMeshClient.hook(`${namespace}.wfs.signal`, { id: signalId, data });
+    }
+  }
+
+  /**
+   * spawn a hook from either the main thread or a hook thread with
+   * the provided options; worflowId/TaskQueue/Name are optional and will
+   * default to the current workflowId/WorkflowTopic if not provided
+   */
+  static async hook(options: HookOptions): Promise<string> {
+    const store = asyncLocalStorage.getStore();
+    const namespace = store.get('namespace');
+    const hotMeshClient = await WorkerService.getHotMesh(`${namespace}.flow.signal`, { namespace });
+    if (await WorkflowService.isSideEffectAllowed(hotMeshClient, 'hook')) {
+      const store = asyncLocalStorage.getStore();
+      let workflowId: string;
+      let workflowTopic: string;
+      if (options.workflowId && options.taskQueue && options.workflowName) {
+        workflowId = options.workflowId;
+        workflowTopic = `${options.taskQueue}-${options.workflowName}`;
+      } else {
+        workflowId = store.get('workflowId');
+        workflowTopic = store.get('workflowTopic');
+      }
+      const payload = {
+        arguments: [...options.args],
+        id: workflowId,
+        workflowTopic,
+        backoffCoefficient: options.config?.backoffCoefficient || DEFAULT_COEFFICIENT,
+      }
+      return await hotMeshClient.hook(`${namespace}.flow.signal`, payload, StreamStatus.PENDING, 202);
+    }
   }
 
   static async sleep(duration: string): Promise<number> {
     const seconds = ms(duration) / 1000;
 
     const store = asyncLocalStorage.getStore();
-    if (!store) {
-      throw new Error('durable-store-not-found');
-    }
     const COUNTER = store.get('counter');
     const execIndex = COUNTER.counter = COUNTER.counter + 1;
     const workflowId = store.get('workflowId');
     const workflowTopic = store.get('workflowTopic');
-    const sleepJobId = `${workflowId}-$sleep-${execIndex}`;
+    const workflowDimension = store.get('workflowDimension') ?? '';
+    const namespace = store.get('namespace');
+    const sleepJobId = `${workflowId}-$sleep${workflowDimension}-${execIndex}`;
 
     try {
-      const hotMeshClient = await WorkerService.getHotMesh(workflowTopic);
-      await hotMeshClient.getState(SLEEP_SUBSCRIBES_TOPIC, sleepJobId);
+      const hotMeshClient = await WorkerService.getHotMesh(workflowTopic, { namespace });
+      await hotMeshClient.getState(`${hotMeshClient.appId}.sleep.execute`, sleepJobId);
       //if no error is thrown, we've already slept, return the delay
       return seconds;
     } catch (e) {
       //if an error, the sleep job was not found...rethrow error; sleep job
       // will be automatically created according to the DAG rules (they
       // spawn a new sleep job if error code 595 is thrown by the worker)
-      throw new DurableSleepError(workflowId, seconds, execIndex);
+      throw new DurableSleepError(workflowId, seconds, execIndex, workflowDimension);
     }
   }
 
   static async waitForSignal(signals: string[], options?: Record<string, string>): Promise<Record<any, any>[]> {
     const store = asyncLocalStorage.getStore();
-    if (!store) {
-      throw new Error('durable-store-not-found');
-    }
     const COUNTER = store.get('counter');
     const workflowId = store.get('workflowId');
     const workflowTopic = store.get('workflowTopic');
-    const hotMeshClient = await WorkerService.getHotMesh(workflowTopic);
+    const workflowDimension = store.get('workflowDimension') ?? '';
+    const namespace = store.get('namespace');
+    const hotMeshClient = await WorkerService.getHotMesh(workflowTopic, { namespace });
 
     //iterate the list of signals and check for done
     let allAreComplete = true;
@@ -123,10 +197,10 @@ export class WorkflowService {
     const signalResults: any[] = [];
     for (const signal of signals) {
       const execIndex = COUNTER.counter = COUNTER.counter + 1;
-      const wfsJobId = `${workflowId}-$wfs-${execIndex}`;
+      const wfsJobId = `${workflowId}-$wfs${workflowDimension}-${execIndex}`;
       try {
         if (allAreComplete) {
-          const state = await hotMeshClient.getState(WFS_SUBSCRIBES_TOPIC, wfsJobId);
+          const state = await hotMeshClient.getState(`${hotMeshClient.appId}.wfs.execute`, wfsJobId);
           if (state.data?.signalData) {
             //user data is nested to isolate from the signal id; unpackage it
             const signalData = state.data.signalData as { id: string, data: Record<any, any> };
@@ -160,23 +234,22 @@ export class WorkflowService {
   static wrapActivity<T>(activityName: string, options?: ActivityConfig): T {
     return async function() {
       const store = asyncLocalStorage.getStore();
-      if (!store) {
-        throw new Error('durable-store-not-found');
-      }
       const COUNTER = store.get('counter');
       //increment by state (not value) to avoid race conditions
       const execIndex = COUNTER.counter = COUNTER.counter + 1;
       const workflowId = store.get('workflowId');
+      const workflowDimension = store.get('workflowDimension') ?? '';
       const workflowTopic = store.get('workflowTopic');
       const trc = store.get('workflowTrace');
       const spn = store.get('workflowSpan');
+      const namespace = store.get('namespace');
       const activityTopic = `${workflowTopic}-activity`;
-      const activityJobId = `${workflowId}-$${activityName}-${execIndex}`;
+      const activityJobId = `${workflowId}-$${activityName}${workflowDimension}-${execIndex}`;
 
       let activityState: JobOutput
       try {
-        const hotMeshClient = await WorkerService.getHotMesh(activityTopic);
-        activityState = await hotMeshClient.getState(ACTIVITY_SUBSCRIBES_TOPIC, activityJobId);
+        const hotMeshClient = await WorkerService.getHotMesh(activityTopic, { namespace });
+        activityState = await hotMeshClient.getState(`${hotMeshClient.appId}.activity.execute`, activityJobId);
         if (activityState.metadata.err) {
           await hotMeshClient.scrub(activityJobId);
           throw new Error(activityState.metadata.err);
@@ -185,9 +258,9 @@ export class WorkflowService {
         }
         //one time subscription
         return await new Promise((resolve, reject) => {
-          hotMeshClient.sub(`${ACTIVITY_PUBLISHES_TOPIC}.${activityJobId}`, async (topic, message) => {
+          hotMeshClient.sub(`${hotMeshClient.appId}.activity.executed.${activityJobId}`, async (topic, message) => {
             const response = message.data?.response;
-            hotMeshClient.unsub(`${ACTIVITY_PUBLISHES_TOPIC}.${activityJobId}`);
+            hotMeshClient.unsub(`${hotMeshClient.appId}.activity.executed.${activityJobId}`);
             // Resolve the Promise when the callback is triggered with a message
             resolve(response);
           });
@@ -204,9 +277,9 @@ export class WorkflowService {
           activityName,
         };
         //start the job
-        const hotMeshClient = await WorkerService.getHotMesh(activityTopic);
+        const hotMeshClient = await WorkerService.getHotMesh(activityTopic, { namespace });
         const context = { metadata: { trc, spn }, data: {}};
-        const jobOutput = await hotMeshClient.pubsub(ACTIVITY_SUBSCRIBES_TOPIC, payload, context as JobState, duration);
+        const jobOutput = await hotMeshClient.pubsub(`${hotMeshClient.appId}.activity.execute`, payload, context as JobState, duration);
         return jobOutput.data.response as T;
       }
     } as T;

--- a/services/hotmesh/index.ts
+++ b/services/hotmesh/index.ts
@@ -20,7 +20,7 @@ import {
   IdsResponse,
   StatsResponse } from '../../types/stats';
 import { ConnectorService } from '../connector';
-import { StreamData, StreamDataResponse } from '../../types/stream';
+import { StreamCode, StreamData, StreamDataResponse, StreamStatus } from '../../types/stream';
 
 class HotMeshService {
   namespace: string;
@@ -165,8 +165,8 @@ class HotMeshService {
   }
 
   // ****** `HOOK` ACTIVITY RE-ENTRY POINT ******
-  async hook(topic: string, data: JobData, dad?: string): Promise<string> {
-    return await this.engine?.hook(topic, data, dad);
+  async hook(topic: string, data: JobData, status?: StreamStatus, code?: StreamCode): Promise<string> {
+    return await this.engine?.hook(topic, data, status, code);
   }
   async hookAll(hookTopic: string, data: JobData, query: JobStatsInput, queryFacets: string[] = []): Promise<string[]> {
     return await this.engine?.hookAll(hookTopic, data, query, queryFacets);

--- a/services/signaler/stream.ts
+++ b/services/signaler/stream.ts
@@ -150,6 +150,7 @@ class StreamSignaler {
     try {
       output = await callback(input);
     } catch (error) {
+      console.error(error);
       this.logger.error(`stream-call-function-error`, { error });
       output = this.structureUnhandledError(input, error);
     }

--- a/services/store/clients/redis.ts
+++ b/services/store/clients/redis.ts
@@ -86,7 +86,7 @@ class RedisStoreService extends StoreService<RedisClientType, RedisMultiType> {
       return (await this.redisClient.sendCommand(['XGROUP', 'CREATE', key, groupName, id, ...args])) === 1;
     } catch (error) {
       const streamType = mkStream === 'MKSTREAM' ? 'with MKSTREAM' : 'without MKSTREAM';
-      this.logger.warn(`x-group-error ${streamType} for key: ${key} and group: ${groupName}`, { error });
+      this.logger.info(`x-group-error ${streamType} for key: ${key} and group: ${groupName}`, { error });
       throw error;
     }
   }

--- a/services/store/index.ts
+++ b/services/store/index.ts
@@ -504,6 +504,8 @@ abstract class StoreService<T, U extends AbstractRedisClient> {
         delete state[':'];
       }
       return [state, status];
+    } else {
+      throw new Error(`Job ${jobId} not found`);
     }
   }
 

--- a/services/telemetry/index.ts
+++ b/services/telemetry/index.ts
@@ -252,10 +252,15 @@ class TelemetryService {
 
   static bindActivityTelemetryToState(state: StringAnyType, config: ActivityType, metadata: ActivityMetadata, context: JobState, leg: number): void {
     if (config.type === 'trigger') {
+      //trigger activities run non-duplexed and only have a single leg (2)
       state[`${metadata.aid}/output/metadata/l1s`] = context['$self'].output.metadata.l1s;
       state[`${metadata.aid}/output/metadata/l2s`] = context['$self'].output.metadata.l2s;
     } else if (polyfill.resolveActivityType(config.type) === 'hook' && leg === 1) {
-      //activities run non-duplexed and only have a single leg
+      //hook activities run non-duplexed and only have a single leg (1)
+      state[`${metadata.aid}/output/metadata/l1s`] = context['$self'].output.metadata.l1s;
+      state[`${metadata.aid}/output/metadata/l2s`] = context['$self'].output.metadata.l1s;
+    } else if (config.type === 'signal' && leg === 1) {
+      //signal activities run non-duplexed and only have a single leg (1)
       state[`${metadata.aid}/output/metadata/l1s`] = context['$self'].output.metadata.l1s;
       state[`${metadata.aid}/output/metadata/l2s`] = context['$self'].output.metadata.l1s;
     } else {

--- a/tests/$setup/apps/signal/v1/.hotmesh.signal.1.json
+++ b/tests/$setup/apps/signal/v1/.hotmesh.signal.1.json
@@ -6,11 +6,26 @@
       {
         "subscribes": "signal.test",
         "publishes": "signal.tested",
+        "input": {
+          "schema": {
+            "type": "object",
+            "properties": {
+              "child_flow_id": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "expire": 180,
         "activities": {
           "trigger": {
             "title": "Entry Point",
-            "type": "trigger"
+            "type": "trigger",
+            "job": {
+              "maps": {
+                "child_flow_id": "{$self.input.data.child_flow_id}"
+              }
+            }
           },
           "sleeper": {
             "title": "Sleep for 5s",
@@ -25,12 +40,16 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "id": {
+                    "type": "string"
+                  },
                   "parent_job_id": {
                     "type": "string"
                   }
                 }
               },
               "maps": {
+                "id": "{trigger.output.data.child_flow_id}",
                 "parent_job_id": "{$job.metadata.jid}"
               }
             }
@@ -117,6 +136,151 @@
         }
       },
       {
+        "subscribes": "signal.one.test",
+        "publishes": "signal.one.tested",
+        "input": {
+          "schema": {
+            "type": "object",
+            "properties": {
+              "child_flow_id": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "expire": 180,
+        "activities": {
+          "onetrigger": {
+            "title": "One Trigger Entry Point",
+            "type": "trigger",
+            "job": {
+              "maps": {
+                "child_flow_id": "{$self.input.data.child_flow_id}"
+              }
+            }
+          },
+          "onesleeper": {
+            "title": "Sleep for 5s",
+            "type": "hook",
+            "sleep": 5
+          },
+          "oneawaiter": {
+            "title": "Invoke another flow",
+            "type": "await",
+            "topic": "hook.test",
+            "input": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "parent_job_id": {
+                    "type": "string"
+                  }
+                }
+              },
+              "maps": {
+                "id": "{onetrigger.output.data.child_flow_id}",
+                "parent_job_id": "{$job.metadata.jid}"
+              }
+            }
+          },
+          "onesignaler": {
+            "title": "Signal other flow - pending",
+            "type": "signal",
+            "subtype": "one",
+            "topic": "hook.resume",
+            "code": 202,
+            "status": "pending",
+            "signal": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "done": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "maps": {
+                "id": "{onetrigger.output.data.child_flow_id}",
+                "done": false
+              }
+            }
+          },
+          "twosignaler": {
+            "title": "Signal other flow - success",
+            "type": "signal",
+            "subtype": "one",
+            "topic": "hook.resume",
+            "code": 200,
+            "status": "success",
+            "signal": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "done": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "maps": {
+                "id": "{onetrigger.output.data.child_flow_id}",
+                "done": true
+              }
+            }
+          },
+          "onepender": {
+            "title": "Runs when awaiter returns 202",
+            "type": "hook"
+          },
+          "oneender": {
+            "title": "Runs when awaiter returns 200",
+            "type": "hook"
+          }
+        },
+        "transitions": {
+          "onetrigger": [
+            {
+              "to": "onesleeper"
+            },
+            {
+              "to": "oneawaiter"
+            }
+          ],
+          "onesleeper": [
+            {
+              "to": "onesignaler"
+            }
+          ],
+          "onesignaler": [
+            {
+              "to": "twosignaler"
+            }
+          ],
+          "oneawaiter": [
+            {
+              "to": "oneender",
+              "conditions": {
+                "code": 200
+              }
+            },
+            {
+              "to": "onepender",
+              "conditions": {
+                "code": 202
+              }
+            }
+          ]
+        }
+      },
+      {
         "subscribes": "hook.test",
         "publishes": "hook.tested",
         "expire": 180,
@@ -144,7 +308,7 @@
           }
         },
         "activities": {
-          "t1": {
+          "hookTrigger": {
             "type": "trigger",
             "emit": true,
             "job": {
@@ -155,6 +319,7 @@
               }
             },
             "stats": {
+              "id": "{$self.input.data.id}",
               "key": "{$self.input.data.parent_job_id}",
               "granularity": "infinity",
               "measures": [
@@ -165,7 +330,7 @@
               ]
             }
           },
-          "a1": {
+          "hookSignaler": {
             "type": "hook",
             "hook": {
               "type": "object",
@@ -181,26 +346,41 @@
               }
             }
           },
-          "a2": {
+          "hook200": {
+            "title": "200 Response",
             "type": "hook"
+          },
+          "hook202": {
+            "title": "202 Response",
+            "type": "hook",
+            "emit": true
           }
         },
         "transitions": {
-          "t1": [
+          "hookTrigger": [
             {
-              "to": "a1"
+              "to": "hookSignaler"
             }
           ],
-          "a1": [
+          "hookSignaler": [
             {
-              "to": "a2"
+              "to": "hook200",
+              "conditions": {
+                "code": 200
+              }
+            },
+            {
+              "to": "hook202",
+              "conditions": {
+                "code": 202
+              }
             }
           ]
         },
         "hooks": {
           "hook.resume": [
             {
-              "to": "a1",
+              "to": "hookSignaler",
               "conditions": {
                 "match": [
                   {

--- a/tests/$setup/apps/signal/v1/hotmesh.yaml
+++ b/tests/$setup/apps/signal/v1/hotmesh.yaml
@@ -5,12 +5,22 @@ app:
     - subscribes: signal.test
       publishes: signal.tested
 
+      input:
+        schema:
+          type: object
+          properties:
+            child_flow_id:
+              type: string
+
       expire: 180
 
       activities:
         trigger:
           title: Entry Point
           type: trigger
+          job:
+            maps:
+              child_flow_id: "{$self.input.data.child_flow_id}"
 
         sleeper:
           title: Sleep for 5s
@@ -25,9 +35,12 @@ app:
             schema:
               type: object
               properties:
+                id:
+                  type: string
                 parent_job_id:
                   type: string
             maps:
+              id: '{trigger.output.data.child_flow_id}'
               parent_job_id: '{$job.metadata.jid}'
 
         signaler:
@@ -81,6 +94,109 @@ app:
             conditions:
               code: 202
 
+    - subscribes: signal.one.test
+      publishes: signal.one.tested
+
+      input:
+        schema:
+          type: object
+          properties:
+            child_flow_id:
+              type: string
+
+      expire: 180
+
+      activities:
+        onetrigger:
+          title: One Trigger Entry Point
+          type: trigger
+          job:
+            maps:
+              child_flow_id: "{$self.input.data.child_flow_id}"
+
+        onesleeper:
+          title: Sleep for 5s
+          type: hook
+          sleep: 5
+
+        oneawaiter:
+          title: Invoke another flow
+          type: await
+          topic: hook.test
+          input:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                parent_job_id:
+                  type: string
+            maps:
+              id: '{onetrigger.output.data.child_flow_id}'
+              parent_job_id: '{$job.metadata.jid}'
+
+        onesignaler:
+          title: Signal other flow - pending
+          type: signal
+          subtype: one
+          topic: hook.resume
+          code: 202
+          status: pending
+          signal:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                done:
+                  type: boolean
+            maps:
+              id: '{onetrigger.output.data.child_flow_id}'
+              done: false
+
+        twosignaler:
+          title: Signal other flow - success
+          type: signal
+          subtype: one
+          topic: hook.resume
+          code: 200
+          status: success
+          signal:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                done:
+                  type: boolean
+            maps:
+              id: '{onetrigger.output.data.child_flow_id}'
+              done: true
+
+        onepender:
+          title: Runs when awaiter returns 202
+          type: hook
+
+        oneender:
+          title: Runs when awaiter returns 200
+          type: hook
+
+      transitions:
+        onetrigger:
+          - to: onesleeper
+          - to: oneawaiter
+        onesleeper:
+          - to: onesignaler
+        onesignaler:
+          - to: twosignaler
+        oneawaiter:
+          - to: oneender
+            conditions:
+              code: 200
+          - to: onepender
+            conditions:
+              code: 202
+
     - subscribes: hook.test
       publishes: hook.tested
 
@@ -102,7 +218,7 @@ app:
               type: boolean
 
       activities:
-        t1:
+        hookTrigger:
           type: trigger
           emit: true
           job:
@@ -111,12 +227,13 @@ app:
               parent_job_id: "{$self.output.data.parent_job_id}"
               done: false
           stats:
+            id: "{$self.input.data.id}"
             key: "{$self.input.data.parent_job_id}"
             granularity: infinity
             measures:
               - measure: index
                 target: "{$self.input.data.parent_job_id}"
-        a1:
+        hookSignaler:
           type: hook
           hook:
             type: object
@@ -127,18 +244,28 @@ app:
             maps:
               done: "{$self.hook.data.done}"
 
-        a2:
+        hook200:
+          title: 200 Response
           type: hook
+        hook202:
+          title: 202 Response
+          type: hook
+          emit: true
 
       transitions:
-        t1:
-          - to: a1
-        a1:
-          - to: a2
+        hookTrigger:
+          - to: hookSignaler
+        hookSignaler:
+          - to: hook200
+            conditions:
+              code: 200
+          - to: hook202
+            conditions:
+              code: 202
 
       hooks:
         hook.resume:
-          - to: a1
+          - to: hookSignaler
             conditions:
               match:
                 - expected: "{$job.metadata.jid}"

--- a/tests/durable/fatal/index.test.ts
+++ b/tests/durable/fatal/index.test.ts
@@ -8,6 +8,7 @@ import { WorkflowHandleService } from '../../../services/durable/handle';
 import { RedisConnection } from '../../../services/connector/clients/ioredis';
 import { StreamSignaler } from '../../../services/signaler/stream';
 import { DurableFatalError } from '../../../modules/errors';
+import { sleepFor } from '../../../modules/utils';
 
 const { Connection, Client, Worker } = Durable;
 
@@ -28,11 +29,12 @@ describe('DURABLE | fatal | `Workflow Promise.all proxyActivities`', () => {
   });
 
   afterAll(async () => {
+    await sleepFor(1500);
     await Durable.Client.shutdown();
     await Durable.Worker.shutdown();
     await StreamSignaler.stopConsuming();
     await RedisConnection.disconnectAll();
-  });
+  }, 10_000);
 
   describe('Connection', () => {
     describe('connect', () => {

--- a/tests/durable/goodbye/src/workflows.ts
+++ b/tests/durable/goodbye/src/workflows.ts
@@ -5,21 +5,34 @@ const { greet, bye } = Durable.workflow
   .proxyActivities<typeof activities>({ activities });
 
 export async function example(name: string): Promise<string> {
-  //set values in the durable workflow data store (these are indexed)
+  //set values (they're added to the workflow HASH AND are indexed)
+  //(`custom1` and `custom2` were added to the 'bye-bye' index)
   const search = await Durable.workflow.search();
   await search.set('custom1', 'durable');
   await search.set('custom2', '55');
-  //this is not indexed (but is still available to the workflow)
+
+  //'jimbo' is not indexed (but it can be retrieved)
   await search.set('jimbo', 'jones');
   const [hello, goodbye] = await Promise.all([greet(name), bye(name)]);
-  //any data is available to the workflow
+
+  //all data is available to the workflow
   await search.get('jimbo');
   await search.incr('counter', 10);
   const val1 = await search.incr('counter', 1);
   const val2 = await search.get('counter');
   const val3 = await search.mult('multer', 12);
+
   //val4 is 120.00000000009 (rounding error due to logarithmic math)
   const val4 = await search.mult('multer', 10);
   //console.log(val1, val2, val3, val4);
+  const [signal1] = await Durable.workflow.waitForSignal(['abcdefg']);
+  //console.log('just awakened with signal=>', signal1);
+
   return `${hello} - ${goodbye}`;
+}
+
+export async function exampleHook(name: string): Promise<void> {
+  const search = await Durable.workflow.search();
+  await search.incr('counter', 100);
+  Durable.workflow.signal('abcdefg', { data: 'hello' });
 }

--- a/tests/durable/helloworld/index.test.ts
+++ b/tests/durable/helloworld/index.test.ts
@@ -31,11 +31,12 @@ describe('DURABLE | hello | `Workflow Sleepy Hello-World`', () => {
   });
 
   afterAll(async () => {
+    await sleepFor(1500);
     await Durable.Client.shutdown();
     await Durable.Worker.shutdown();
     await StreamSignaler.stopConsuming();
     await RedisConnection.disconnectAll();
-  });
+  }, 10_000);
 
   describe('Connection', () => {
     describe('connect', () => {

--- a/tests/durable/hook/child/activities.ts
+++ b/tests/durable/hook/child/activities.ts
@@ -1,0 +1,3 @@
+export async function childActivity(name: string): Promise<string> {
+  return `childActivity, ${name}!`;
+}

--- a/tests/durable/hook/child/workflows.ts
+++ b/tests/durable/hook/child/workflows.ts
@@ -1,0 +1,9 @@
+import { Durable } from '../../../../services/durable';
+import * as activities from './activities';
+
+const { childActivity } = Durable.workflow
+  .proxyActivities<typeof activities>({ activities });
+
+export async function childExample(name: string): Promise<string> {
+  return await childActivity(name);
+}

--- a/tests/durable/hook/src/activities.ts
+++ b/tests/durable/hook/src/activities.ts
@@ -1,0 +1,7 @@
+export async function greet(name: string): Promise<string> {
+  return `Hello, ${name}!`;
+}
+
+export async function bye(name: string): Promise<string> {
+  return `Goodbye, ${name}!`;
+}

--- a/tests/durable/hook/src/workflows.ts
+++ b/tests/durable/hook/src/workflows.ts
@@ -1,0 +1,73 @@
+import { Durable } from '../../../../services/durable';
+import * as activities from './activities';
+
+const { greet, bye } = Durable.workflow
+  .proxyActivities<typeof activities>({ activities });
+
+/**
+ * This is the main workflow function that will be executed. The workflow
+ * will end and self-clean once the final statement executes. While it
+ * is active other hook functions may also run in parallel. Once it ends
+ * no hook functions may run.
+ * 
+ * @param {string} name
+ * @returns {Promise<string>}
+ */
+export async function example(name: string): Promise<string> {
+  //create a search session and add some values
+  const search = await Durable.workflow.search();
+  await search.set('custom1', 'durable');
+  await search.set('custom2', '55');
+  //the hook function will update this value to 'jackson'
+  await search.set('jimbo', 'jones');
+
+  const childWorkflowOutput = await Durable.workflow.executeChild<string>({
+    args: [`${name} to CHILD`],
+    taskQueue: 'child-world',
+    workflowName: 'childExample',
+    workflowId: '-'
+  });
+  console.log('childWorkflowOutput is=>', childWorkflowOutput);
+
+  //call a few activities in parallel (proxyActivities)
+  const [hello, goodbye] = await Promise.all([greet(name), bye(name)]);
+
+  //bind some more search data to workflow state (multiply, increment)
+  await search.get('jimbo');
+  await search.incr('counter', 10);
+  await search.incr('counter', 1);
+  await search.get('counter');
+  await search.mult('multer', 12);
+  await search.mult('multer', 10);
+
+  //wait for the `abcdefg` signal ('exampleHook' will send it)
+  const [signal1] = await Durable.workflow.waitForSignal(['abcdefg']);
+  console.log('awakened with signal=>', signal1);
+  console.log('jimbo should be jackson=>', await search.get('jimbo'));
+
+  //sleep for 5 and then return
+  await Durable.workflow.sleep('5 seconds');
+  return `${hello} - ${goodbye}`;
+}
+
+/**
+ * This is a hook function that can be used to update the shared workflow state
+ * The function will run in a separate thread and has no blocking effect
+ * on the main thread outside of the signal command that is being used in
+ * this test. This function is called by the test runner a few seconds
+ * after it starts the main workflow.
+ * @param {string} name
+ */
+export async function exampleHook(name: string): Promise<void> {
+  //update shared job state (the workflow HASH)
+  const search = await Durable.workflow.search();
+  await search.incr('counter', 100);
+  await search.set('jimbo', 'jackson');
+  const greeting = await bye(name);
+
+  //test out sleeping
+  await Durable.workflow.sleep('1 second');
+
+  //awake the parent/main thread by sending the 'abcdefg' signal
+  await Durable.workflow.signal('abcdefg', { data: greeting });
+}

--- a/tests/durable/loopactivity/index.test.ts
+++ b/tests/durable/loopactivity/index.test.ts
@@ -7,6 +7,7 @@ import { nanoid } from 'nanoid';
 import { WorkflowHandleService } from '../../../services/durable/handle';
 import { RedisConnection } from '../../../services/connector/clients/ioredis';
 import { StreamSignaler } from '../../../services/signaler/stream';
+import { sleepFor } from '../../../modules/utils';
 
 
 const { Connection, Client, Worker } = Durable;
@@ -27,11 +28,12 @@ describe('DURABLE | loopactivity | `Iterate Same Activity`', () => {
   });
 
   afterAll(async () => {
+    await sleepFor(1500);
     await Durable.Client.shutdown();
     await Durable.Worker.shutdown();
     await StreamSignaler.stopConsuming();
     await RedisConnection.disconnectAll();
-  });
+  }, 10_000);
 
   describe('Connection', () => {
     describe('connect', () => {

--- a/tests/durable/nested/index.test.ts
+++ b/tests/durable/nested/index.test.ts
@@ -8,6 +8,7 @@ import { nanoid } from 'nanoid';
 import { WorkflowHandleService } from '../../../services/durable/handle';
 import { RedisConnection } from '../../../services/connector/clients/ioredis';
 import { StreamSignaler } from '../../../services/signaler/stream';
+import { sleepFor } from '../../../modules/utils';
 
 const { Connection, Client, NativeConnection, Worker } = Durable;
 
@@ -27,6 +28,7 @@ describe('DURABLE | nested | `workflow.executeChild`', () => {
   });
 
   afterAll(async () => {
+    await sleepFor(1500);
     await Durable.Client.shutdown();
     await Durable.Worker.shutdown();
     await StreamSignaler.stopConsuming();

--- a/tests/durable/retry/index.test.ts
+++ b/tests/durable/retry/index.test.ts
@@ -7,6 +7,7 @@ import { nanoid } from 'nanoid';
 import { WorkflowHandleService } from '../../../services/durable/handle';
 import { RedisConnection } from '../../../services/connector/clients/ioredis';
 import { StreamSignaler } from '../../../services/signaler/stream';
+import { sleepFor } from '../../../modules/utils';
 
 const { Connection, Client, Worker } = Durable;
 
@@ -27,11 +28,12 @@ describe('DURABLE | sleep | `Workflow Promise.all proxyActivities`', () => {
   });
 
   afterAll(async () => {
+    await sleepFor(1500);
     await Durable.Client.shutdown();
     await Durable.Worker.shutdown();
     await StreamSignaler.stopConsuming();
     await RedisConnection.disconnectAll();
-  });
+  }, 10_000);
 
   describe('Connection', () => {
     describe('connect', () => {

--- a/tests/durable/signal/index.test.ts
+++ b/tests/durable/signal/index.test.ts
@@ -27,6 +27,7 @@ describe('DURABLE | signal | `Durable.workflow.signal`', () => {
   });
 
   afterAll(async () => {
+    await sleepFor(1500);
     await Durable.Client.shutdown();
     await Durable.Worker.shutdown();
     await StreamSignaler.stopConsuming();

--- a/tests/durable/sleep/index.test.ts
+++ b/tests/durable/sleep/index.test.ts
@@ -28,11 +28,12 @@ describe('DURABLE | sleep | `Durable.workflow.sleep`', () => {
   });
 
   afterAll(async () => {
+    await sleepFor(1500);
     await Durable.Client.shutdown();
     await Durable.Worker.shutdown();
     await StreamSignaler.stopConsuming();
     await RedisConnection.disconnectAll();
-  });
+  }, 10_000);
 
   describe('Connection', () => {
     describe('connect', () => {

--- a/tests/functional/index.test.ts
+++ b/tests/functional/index.test.ts
@@ -152,8 +152,9 @@ describe('FUNCTIONAL | HotMesh', () => {
         facility: 'acme',
         actual_release_series: '202304110015'
       };
-      const jobId = await hotMesh.hook('order.routed', payload);
-      expect(jobId).not.toBeNull();
+      //hook returns the streamId (searchable through open telemetry)
+      const streamId = await hotMesh.hook('order.routed', payload);
+      expect(streamId).not.toBeNull();
     });
 
     it('should distribute messages to different job queues', async () => {

--- a/types/activity.ts
+++ b/types/activity.ts
@@ -70,14 +70,16 @@ interface HookActivity extends BaseActivity {
 }
 
 interface SignalActivity extends BaseActivity {
-  type: 'signal';         //signal activities call hook/hookAll
-  subtype: 'one' | 'all'; //trigger: hook(One) or hookAll
-  topic: string;          //e.g., 'hook.resume'
-  key_name: string;       //e.g., 'parent_job_id'
-  key_value: string;      //e.g., '1234567890'
-  scrub: boolean;         //if true, the index will be deleted after use
-  signal?: Record<string, any>;   //used to define/map the signal input data
-  resolver?: Record<string, any>; //used to define/map the signal key resolver
+  type: 'signal';                 //signal activities call hook/hookAll
+  subtype: 'one' | 'all';         //trigger: hook(One) or hookAll
+  topic: string;                  //e.g., 'hook.resume'
+  key_name?: string;              //e.g., 'parent_job_id'
+  key_value?: string;             //e.g., '1234567890'
+  scrub?: boolean;                //if true, the index will be deleted after use
+  signal?: Record<string, any>;   //used to define/map the signal input data (what to send/singnal into the job(s))
+  resolver?: Record<string, any>; //used to define/map the signal key resolver (the key used to lookup the job(s that are assigned to the key)
+  status?: string;                //pending, success (default), error
+  code?: number;                  //202, 200 (default)
 }
 
 interface IterateActivity extends BaseActivity {

--- a/types/durable.ts
+++ b/types/durable.ts
@@ -15,6 +15,7 @@ type WorkflowSearchOptions = {
 }
 
 type WorkflowOptions = {
+  namespace?: string;   //'durable' is the default namespace if not provided; similar to setting `appid` in the YAML
   taskQueue: string;
   args: any[];          //input arguments to pass in
   workflowId: string;   //execution id (the job id)
@@ -24,6 +25,16 @@ type WorkflowOptions = {
   workflowSpan?: string;
   search?: WorkflowSearchOptions
   config?: WorkflowConfig;
+}
+
+type HookOptions = {
+  namespace?: string;   //'durable' is the default namespace if not provided; similar to setting `appid` in the YAML
+  taskQueue: string;
+  args: any[];          //input arguments to pass into the hook
+  workflowId: string;   //execution id (the job id to hook into)
+  workflowName?: string; //the name of the user's hook function
+  search?: WorkflowSearchOptions //bind additional search terms immediately before hook reentry
+  config?: WorkflowConfig; //hook function constraints (backoffCoefficient, maximumAttempts, maximumInterval, initialInterval)
 }
 
 type SignalOptions = {
@@ -71,6 +82,7 @@ type WorkerConfig = {
 }
 
 type WorkerOptions = {
+  logLevel?: string; //debug, info, warn, error
   maxSystemRetries?: number; //1-3 (10ms, 100ms, 1_000ms)
   backoffCoefficient?: number; //2-10ish
 }
@@ -107,6 +119,7 @@ export {
   ProxyType,
   Registry,
   SignalOptions,
+  HookOptions,
   WorkerConfig,
   WorkflowConfig,
   WorkerOptions,

--- a/types/hook.ts
+++ b/types/hook.ts
@@ -16,7 +16,6 @@ interface HookConditions {
 
 interface HookRule {
   to: string;
-  keep_alive?: boolean; //if true, the hook will not be deleted after use
   conditions: HookConditions;
 }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -37,6 +37,7 @@ export {
     NativeConnection,
     ProxyType,
     Registry,
+    HookOptions,
     WorkflowConfig,
     WorkerConfig,
     WorkerOptions,


### PR DESCRIPTION
Adds durable hooks and signals, allowing for a main workflow to be supported with supporting workflows that share the same execution and memory space. The provides class-like support in that any workflow can have a 'main' thread that while 'running' and incomplete ensures the class instance is running. Other instance methods can likewise update any shared state, executing in isolated threads, but with access to the shared workflow state. Refer to the 'hook' durable test for a full example of signals, child flows, in-process flows, sleeping, incrementing, multiplying, setting, updating, etc. It serves as a kitchen sink test for complex durable workflows.