### PR TITLE
readme update / extend workflow options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.0.31",
+      "version": "0.0.32",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "Unbreakable Workflows",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/services/durable/client.ts
+++ b/services/durable/client.ts
@@ -92,8 +92,8 @@ export class ClientService {
 
   workflow = {
     start: async (options: WorkflowOptions): Promise<WorkflowHandleService> => {
-      const taskQueueName = options.taskQueue;
-      const workflowName = options.workflowName;
+      const taskQueueName = options.entity ?? options.taskQueue;
+      const workflowName = options.entity ?? options.workflowName;
       const trc = options.workflowTrace;
       const spn = options.workflowSpan;
       //topic is concat of taskQueue and workflowName

--- a/types/durable.ts
+++ b/types/durable.ts
@@ -54,11 +54,11 @@ type WorkflowSearchOptions = {
 
 type WorkflowOptions = {
   namespace?: string;         //'durable' is the default namespace if not provided; similar to setting `appid` in the YAML
-  taskQueue: string;
+  taskQueue?: string;         //optional if entity is provided
   args: any[];                //input arguments to pass in
   workflowId?: string;        //execution id (the job id)
   entity?: string;            //If invoking a workflow, passing 'entity' will apply the value as the workflowName, taskQueue, and prefix, ensuring the FT.SEARCH index is properly scoped. This is a convenience method but limits options.
-  workflowName?: string;      //the name of the user's workflow function
+  workflowName?: string;      //the name of the user's workflow function; optional if 'entity' is provided
   parentWorkflowId?: string;  //system reserved; the id of the parent; if present the flow will not self-clean until the parent that spawned it self-cleans
   workflowTrace?: string;
   workflowSpan?: string;
@@ -68,7 +68,7 @@ type WorkflowOptions = {
 
 type HookOptions = {
   namespace?: string;   //'durable' is the default namespace if not provided; similar to setting `appid` in the YAML
-  taskQueue?: string;
+  taskQueue?: string;   //optional if 'entity' is provided
   args: any[];          //input arguments to pass into the hook
   entity?: string;      //If invoking a hook, passing 'entity' will apply the value as the workflowName, taskQueue, and prefix, ensuring the FT.SEARCH index is properly scoped. This is a convenience method but limits options.
   workflowId?: string;   //execution id (the job id to hook into)


### PR DESCRIPTION
updates the readme to show the Durable workflow for setting up a solution; makes taskQueue optional if 'entity' is present.