### PR TITLE
adds status threshold

### DIFF
--- a/docs/functions/conditional.md
+++ b/docs/functions/conditional.md
@@ -6,6 +6,8 @@ In this section, various conditional functions will be explored, which are avail
 - [conditional.ternary](#conditionalternary)
 - [conditional.equality](#conditionalequality)
 - [conditional.strict_equality](#conditionalstrict_equality)
+- [conditional.inequality](#conditionalinequality)
+- [conditional.strict_inequality](#conditionalstrict_inequality)
 - [conditional.greater_than](#conditionalgreater_than)
 - [conditional.less_than](#conditionalless_than)
 - [conditional.greater_than_or_equal](#conditionalgreater_than_or_equal)
@@ -114,6 +116,75 @@ After executing the mapping rules, the resulting JSON object will be:
 ```json
 {
   "are_values_strictly_equal": false
+}
+```
+## conditional.inequality
+
+The `conditional.inequality` function checks whether two values are not equal, using non-strict inequality (!=). It takes two parameters: the first value (`value1`) and the second value (`value2`).
+
+### Example
+
+Suppose there are the following input JSON objects:
+
+**Object A:**
+```json
+{
+  "data": {
+    "value1": 42,
+    "value2": "42"
+  }
+}
+```
+
+The goal is to create a new object with a boolean value indicating whether `value1` and `value2` are not equal. The `conditional.inequality` function can be used in the mapping rules as follows:
+
+```yaml
+are_values_not_equal:
+  "@pipe":
+    - ["{a.data.value1}", "{a.data.value2}"]
+    - ["{@conditional.inequality}"]
+```
+
+After executing the mapping rules, the resulting JSON object will be `false` as `42` and "42" are assumed to be equal when loosely compared.
+
+```json
+{
+  "are_values_not_equal": false
+}
+```
+
+## conditional.strict_inequality
+
+The `conditional.strict_inequality` function checks whether two values are not equal, using strict inequality (!==). It takes two parameters: the first value (`value1`) and the second value (`value2`).
+
+### Example
+
+Suppose there are the following input JSON objects:
+
+**Object A:**
+```json
+{
+  "data": {
+    "value1": 42,
+    "value2": "42"
+  }
+}
+```
+
+The goal is to create a new object with a boolean value indicating whether `value1` and `value2` are strictly not equal. The `conditional.strict_inequality` function can be used in the mapping rules as follows:
+
+```yaml
+are_values_strictly_not_equal:
+  "@pipe":
+    - ["{a.data.value1}", "{a.data.value2}"]
+    - ["{@conditional.strict_inequality}"]
+```
+
+After executing the mapping rules, the resulting JSON object will be:
+
+```json
+{
+  "are_values_strictly_not_equal": true
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Unbreakable Workflows",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/collator/index.ts
+++ b/services/collator/index.ts
@@ -17,8 +17,9 @@ class CollatorService {
     status: number,
     jobId: string,
     activityId: string,
+    threshold = 0,
   ): void {
-    if (status <= 0) {
+    if (status <= threshold) {
       throw new InactiveJobError(jobId, status, activityId);
     }
   }

--- a/services/durable/client.ts
+++ b/services/durable/client.ts
@@ -136,6 +136,7 @@ export class ClientService {
         arguments: [...options.args],
         originJobId: options.originJobId,
         expire: options.expire ?? HMSH_EXPIRE_JOB_SECONDS,
+        signalIn: options.signalIn,
         parentWorkflowId: options.parentWorkflowId,
         workflowId: options.workflowId || HotMesh.guid(),
         workflowTopic: workflowTopic,

--- a/services/pipe/functions/conditional.ts
+++ b/services/pipe/functions/conditional.ts
@@ -11,6 +11,14 @@ class ConditionalHandler {
     return value1 === value2;
   }
 
+  inequality(value1: any, value2: any): boolean {
+    return value1 != value2;
+  }
+
+  strict_inequality(value1: any, value2: any): boolean {
+    return value1 !== value2;
+  }
+
   greater_than(value1: number, value2: number): boolean {
     return value1 > value2;
   }

--- a/tests/$setup/apps/signal/v1/.hotmesh.signal.1.json
+++ b/tests/$setup/apps/signal/v1/.hotmesh.signal.1.json
@@ -392,6 +392,107 @@
             }
           ]
         }
+      },
+      {
+        "subscribes": "signal.toggle",
+        "publishes": "signal.toggled",
+        "input": {
+          "schema": {
+            "type": "object",
+            "properties": {
+              "jobId": {
+                "type": "string"
+              },
+              "statusThreshold": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "output": {
+          "schema": {
+            "type": "object",
+            "properties": {
+              "done": {
+                "type": "boolean"
+              },
+              "howdy": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "expire": 180,
+        "activities": {
+          "toggleTrigger": {
+            "title": "Entry Point for status threshold test",
+            "type": "trigger",
+            "stats": {
+              "id": "{$self.input.data.jobId}"
+            },
+            "job": {
+              "maps": {
+                "done": false
+              }
+            }
+          },
+          "waitForSignaler": {
+            "title": "Conditionally registers a signal-in listener if statusThreshold is met",
+            "type": "hook",
+            "statusThreshold": "{toggleTrigger.output.data.statusThreshold}",
+            "emit": {
+              "@pipe": [
+                [
+                  "{toggleTrigger.output.data.statusThreshold}",
+                  true,
+                  false
+                ],
+                [
+                  "{@conditional.ternary}"
+                ]
+              ]
+            },
+            "hook": {
+              "type": "object",
+              "properties": {
+                "done": {
+                  "type": "boolean"
+                },
+                "howdy": {
+                  "type": "string"
+                }
+              }
+            },
+            "job": {
+              "maps": {
+                "done": "{$self.hook.data.done}",
+                "howdy": "{$self.hook.data.howdy}"
+              }
+            }
+          }
+        },
+        "transitions": {
+          "toggleTrigger": [
+            {
+              "to": "waitForSignaler"
+            }
+          ]
+        },
+        "hooks": {
+          "waitForSignaler.doPleaseResume": [
+            {
+              "to": "waitForSignaler",
+              "conditions": {
+                "match": [
+                  {
+                    "expected": "{$job.metadata.jid}",
+                    "actual": "{$self.hook.data.id}"
+                  }
+                ]
+              }
+            }
+          ]
+        }
       }
     ]
   }

--- a/tests/$setup/apps/signal/v1/hotmesh.yaml
+++ b/tests/$setup/apps/signal/v1/hotmesh.yaml
@@ -270,3 +270,67 @@ app:
               match:
                 - expected: "{$job.metadata.jid}"
                   actual: "{$self.hook.data.id}"
+
+    - subscribes: signal.toggle
+      publishes: signal.toggled
+
+      input:
+        schema:
+          type: object
+          properties:
+            jobId:
+              type: string
+            statusThreshold:
+              type: number
+      output:
+        schema:
+          type: object
+          properties:
+            done:
+              type: boolean
+            howdy:
+              type: string
+
+      expire: 180
+
+      activities:
+        toggleTrigger:
+          title: Entry Point for status threshold test
+          type: trigger
+          stats:
+            id: "{$self.input.data.jobId}"
+          job:
+            maps:
+              done: false
+
+        waitForSignaler:
+          title: Conditionally registers a signal-in listener if statusThreshold is met
+          type: hook
+          statusThreshold: '{toggleTrigger.output.data.statusThreshold}'
+          emit:
+            '@pipe':
+              - ['{toggleTrigger.output.data.statusThreshold}', true, false]
+              - ['{@conditional.ternary}']
+          hook:
+            type: object
+            properties:
+              done:
+                type: boolean
+              howdy:
+                type: string
+          job:
+            maps:
+              done: "{$self.hook.data.done}"
+              howdy: "{$self.hook.data.howdy}"
+
+      transitions:
+        toggleTrigger:
+          - to: waitForSignaler
+
+      hooks:
+        waitForSignaler.doPleaseResume:
+          - to: waitForSignaler
+            conditions:
+              match:
+                - expected: "{$job.metadata.jid}"
+                  actual: "{$self.hook.data.id}"

--- a/tests/durable/goodbye/src/workflows.ts
+++ b/tests/durable/goodbye/src/workflows.ts
@@ -22,7 +22,6 @@ export async function example(name: string): Promise<string> {
   await search.incr('counter', 10);
   const j2 = await search.get('jimbo');
   const j3 = await search.mget('jimbo');
-  //console.log(j1, j2, j3[0]);
   const val1 = await search.incr('counter', 1);
   const val2 = await search.get('counter');
   const val3 = await search.mult('multer', 12);

--- a/tests/durable/helloworld/index.test.ts
+++ b/tests/durable/helloworld/index.test.ts
@@ -61,6 +61,9 @@ describe('DURABLE | hello | `Workflow Sleepy Hello-World`', () => {
           taskQueue: 'hello-world',
           workflowName: 'example',
           workflowId: 'workflow-' + guid(),
+          expire: 180,
+          //NOTE: default is true; set to false to optimize any workflow that doesn't use hooks
+          signalIn: false,
         });
         expect(handle.workflowId).toBeDefined();
       });

--- a/types/activity.ts
+++ b/types/activity.ts
@@ -18,6 +18,8 @@ interface BaseActivity {
   title?: string;
   type?: ActivityExecutionType;
   subtype?: string;
+  statusThreshold?: number; //default is 0; set to 1 to ensure not last standing; message will be ignored as if too late to process
+  statusThresholdType?: 'stop' | 'throw' | 'stall'; //default is stop; must explicitly set to throw to throw an error or stall to stall
   input?: Record<string, any>;
   output?: Record<string, any>;
   settings?: Record<string, any>;

--- a/types/durable.ts
+++ b/types/durable.ts
@@ -315,6 +315,11 @@ type WorkflowOptions = {
   expire?: number;
 
   /**
+   * default is true; set to false to optimize workflows that do not require a `signal in`
+   */
+  signalIn?: boolean;
+
+  /**
    * default is true; if false, will not await the execution
    */
   await?: boolean;


### PR DESCRIPTION
- adds status threshold to the base activity model, allowing for any activity to trigger an exit (and job conclusion) when the job status semaphore reaches the custom (positive integer) value.
- adds inequality and strict_inequality mapper conditionals
- Increments the durable model to version 2 (to support statusThreshold and signalIn suppression)