### PR TITLE
sets hook defaults; fixes taskQueue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Unbreakable Workflows",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/meshflow/client.ts
+++ b/services/meshflow/client.ts
@@ -183,7 +183,7 @@ export class ClientService {
      * adds searchable data to the record.
      */
     start: async (options: WorkflowOptions): Promise<WorkflowHandleService> => {
-      const taskQueueName = options.entity ?? options.taskQueue;
+      const taskQueueName = options.taskQueue ?? options.entity;
       const workflowName = options.entity ?? options.workflowName;
       const trc = options.workflowTrace;
       const spn = options.workflowSpan;
@@ -261,7 +261,7 @@ export class ClientService {
      * ```
      */
     hook: async (options: HookOptions): Promise<string> => {
-      const workflowTopic = `${options.taskQueue}-${options.workflowName}`;
+      const workflowTopic = `${options.taskQueue ?? options.entity}-${options.entity ?? options.workflowName}`;
       const payload = {
         arguments: [...options.args],
         id: options.workflowId,

--- a/services/meshflow/workflow.ts
+++ b/services/meshflow/workflow.ts
@@ -231,7 +231,7 @@ export class WorkflowService {
           }
         }
         return result.$error as T;
-      } else if (result.data) {
+      } else {
         return result.data as T;
       }
     }
@@ -518,16 +518,21 @@ export class WorkflowService {
       const targetWorkflowId = options.workflowId ?? workflowId;
       let targetTopic: string;
       if (options.entity || (options.taskQueue && options.workflowName)) {
-        targetTopic = `${options.entity ?? options.taskQueue}-${options.entity ?? options.workflowName}`;
+        targetTopic = `${options.taskQueue ?? options.entity}-${options.entity ?? options.workflowName}`;
       } else {
         targetTopic = workflowTopic;
       }
       const payload = {
         arguments: [...options.args],
         id: targetWorkflowId,
-        workflowTopic,
+        workflowTopic: targetTopic,
         backoffCoefficient:
           options.config?.backoffCoefficient || HMSH_MESHFLOW_EXP_BACKOFF,
+        maximumAttempts:
+          options.config?.maximumAttempts || HMSH_MESHFLOW_MAX_ATTEMPTS,
+        maximumInterval: s(
+          options?.config?.maximumInterval ?? HMSH_MESHFLOW_MAX_INTERVAL,
+        ),
       };
       return await hotMeshClient.hook(
         `${namespace}.flow.signal`,

--- a/tests/meshflow/basic/index.test.ts
+++ b/tests/meshflow/basic/index.test.ts
@@ -115,7 +115,6 @@ describe('MESHFLOW | basic | `MeshFlow Foundational`', () => {
         const r1 = deterministicRandom(1);
         const r2 = deterministicRandom(4);
         expect(result).toEqual({
-          jobBody: 'Hello from child workflow, start-HotMeshy!',
           jobId: 'MyWorkflowId123',
           oneTimeGreeting: { complex: 'Basic, HotMesh!' },
           payload: { data: { hello: 'world', id: 'abcdefg' }, id: 'abcdefg' },

--- a/tests/meshflow/basic/src/workflows.ts
+++ b/tests/meshflow/basic/src/workflows.ts
@@ -26,7 +26,7 @@ type responseType = {
     complex: string;
   };
   jobId: string;
-  jobBody: string;
+  jobBody: void;
 };
 
 type payloadType = {
@@ -80,7 +80,7 @@ export async function example(name: string): Promise<responseType> {
       taskQueue: 'basic-world',
       workflowId: 'MyWorkflowId123',
     }),
-    MeshFlow.workflow.execChild<string>({
+    MeshFlow.workflow.execChild<void>({
       workflowName: 'childExample',
       args: [`start-${name}y`],
       taskQueue: 'basic-world',
@@ -101,6 +101,6 @@ export async function example(name: string): Promise<responseType> {
   };
 }
 
-export async function childExample(name: string): Promise<string> {
-  return `Hello from child workflow, ${name}!`;
+export async function childExample(name: string): Promise<void> {
+  return;
 }


### PR DESCRIPTION
HotMesh uses a flexible topic space (`*.*.*`) when mapping linked functions. The 'MeshFlow' module (which emulates Temporal), reduces this pattern to Temporal's two-part prefix/suffix system (taskQueue+workflowName). This PR fixes the MeshFlow defaults making them consistent across all public entry points (hook, start, workflow.hook), such that the `taskQueue` always takes _priority_ for the prefix and the `entity` takes priority for the _suffix_.

- Establishes the default pattern for taskQueue+entity+workflowName combinations, prioritizing in the following manner: taskQueue>entity>workflowName.
- Allows workflows to return void/undefined