### PR TITLE
Validation verification improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
@@ -85,6 +85,7 @@
     "test:unit": "vitest run tests/unit"
   },
   "keywords": [
+    "Invisible Infrastructure",
     "Headless Orchestration",
     "Durable Workflows",
     "Data in Motion",

--- a/services/engine/init.ts
+++ b/services/engine/init.ts
@@ -80,6 +80,8 @@ export async function initStoreChannel(
     instance.namespace,
     instance.appId,
     instance.logger,
+    instance.guid,
+    'engine',
   );
 }
 

--- a/services/engine/schema.ts
+++ b/services/engine/schema.ts
@@ -33,9 +33,13 @@ export async function initActivity(
 ) {
   const [activityId, schema] = await getSchema(instance, topic);
   if (!schema) {
-    throw new Error(
-      `Activity schema not found for "${activityId}" (topic: ${topic}) in app ${instance.appId}`,
+    const err = new Error(
+      `Activity schema not found for "${activityId}" (topic: ${topic}) in app ${instance.appId}. ` +
+      `This is typically caused by a worker activity whose topic collides with the graph subscribes topic. ` +
+      `Redeploy with a distinct worker topic.`,
     );
+    (err as any).code = 598;
+    throw err;
   }
   const ActivityHandler = Activities[schema.type];
   if (ActivityHandler) {

--- a/services/quorum/index.ts
+++ b/services/quorum/index.ts
@@ -113,6 +113,8 @@ class QuorumService {
       this.namespace,
       this.appId,
       this.logger,
+      this.guid,
+      'quorum',
     );
   }
 

--- a/services/router/consumption/index.ts
+++ b/services/router/consumption/index.ts
@@ -631,8 +631,25 @@ export class ConsumptionManager<
       );
     }
     try {
-      const messageId = await this.publishResponse(input, output);
-      telemetry.setStreamAttributes({ 'app.worker.mid': messageId });
+      // When the ENGINE itself fails to process a message (e.g., schema not
+      // found, missing subscription), do NOT republish the error back to the
+      // engine stream — that creates an infinite poison loop. The engine
+      // When the ENGINE encounters an infrastructure error (schema not found,
+      // subscription missing — code 598), the message is permanently unprocessable.
+      // Do NOT republish it — that creates an infinite poison loop. Only suppress
+      // these specific infrastructure errors; application-level errors (retries,
+      // duplicates, workflow failures) must still flow through normally.
+      if (group === 'ENGINE' && output?.code === 598) {
+        this.logger.error(`stream-engine-dispatch-fatal`, {
+          stream, id, group,
+          aid: (input as any).metadata?.aid,
+          jid: (input as any).metadata?.jid,
+          message: output.data?.message,
+        });
+      } else {
+        const messageId = await this.publishResponse(input, output);
+        telemetry.setStreamAttributes({ 'app.worker.mid': messageId });
+      }
     } catch (publishErr) {
       // If publishResponse fails, still ack the message to prevent
       // infinite reprocessing. Log the error for debugging.

--- a/services/router/error-handling/index.ts
+++ b/services/router/error-handling/index.ts
@@ -77,7 +77,7 @@ export class ErrorHandler {
     }
     const result = {
       status: 'error',
-      code: HMSH_CODE_UNKNOWN,
+      code: (err as any).code || HMSH_CODE_UNKNOWN,
       metadata: { ...input.metadata, guid: guid() },
       data: error as StreamError,
     } as StreamDataResponse;

--- a/services/store/factory.ts
+++ b/services/store/factory.ts
@@ -13,6 +13,8 @@ class StoreServiceFactory {
     namespace: string,
     appId: string,
     logger: ILogger,
+    guid?: string,
+    role?: string,
   ): Promise<
     StoreService<ProviderClient, ProviderTransaction> & StoreInitializable
   > {
@@ -21,7 +23,7 @@ class StoreServiceFactory {
     if (identifyProvider(providerClient) === 'postgres') {
       service = new PostgresStoreService(providerClient);
     } //etc
-    await service.init(namespace, appId, logger);
+    await service.init(namespace, appId, logger, guid, role);
     return service;
   }
 }

--- a/services/store/index.ts
+++ b/services/store/index.ts
@@ -39,6 +39,8 @@ abstract class StoreService<
     namespace: string,
     appId: string,
     logger: ILogger,
+    guid?: string,
+    role?: string,
   ): Promise<HotMeshApps>;
 
   //domain-level methods

--- a/services/store/providers/postgres/kvsql.ts
+++ b/services/store/providers/postgres/kvsql.ts
@@ -1,4 +1,4 @@
-import { HMNS, KeyService } from '../../../../modules/key';
+import { KeyService } from '../../../../modules/key';
 import { KeyStoreParams } from '../../../../types/hotmesh';
 import { PostgresClientType } from '../../../../types/postgres';
 import { ProviderTransaction } from '../../../../types/provider';
@@ -68,20 +68,15 @@ export class KVSQL {
   }
 
   /**
-   * Resolves the table name when provided a key
+   * Resolves the table name when provided a key.
+   * Public tables (applications, connections) are no longer routed through
+   * the KV layer — they use direct SQL in postgres.ts.
    */
   tableForKey(
     key: string,
     stats_type?: 'hash' | 'sorted_set' | 'list',
   ): string {
-    if (key === HMNS) {
-      return 'public.hotmesh_connections';
-    }
-
     const [_, appName, abbrev, ...rest] = key.split(':');
-    if (appName === 'a') {
-      return 'public.hotmesh_applications';
-    }
 
     const id = rest?.length ? rest.join(':') : '';
     const entity = KeyService.resolveEntityType(abbrev, id);
@@ -108,11 +103,25 @@ export class KVSQL {
 
     if (entity === 'unknown_entity') {
       throw new Error(`Unknown entity type abbreviation: ${abbrev}`);
-    } else if (entity === 'applications') {
-      return 'public.hotmesh_applications';
     } else {
       return `${schemaName}.${entity}`;
     }
+  }
+
+  /**
+   * Strips the `hmsh:<appId>:<entity>:` prefix from a full Redis-style key,
+   * keeping only the meaningful suffix for SQL storage. Applied only to the
+   * `key` column in SQL params — never to member values, field names, or values.
+   *
+   * Excluded tables (jobs, streams, job attributes) retain the full key.
+   */
+  storageKey(fullKey: string): string {
+    const parts = fullKey.split(':');
+    if (parts.length < 3) return fullKey;
+    const entity = parts[2];
+    // Excluded tables: jobs (j), streams (x), job attributes (d)
+    if (entity === 'j' || entity === 'x' || entity === 'd') return fullKey;
+    return parts.slice(3).join(':');
   }
 
   safeName(input: string, prefix = ''): string {
@@ -273,6 +282,7 @@ export class KVSQL {
           AND (expired_at IS NULL OR expired_at > NOW())
         LIMIT 1;
       `;
+      return { sql, params: [key] };
     } else {
       sql = `
         SELECT FROM ${tableName}
@@ -280,8 +290,7 @@ export class KVSQL {
           AND (expiry IS NULL OR expiry > NOW())
         LIMIT 1;
       `;
+      return { sql, params: [this.storageKey(key)] };
     }
-    const params = [key];
-    return { sql, params };
   }
 }

--- a/services/store/providers/postgres/kvtables.ts
+++ b/services/store/providers/postgres/kvtables.ts
@@ -188,6 +188,41 @@ export const KVTables = (context: PostgresStoreService) => ({
         const fullTableName = `${tableDef.schema}.${tableDef.name}`;
 
         switch (tableDef.type) {
+          case 'relational_app':
+            await client.query(`
+              CREATE TABLE IF NOT EXISTS ${fullTableName} (
+                app_id TEXT PRIMARY KEY,
+                version TEXT NOT NULL DEFAULT '1',
+                active BOOLEAN DEFAULT TRUE,
+                settings JSONB DEFAULT '{}',
+                created_at TIMESTAMPTZ DEFAULT NOW(),
+                updated_at TIMESTAMPTZ DEFAULT NOW()
+              );
+            `);
+            await client.query(`
+              CREATE TABLE IF NOT EXISTS public.hmsh_application_versions (
+                app_id TEXT NOT NULL REFERENCES public.hmsh_applications(app_id) ON DELETE CASCADE,
+                version TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'deployed',
+                deployed_at TIMESTAMPTZ DEFAULT NOW(),
+                PRIMARY KEY (app_id, version)
+              );
+            `);
+            break;
+
+          case 'relational_connection':
+            await client.query(`
+              CREATE TABLE IF NOT EXISTS ${fullTableName} (
+                guid TEXT NOT NULL,
+                app_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                version TEXT NOT NULL,
+                connected_at TIMESTAMPTZ DEFAULT NOW(),
+                PRIMARY KEY (guid, app_id)
+              );
+            `);
+            break;
+
           case 'string':
             await client.query(`
               CREATE TABLE IF NOT EXISTS ${fullTableName} (
@@ -451,8 +486,12 @@ export const KVTables = (context: PostgresStoreService) => ({
   getTableNames(appName: string): string[] {
     const tableNames = [];
 
-    // Applications table (only hotmesh prefix)
-    tableNames.push('hotmesh_applications', 'hotmesh_connections');
+    // Public relational tables
+    tableNames.push(
+      'public.hmsh_applications',
+      'public.hmsh_application_versions',
+      'public.hmsh_connections',
+    );
 
     // Other tables with appName
     const tablesWithAppName = [
@@ -487,13 +526,13 @@ export const KVTables = (context: PostgresStoreService) => ({
     const tableDefinitions = [
       {
         schema: 'public',
-        name: 'hotmesh_applications',
-        type: 'hash',
+        name: 'hmsh_applications',
+        type: 'relational_app',
       },
       {
         schema: 'public',
-        name: 'hotmesh_connections',
-        type: 'hash',
+        name: 'hmsh_connections',
+        type: 'relational_connection',
       },
       {
         schema: schemaName,

--- a/services/store/providers/postgres/kvtypes/hash/basic.ts
+++ b/services/store/providers/postgres/kvtypes/hash/basic.ts
@@ -432,7 +432,7 @@ export function _hset(
       ${conflictAction}
       RETURNING 1 as count
     `;
-    params.unshift(key); // Add key as the first parameter
+    params.unshift(context.storageKey(key)); // Add stripped key as the first parameter
   }
 
   return { sql, params };
@@ -485,7 +485,7 @@ export function _hget(
       WHERE key = $1 AND field = $2
     `;
     const sql = context.appendExpiryClause(baseQuery, tableName);
-    return { sql, params: [key, field] };
+    return { sql, params: [context.storageKey(key), field] };
   }
 }
 
@@ -526,7 +526,7 @@ export function _hdel(
       )
       SELECT COUNT(*) as count FROM deleted
     `;
-    return { sql, params: [key, ...fields] };
+    return { sql, params: [context.storageKey(key), ...fields] };
   }
 }
 
@@ -587,7 +587,7 @@ export function _hmget(
         AND field = ANY($2::text[])
     `;
     const sql = context.appendExpiryClause(baseQuery, tableName);
-    return { sql, params: [key, fields] };
+    return { sql, params: [context.storageKey(key), fields] };
   }
 }
 
@@ -636,7 +636,7 @@ export function _hgetall(
       `,
       tableName,
     );
-    return { sql, params: [key] };
+    return { sql, params: [context.storageKey(key)] };
   }
 }
 
@@ -684,7 +684,7 @@ export function _hincrbyfloat(
       SET value = ((COALESCE(${tableName}.value, '0')::double precision + $3::double precision)::text)
       RETURNING value
     `;
-    return { sql, params: [key, field, increment] };
+    return { sql, params: [context.storageKey(key), field, increment] };
   }
 }
 

--- a/services/store/providers/postgres/kvtypes/hash/scan.ts
+++ b/services/store/providers/postgres/kvtypes/hash/scan.ts
@@ -5,6 +5,7 @@ import {
   HScanResult,
   ProviderTransaction,
 } from './types';
+import { isJobsTable } from './utils';
 
 export function createScanOperations(context: HashContext['context']) {
   return {
@@ -89,7 +90,8 @@ export function _hscan(
   pattern?: string,
 ): SqlResult {
   const tableName = context.tableForKey(key, 'hash');
-  const params = [key];
+  const isJobs = tableName.endsWith('jobs');
+  const params = [isJobs ? key : context.storageKey(key)];
   let sql = `
     SELECT field, value FROM ${tableName}
     WHERE key = $1 AND (expiry IS NULL OR expiry > NOW())

--- a/services/store/providers/postgres/kvtypes/list.ts
+++ b/services/store/providers/postgres/kvtypes/list.ts
@@ -62,7 +62,7 @@ export const listModule = (context: any) => ({
       WHERE rn BETWEEN indices.adjusted_start AND indices.adjusted_end
       ORDER BY rn ASC
     `;
-    const params = [key, start, end];
+    const params = [context.storageKey(key), start, end];
     return { sql, params };
   },
 
@@ -116,7 +116,7 @@ export const listModule = (context: any) => ({
       )
       SELECT COUNT(*) as count FROM inserted
     `;
-    const params = [key, ...values];
+    const params = [context.storageKey(key), ...values];
     return { sql, params };
   },
 
@@ -170,7 +170,7 @@ export const listModule = (context: any) => ({
       )
       SELECT COUNT(*) as count FROM inserted
     `;
-    const params = [key, ...values];
+    const params = [context.storageKey(key), ...values];
     return { sql, params };
   },
 
@@ -196,6 +196,7 @@ export const listModule = (context: any) => ({
 
   _lpop(key: string): { sql: string; params: any[] } {
     const tableName = context.tableForKey(key, 'list');
+    const sKey = context.storageKey(key);
     const sql = `
       DELETE FROM ${tableName}
       WHERE key = $1 AND "index" = (
@@ -203,7 +204,7 @@ export const listModule = (context: any) => ({
       )
       RETURNING value
     `;
-    const params = [key];
+    const params = [sKey];
     return { sql, params };
   },
 
@@ -276,7 +277,7 @@ export const listModule = (context: any) => ({
       )
       SELECT value FROM inserted
     `;
-    const params = [source, destination];
+    const params = [context.storageKey(source), context.storageKey(destination)];
     return { sql, params };
   },
 
@@ -315,7 +316,7 @@ export const listModule = (context: any) => ({
     const sql = `
       UPDATE ${tableName} SET key = $2 WHERE key = $1;
     `;
-    const params = [oldKey, newKey];
+    const params = [context.storageKey(oldKey), context.storageKey(newKey)];
     return { sql, params };
   },
 });

--- a/services/store/providers/postgres/kvtypes/string.ts
+++ b/services/store/providers/postgres/kvtypes/string.ts
@@ -32,7 +32,7 @@ export const stringModule = (context: any) => ({
       WHERE key = $1 AND (expiry IS NULL OR expiry > NOW())
       LIMIT 1
     `;
-    const params = [key];
+    const params = [context.storageKey(key)];
     return { sql, params };
   },
 
@@ -117,7 +117,7 @@ export const stringModule = (context: any) => ({
   ): { sql: string; params: any[] } {
     const tableName = context.tableForKey(key);
     let sql = '';
-    const params = [key, value];
+    const params = [context.storageKey(key), value];
     let expiryClause = '';
 
     if (options?.ex) {
@@ -178,7 +178,7 @@ export const stringModule = (context: any) => ({
       )
       SELECT COUNT(*) as count FROM deleted
     `;
-    const params = [key];
+    const params = [context.storageKey(key)];
     return { sql, params };
   },
 });

--- a/services/store/providers/postgres/kvtypes/zset.ts
+++ b/services/store/providers/postgres/kvtypes/zset.ts
@@ -52,7 +52,7 @@ export const zsetModule = (context: any) => ({
   ): { sql: string; params: any[] } {
     const tableName = context.tableForKey(key, 'sorted_set');
     let sql = '';
-    const params = [key, member, score];
+    const params = [context.storageKey(key), member, score];
 
     if (options?.nx) {
       sql = `
@@ -141,7 +141,7 @@ export const zsetModule = (context: any) => ({
                   AND LEAST(GREATEST(adjusted_stop, 0), max_index)
       ORDER BY rn ASC;
     `;
-    const params = [key, start, stop];
+    const params = [context.storageKey(key), start, stop];
     return { sql, params };
   },
 
@@ -183,7 +183,7 @@ export const zsetModule = (context: any) => ({
         AND (expiry IS NULL OR expiry > NOW())
       LIMIT 1
     `;
-    const params = [key, member];
+    const params = [context.storageKey(key), member];
     return { sql, params };
   },
 
@@ -225,7 +225,7 @@ export const zsetModule = (context: any) => ({
       WHERE key = $1 AND score BETWEEN $2 AND $3 AND (expiry IS NULL OR expiry > NOW())
       ORDER BY score ASC, member ASC
     `;
-    const params = [key, min, max];
+    const params = [context.storageKey(key), min, max];
     return { sql, params };
   },
 
@@ -267,7 +267,7 @@ export const zsetModule = (context: any) => ({
       WHERE key = $1 AND score BETWEEN $2 AND $3 AND (expiry IS NULL OR expiry > NOW())
       ORDER BY score ASC, member ASC
     `;
-    const params = [key, min, max];
+    const params = [context.storageKey(key), min, max];
     return { sql, params };
   },
 
@@ -310,7 +310,7 @@ export const zsetModule = (context: any) => ({
       )
       SELECT COUNT(*) as count FROM deleted
     `;
-    const params = [key, member];
+    const params = [context.storageKey(key), member];
     return { sql, params };
   },
 
@@ -355,7 +355,7 @@ export const zsetModule = (context: any) => ({
       WHERE ms.key = $1 AND (expiry IS NULL OR expiry > NOW())
       AND (ms.score < member_score.score OR (ms.score = member_score.score AND ms.member < $2))
     `;
-    const params = [key, member];
+    const params = [context.storageKey(key), member];
     return { sql, params };
   },
 });

--- a/services/store/providers/postgres/postgres.ts
+++ b/services/store/providers/postgres/postgres.ts
@@ -90,6 +90,8 @@ class PostgresStoreService extends StoreService<
     namespace = HMNS,
     appId: string,
     logger: ILogger,
+    guid?: string,
+    role?: string,
   ): Promise<HotMeshApps> {
     //bind appId and namespace to storeClient once initialized
     // (it uses these values to construct keys for the store)
@@ -104,7 +106,7 @@ class PostgresStoreService extends StoreService<
     await this.deployTimeNotificationTriggers(appId);
 
     //note: getSettings will contact db to confirm r/w access
-    const settings = await this.getSettings(true);
+    const settings = await this.getSettings(true, guid, role);
     this.cache = new Cache(appId, settings);
     this.serializer = new Serializer();
     await this.getApp(appId);
@@ -198,7 +200,11 @@ class PostgresStoreService extends StoreService<
     return this.isSuccessful(success);
   }
 
-  async getSettings(bCreate = false): Promise<HotMeshSettings> {
+  async getSettings(
+    bCreate = false,
+    guid?: string,
+    role?: string,
+  ): Promise<HotMeshSettings> {
     let settings = this.cache?.getSettings();
     if (settings) {
       return settings;
@@ -207,7 +213,9 @@ class PostgresStoreService extends StoreService<
         const packageJson = await import('../../../../package.json');
         const version: string = packageJson['version'] || '0.0.0';
         settings = { namespace: HMNS, version } as HotMeshSettings;
-        await this.setSettings(settings);
+        if (guid && role) {
+          await this.registerConnection(guid, role, version);
+        }
         return settings;
       }
     }
@@ -215,10 +223,21 @@ class PostgresStoreService extends StoreService<
   }
 
   async setSettings(manifest: HotMeshSettings): Promise<any> {
-    //HotMesh heartbeat. If a connection is made, the version will be set
-    const params: KeyStoreParams = {};
-    const key = this.mintKey(KeyType.HOTMESH, params);
-    return await this.kvsql().hset(key, manifest);
+    // No-op for Postgres — settings are derived from package.json
+    // and connections are registered via registerConnection()
+    return;
+  }
+
+  async registerConnection(
+    guid: string,
+    role: string,
+    version: string,
+  ): Promise<void> {
+    const sql = `INSERT INTO public.hmsh_connections (guid, app_id, role, version)
+      VALUES ($1, $2, $3, $4)
+      ON CONFLICT (guid, app_id) DO UPDATE SET
+        version = EXCLUDED.version, connected_at = NOW()`;
+    await this.pgClient.query(sql, [guid, this.appId, role, version]);
   }
 
   async reserveSymbolRange(
@@ -400,73 +419,91 @@ class PostgresStoreService extends StoreService<
   }
 
   async getApp(id: string, refresh = false): Promise<HotMeshApp> {
-    let app: Partial<HotMeshApp> = this.cache.getApp(id);
+    let app: Partial<HotMeshApp> = this.cache?.getApp(id);
     if (refresh || !(app && Object.keys(app).length > 0)) {
-      const params: KeyStoreParams = { appId: id };
-      const key = this.mintKey(KeyType.APP, params);
-      const sApp = await this.kvsql().hgetall(key);
-      if (!sApp) return null;
-      app = {};
-      for (const field in sApp) {
-        try {
-          if (field === 'active') {
-            app[field] = sApp[field] === 'true';
-          } else {
-            app[field] = sApp[field];
-          }
-        } catch (e) {
-          app[field] = sApp[field];
-        }
+      // Fetch from relational tables
+      const appResult = await this.pgClient.query(
+        `SELECT app_id, version, active, settings FROM public.hmsh_applications WHERE app_id = $1`,
+        [id],
+      );
+      if (!appResult.rows.length) return null;
+      const row = appResult.rows[0];
+      app = {
+        id: row.app_id,
+        version: row.version,
+        active: row.active,
+      };
+      // Fetch version history
+      const versionsResult = await this.pgClient.query(
+        `SELECT version, status, deployed_at FROM public.hmsh_application_versions WHERE app_id = $1`,
+        [id],
+      );
+      for (const vRow of versionsResult.rows) {
+        app[`versions/${vRow.version}`] = `${vRow.status}:${formatISODate(new Date(vRow.deployed_at))}`;
       }
-      this.cache.setApp(id, app as HotMeshApp);
+      this.cache?.setApp(id, app as HotMeshApp);
     }
     return app as HotMeshApp;
   }
 
   async setApp(id: string, version: string): Promise<HotMeshApp> {
-    const params: KeyStoreParams = { appId: id };
-    const key = this.mintKey(KeyType.APP, params);
-    const versionId = `versions/${version}`;
+    const now = new Date();
+    // Upsert into applications
+    await this.pgClient.query(
+      `INSERT INTO public.hmsh_applications (app_id, version, active, updated_at)
+       VALUES ($1, $2, TRUE, $3)
+       ON CONFLICT (app_id) DO UPDATE SET version = $2, updated_at = $3`,
+      [id, version, now],
+    );
+    // Insert version record
+    await this.pgClient.query(
+      `INSERT INTO public.hmsh_application_versions (app_id, version, status, deployed_at)
+       VALUES ($1, $2, 'deployed', $3)
+       ON CONFLICT (app_id, version) DO UPDATE SET status = 'deployed', deployed_at = $3`,
+      [id, version, now],
+    );
     const payload: HotMeshApp = {
       id,
       version,
-      [versionId]: `deployed:${formatISODate(new Date())}`,
+      [`versions/${version}`]: `deployed:${formatISODate(now)}`,
     };
-    await this.kvsql().hset(key, payload as any);
-    this.cache.setApp(id, payload);
+    this.cache?.setApp(id, payload);
     return payload;
   }
 
   async activateAppVersion(id: string, version: string): Promise<boolean> {
-    const params: KeyStoreParams = { appId: id };
-    const key = this.mintKey(KeyType.APP, params);
-    const versionId = `versions/${version}`;
     const app = await this.getApp(id, true);
+    const versionId = `versions/${version}`;
     if (app && app[versionId]) {
-      const payload: HotMeshApp = {
-        id,
-        version: version.toString(),
-        [versionId]: `activated:${formatISODate(new Date())}`,
-        active: true,
-      };
-      Object.entries(payload).forEach(([key, value]) => {
-        payload[key] = value.toString();
-      });
-      await this.kvsql().hset(key, payload as any);
+      const now = new Date();
+      await this.pgClient.query(
+        `UPDATE public.hmsh_applications SET active = TRUE, version = $2, updated_at = $3 WHERE app_id = $1`,
+        [id, version, now],
+      );
+      await this.pgClient.query(
+        `UPDATE public.hmsh_application_versions SET status = 'activated', deployed_at = $3 WHERE app_id = $1 AND version = $2`,
+        [id, version, now],
+      );
       return true;
     }
     throw new Error(`Version ${version} does not exist for app ${id}`);
   }
 
   async registerAppVersion(appId: string, version: string): Promise<any> {
-    const params: KeyStoreParams = { appId };
-    const key = this.mintKey(KeyType.APP, params);
-    const payload: HotMeshApp = {
-      id: appId,
-      version: version.toString(),
-      [`versions/${version}`]: formatISODate(new Date()),
-    };
-    return await this.kvsql().hset(key, payload as any);
+    const now = new Date();
+    await this.pgClient.query(
+      `INSERT INTO public.hmsh_applications (app_id, version, active, updated_at)
+       VALUES ($1, $2, TRUE, $3)
+       ON CONFLICT (app_id) DO UPDATE SET version = $2, updated_at = $3`,
+      [appId, version, now],
+    );
+    await this.pgClient.query(
+      `INSERT INTO public.hmsh_application_versions (app_id, version, status, deployed_at)
+       VALUES ($1, $2, 'deployed', $3)
+       ON CONFLICT (app_id, version) DO UPDATE SET status = 'deployed', deployed_at = $3`,
+      [appId, version, now],
+    );
+    return 1;
   }
 
   async setStats(
@@ -1631,7 +1668,7 @@ class PostgresStoreService extends StoreService<
    */
   private async getNextAwakeningTime(): Promise<number | null> {
     const schemaName = this.kvsql().safeName(this.appId);
-    const appKey = `${this.appId}:time_range`;
+    const appKey = '';
 
     try {
       const result = await this.pgClient.query(

--- a/services/store/providers/postgres/time-notify.ts
+++ b/services/store/providers/postgres/time-notify.ts
@@ -17,25 +17,26 @@ DECLARE
     next_time TIMESTAMP WITH TIME ZONE;
 BEGIN
     -- Get the earliest (lowest score) entry from the time range ZSET
+    -- After normalization, the key is empty string (prefix stripped)
     SELECT score INTO next_score
     FROM ${schema}.task_schedules
-    WHERE key = app_key
+    WHERE key = ''
     AND (expiry IS NULL OR expiry > NOW())
     ORDER BY score ASC
     LIMIT 1;
-    
+
     IF next_score IS NULL THEN
         RETURN NULL;
     END IF;
-    
+
     -- Convert epoch milliseconds to timestamp
     next_time := to_timestamp(next_score / 1000.0);
-    
+
     -- Only return if it's in the future
     IF next_time > NOW() THEN
         RETURN next_time;
     END IF;
-    
+
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
@@ -51,8 +52,8 @@ DECLARE
     current_next_time TIMESTAMP WITH TIME ZONE;
     app_key TEXT;
 BEGIN
-    -- Build the time range key for this app
-    app_key := app_id || ':time_range';
+    -- After normalization, the key is empty string
+    app_key := '';
     channel_name := 'time_hooks_' || app_id;
     
     -- Get the current next awakening time
@@ -98,18 +99,14 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION ${schema}.on_time_hook_change()
 RETURNS TRIGGER AS $$
 DECLARE
-    app_id_extracted TEXT;
     awakening_time TIMESTAMP WITH TIME ZONE;
 BEGIN
-    -- Extract app_id from the key (assumes format: app_id:time_range)
-    app_id_extracted := split_part(NEW.key, ':time_range', 1);
-    
     -- Convert the score (epoch milliseconds) to timestamp
     awakening_time := to_timestamp(NEW.score / 1000.0);
-    
-    -- Schedule notification for this new awakening time
-    PERFORM ${schema}.schedule_time_notification(app_id_extracted, awakening_time);
-    
+
+    -- Schedule notification (app_id is the schema name)
+    PERFORM ${schema}.schedule_time_notification('${schema}', awakening_time);
+
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
@@ -117,15 +114,10 @@ $$ LANGUAGE plpgsql;
 -- Trigger function for when time hooks are removed
 CREATE OR REPLACE FUNCTION ${schema}.on_time_hook_remove()
 RETURNS TRIGGER AS $$
-DECLARE
-    app_id_extracted TEXT;
 BEGIN
-    -- Extract app_id from the key
-    app_id_extracted := split_part(OLD.key, ':time_range', 1);
-    
     -- Recalculate and notify about the schedule update
-    PERFORM ${schema}.schedule_time_notification(app_id_extracted);
-    
+    PERFORM ${schema}.schedule_time_notification('${schema}');
+
     RETURN OLD;
 END;
 $$ LANGUAGE plpgsql;
@@ -138,22 +130,23 @@ DROP TRIGGER IF EXISTS trg_time_hook_update ON ${schema}.task_schedules;
 DROP TRIGGER IF EXISTS trg_time_hook_delete ON ${schema}.task_schedules;
 
 -- Create new triggers
+-- After normalization, the task_schedules key for time range is empty string
 CREATE TRIGGER trg_time_hook_insert
     AFTER INSERT ON ${schema}.task_schedules
     FOR EACH ROW
-    WHEN (NEW.key LIKE '%:time_range')
+    WHEN (NEW.key = '')
     EXECUTE FUNCTION ${schema}.on_time_hook_change();
 
 CREATE TRIGGER trg_time_hook_update
     AFTER UPDATE ON ${schema}.task_schedules
     FOR EACH ROW
-    WHEN (NEW.key LIKE '%:time_range')
+    WHEN (NEW.key = '')
     EXECUTE FUNCTION ${schema}.on_time_hook_change();
 
 CREATE TRIGGER trg_time_hook_delete
     AFTER DELETE ON ${schema}.task_schedules
     FOR EACH ROW
-    WHEN (OLD.key LIKE '%:time_range')
+    WHEN (OLD.key = '')
     EXECUTE FUNCTION ${schema}.on_time_hook_remove();
 `;
 }

--- a/services/store/providers/store-initializable.ts
+++ b/services/store/providers/store-initializable.ts
@@ -2,5 +2,5 @@ import { ILogger } from '../../logger';
 import { HotMeshApps } from '../../../types/hotmesh';
 
 export interface StoreInitializable {
-  init(namespace: string, appId: string, logger: ILogger): Promise<HotMeshApps>;
+  init(namespace: string, appId: string, logger: ILogger, guid?: string, role?: string): Promise<HotMeshApps>;
 }

--- a/services/worker/index.ts
+++ b/services/worker/index.ts
@@ -176,6 +176,8 @@ class WorkerService {
       service.namespace,
       service.appId,
       service.logger,
+      service.guid,
+      'worker',
     );
   }
 

--- a/tests/durable/basic/src/workflows.ts
+++ b/tests/durable/basic/src/workflows.ts
@@ -15,7 +15,7 @@ type responseType = {
     complex: string;
   };
   random2: number;
-  payload: { id: string; data: { hello: string; id: string } };
+  payload: false | { id: string; data: { hello: string; id: string } };
   proxyGreeting3: {
     complex: string;
   };

--- a/tests/unit/services/pipe/index.test.ts
+++ b/tests/unit/services/pipe/index.test.ts
@@ -89,6 +89,38 @@ describe('Pipe', () => {
 
       expect(result).toBe(-1); //invalid cron expression
     });
+
+    it('should resolve cron cycle sleep via nextDelay + math.max (mirrors factory schema)', () => {
+      // Reproduces the exact pipe from services/virtual/schemas/factory.ts cycle_cron:
+      //   - ['{trigger_cron.output.data.cron}']
+      //   - ['{@cron.nextDelay}', '{trigger_cron.output.data.interval}']
+      //   - ['{@math.max}']
+      const fidelity = 5; // HMSH_FIDELITY_SECONDS default
+      jobData = {
+        trigger_cron: {
+          output: {
+            data: {
+              cron: '* * * * *', // every minute
+              interval: fidelity,
+            },
+          },
+        },
+      };
+
+      rules = [
+        ['{trigger_cron.output.data.cron}'],
+        ['{@cron.nextDelay}', '{trigger_cron.output.data.interval}'],
+        ['{@math.max}'],
+      ];
+
+      pipe = new Pipe(rules, jobData);
+      const result = pipe.process();
+
+      // nextDelay for '* * * * *' should be 1-60s; math.max ensures >= fidelity
+      expect(result).toBeGreaterThanOrEqual(fidelity);
+      // must NOT collapse to fidelity — cron delay should dominate
+      expect(result).toBeGreaterThan(fidelity);
+    });
   });
 
   describe('number', () => {

--- a/tests/unit/services/router/consumption/index.test.ts
+++ b/tests/unit/services/router/consumption/index.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ConsumptionManager } from '../../../../../services/router/consumption';
+import { ErrorHandler } from '../../../../../services/router/error-handling';
+
+/**
+ * Proves the poison loop: when the ENGINE group's callback throws,
+ * the error must NOT be republished to the engine stream (which would
+ * cause infinite reprocessing). Instead it should be acked and discarded.
+ *
+ * Without the fix, `publishResponse` is called unconditionally, sending
+ * the error back to the engine stream where it re-enters processStreamMessage,
+ * fails again, and loops forever.
+ */
+
+function createMockStream() {
+  return {
+    mintKey: vi.fn().mockReturnValue('hmsh:test:x:'),
+    publishMessages: vi.fn().mockResolvedValue(['msg-1']),
+    ackAndDelete: vi.fn().mockResolvedValue(undefined),
+    getProviderSpecificFeatures: vi.fn().mockReturnValue({
+      supportsNotifications: false,
+      supportsRetry: false,
+    }),
+    createConsumerGroup: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMockLogger() {
+  return {
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  };
+}
+
+function createMockLifecycle() {
+  return {
+    isStopped: vi.fn().mockReturnValue(false),
+    getShouldConsume: vi.fn().mockReturnValue(true),
+    isReadonly: vi.fn().mockReturnValue(false),
+    startConsuming: vi.fn().mockResolvedValue(undefined),
+    setIsUsingNotifications: vi.fn(),
+  };
+}
+
+function createMockRouter() {
+  return {
+    errorCount: 0,
+    counts: {},
+    hasReachedMaxBackoff: false,
+    throttle: 0,
+    reclaimDelay: 60000,
+    reclaimCount: 0,
+  };
+}
+
+describe('ConsumptionManager | Engine Poison Loop Prevention', () => {
+  let stream: any;
+  let logger: any;
+  let manager: any;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    stream = createMockStream();
+    logger = createMockLogger();
+    const throttleManager = { acquire: vi.fn().mockResolvedValue(undefined), release: vi.fn() };
+    const errorHandler = new ErrorHandler();
+    const lifecycleManager = createMockLifecycle();
+    const router = createMockRouter();
+
+    manager = new ConsumptionManager(
+      stream,
+      logger,
+      throttleManager as any,
+      errorHandler,
+      lifecycleManager as any,
+      60000, // reclaimDelay
+      10,    // reclaimCount
+      'test-app',
+      'ENGINE', // role
+      router,
+      undefined, // no retry policy
+    );
+  });
+
+  it('should NOT republish errors to engine stream when ENGINE callback throws', async () => {
+    const input = {
+      metadata: { guid: 'g1', aid: 'a1', jid: 'j1', gid: 'gid1', topic: '.a1' },
+      data: {},
+    };
+
+    // Callback that throws (simulates processStreamMessage failing
+    // because activity schema not found — code 598 marks it as
+    // infrastructure/unprocessable, distinct from application errors)
+    const schemaError = new Error('Activity schema not found for "a1" (topic: .a1) in app test-app');
+    (schemaError as any).code = 598;
+    const callback = vi.fn().mockRejectedValue(schemaError);
+
+    await manager.consumeOne(
+      'hmsh:test-app:x:',
+      'ENGINE',
+      'msg-123',
+      input,
+      callback,
+    );
+
+    // The message MUST be acked (not left dangling)
+    expect(stream.ackAndDelete).toHaveBeenCalledWith(
+      'hmsh:test-app:x:',
+      'ENGINE',
+      ['msg-123'],
+    );
+
+    // The error MUST NOT be published back to the engine stream
+    // (publishing creates the poison loop)
+    expect(stream.publishMessages).not.toHaveBeenCalled();
+  });
+
+  it('should still publish errors for WORKER group (normal error flow)', async () => {
+    // Recreate with WORKER role
+    const errorHandler = new ErrorHandler();
+    const workerManager = new ConsumptionManager(
+      stream,
+      logger,
+      { acquire: vi.fn().mockResolvedValue(undefined), release: vi.fn() } as any,
+      errorHandler,
+      createMockLifecycle() as any,
+      60000,
+      10,
+      'test-app',
+      'WORKER',
+      createMockRouter(),
+      undefined,
+    );
+
+    const input = {
+      metadata: { guid: 'g1', aid: 'a1', jid: 'j1', gid: 'gid1', topic: 'worker-topic' },
+      data: {},
+    };
+
+    const callback = vi.fn().mockRejectedValue(
+      new Error('some worker error'),
+    );
+
+    await workerManager.consumeOne(
+      'hmsh:test-app:x:worker-topic',
+      'WORKER',
+      'msg-456',
+      input,
+      callback,
+    );
+
+    // Worker errors SHOULD be published back to engine
+    expect(stream.publishMessages).toHaveBeenCalled();
+  });
+});

--- a/tests/virtual/postgres.test.ts
+++ b/tests/virtual/postgres.test.ts
@@ -223,6 +223,41 @@ describe('VIRTUAL | Postgres', () => {
       }, 6_500);
     });
 
+    describe('cron expression syntax', () => {
+      it('should respect cron expression interval (not fire every fidelity tick)', async () => {
+        let callCount = 0;
+
+        const inited = await Virtual.cron({
+          guid: 'cron-expr',
+          args: [],
+          topic: 'my.cron.expression',
+          connection,
+          options: {
+            id: 'cronexpr123',
+            interval: '* * * * *', // every 1 minute in cron syntax
+          },
+          callback: async (): Promise<number> => {
+            callCount++;
+            return callCount;
+          },
+        });
+        expect(inited).toBe(true);
+
+        // Wait 15 seconds. With a 1-minute cron, we should see at most 1 call.
+        // If the alleged bug existed, callCount would be 3+ (firing every fidelity tick).
+        await sleepFor(15_000);
+
+        await Virtual.interrupt({
+          topic: 'my.cron.expression',
+          connection,
+          options: { id: 'cronexpr123' },
+        });
+
+        // A 1-minute cron should fire at most 1 time in 15 seconds.
+        expect(callCount).toBeLessThanOrEqual(2);
+      }, 25_000);
+    });
+
     describe('error handling', () => {
       it('should stop after 3 retries when retry policy set to 3', async () => {
         let callCount = 0;


### PR DESCRIPTION
 - Poison loop prevention for code 598 engine errors — Infrastructure errors like missing activity schemas (code 598) are now logged and acked without republishing back to   
  the engine stream, preventing infinite reprocessing. All other error types (retries, duplicates, workflow failures) continue to flow through normally.                       
  - Postgres DDL: relational tables for applications/connections — Replaced KV-style hotmesh_applications and hotmesh_connections hash tables with proper relational tables    
  (hmsh_applications, hmsh_application_versions, hmsh_connections) with typed columns and foreign keys.                                                                        
  - Storage key stripping for SQL params — Added storageKey() to strip the hmsh:<appId>:<entity>: prefix from Redis-style keys before SQL storage, reducing redundant data in  
  key columns. Jobs, streams, and job attributes retain full keys.                                                                                                             
  - Improved activity schema error messaging — initActivity error now includes guidance about topic collisions and redeployment, and propagates error code 598 through
  ErrorHandler.                                                                                                                                                                
  - Store init accepts guid/role — StoreServiceFactory.init() now passes guid and role through from engine/quorum callers for connection tracking.
  - Cron expression fidelity test — New unit test proving nextDelay + math.max pipe correctly respects cron intervals, plus integration test verifying cron expressions don't  
  collapse to fidelity ticks.                                                                                                                                                  
  - Unit tests for poison loop — New ConsumptionManager unit tests verifying code 598 ENGINE errors are suppressed while WORKER errors still republish normally.               
  - TypeScript fix — responseType.payload in basic durable test correctly typed as false | payloadType to match condition() return type.          