### PR TITLE
enforces connection namespaces

### DIFF
--- a/modules/utils.ts
+++ b/modules/utils.ts
@@ -1,6 +1,6 @@
 import os from 'os';
+import { createHash } from 'crypto';
 
-import si from 'systeminformation';
 import { nanoid } from 'nanoid';
 
 import { StoreService } from '../services/store';
@@ -24,10 +24,19 @@ async function safeExecute<T>(
   }
 }
 
+export const hashOptions = (options: any): string =>{
+  const str = JSON.stringify(options);
+  return createHash('sha256').update(str).digest('hex');
+}
+
 export async function getSystemHealth(): Promise<SystemHealth> {
   const totalMemory = os.totalmem();
   const freeMemory = os.freemem();
   const usedMemory = totalMemory - freeMemory;
+
+  //NOTE: enable the following if desired; for now, only
+  //      `memory` is emitted when system health is requested
+
   //const cpus = os.cpus();
 
   // CPU load calculation remains unchanged
@@ -38,10 +47,9 @@ export async function getSystemHealth(): Promise<SystemHealth> {
   //   return { [`CPU ${i} Usage`]: `${usage.toFixed(2)}%` };
   // });
 
-  // Wrap each systeminformation call with safeExecute
+  // Wrap each systeminformation call with safeExecute (systeminformation npm package)
   //const networkStats = await safeExecute(si.networkStats(), []);
 
-  // Construct the system health object with error handling in mind
   const systemHealth = {
     TotalMemoryGB: `${(totalMemory / 1024 / 1024 / 1024).toFixed(2)} GB`,
     FreeMemoryGB: `${(freeMemory / 1024 / 1024 / 1024).toFixed(2)} GB`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "js-yaml": "^4.1.0",
         "ms": "^2.1.3",
         "nanoid": "^3.3.6",
-        "systeminformation": "^5.22.2",
         "winston": "^3.8.2"
       },
       "devDependencies": {
@@ -6460,31 +6459,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
-    },
-    "node_modules/systeminformation": {
-      "version": "5.22.2",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.22.2.tgz",
-      "integrity": "sha512-VsXY7i1UFZZhbNRv8QN6yTIqNL66/rXpMGb5xYzXx8jDYyEM0+tQpehpPdaxxvym+oYIHs9usUxDzRDNkabpVQ==",
-      "os": [
-        "darwin",
-        "linux",
-        "win32",
-        "freebsd",
-        "openbsd",
-        "netbsd",
-        "sunos",
-        "android"
-      ],
-      "bin": {
-        "systeminformation": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "Buy me a coffee",
-        "url": "https://www.buymeacoffee.com/systeminfo"
-      }
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "js-yaml": "^4.1.0",
     "ms": "^2.1.3",
     "nanoid": "^3.3.6",
-    "systeminformation": "^5.22.2",
     "winston": "^3.8.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Unbreakable Workflows",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/activities/activity.ts
+++ b/services/activities/activity.ts
@@ -79,8 +79,7 @@ class Activity {
   }
 
   /**
-   * Upon entering leg 1 of a duplexed activty, verify
-   * all aspects of the entry including job and activty state
+   * Upon entering leg 1 of a duplexed activity
    */
   async verifyEntry() {
     this.setLeg(1);
@@ -94,8 +93,7 @@ class Activity {
   }
 
   /**
-   * Upon entering leg 2 of a duplexed activty, verify
-   * all aspects of the re-entry including job and activty state
+   * Upon entering leg 2 of a duplexed activity
    */
   async verifyReentry(): Promise<number> {
     const guid = this.context.metadata.guid;
@@ -149,11 +147,11 @@ class Activity {
       let multiResponse: MultiResponseFlags;
 
       if (status === StreamStatus.PENDING) {
-        multiResponse = await this.processPending(telemetry, type);
+        multiResponse = await this.processPending(type);
       } else if (status === StreamStatus.SUCCESS) {
-        multiResponse = await this.processSuccess(telemetry, type);
+        multiResponse = await this.processSuccess(type);
       } else {
-        multiResponse = await this.processError(telemetry, type);
+        multiResponse = await this.processError();
       }
       this.transitionAdjacent(multiResponse, telemetry);
     } catch (error) {
@@ -184,10 +182,7 @@ class Activity {
     }
   }
 
-  async processPending(
-    telemetry: TelemetryService,
-    type: 'hook' | 'output',
-  ): Promise<MultiResponseFlags> {
+  async processPending(type: 'hook' | 'output'): Promise<MultiResponseFlags> {
     this.bindActivityData(type);
     this.adjacencyList = await this.filterAdjacent();
     this.mapJobData();
@@ -199,10 +194,7 @@ class Activity {
     return (await multi.exec()) as MultiResponseFlags;
   }
 
-  async processSuccess(
-    telemetry: TelemetryService,
-    type: 'hook' | 'output',
-  ): Promise<MultiResponseFlags> {
+  async processSuccess(type: 'hook' | 'output'): Promise<MultiResponseFlags> {
     this.bindActivityData(type);
     this.adjacencyList = await this.filterAdjacent();
     this.mapJobData();
@@ -214,10 +206,7 @@ class Activity {
     return (await multi.exec()) as MultiResponseFlags;
   }
 
-  async processError(
-    telemetry: TelemetryService,
-    type: string,
-  ): Promise<MultiResponseFlags> {
+  async processError(): Promise<MultiResponseFlags> {
     this.bindActivityError(this.data);
     this.adjacencyList = await this.filterAdjacent();
     if (!this.adjacencyList.length) {

--- a/types/durable.ts
+++ b/types/durable.ts
@@ -106,6 +106,11 @@ type WorkflowContext = {
    * the native HotMesh message that encapsulates the arguments, metadata, and raw data for the workflow
    */
   raw: StreamData;
+
+  /**
+   * the HotMesh connection configuration (io/redis NPM package reference and login credentials)
+   */
+  connection: Connection;
 };
 
 /**


### PR DESCRIPTION
Adds _connection isolation_ to namespaces, ensuring that separate Redis DBs can be connected to from a single microservice. Each database can contain application namespaces that are the same as those in other databases without collision.