### PR TITLE
Fix cron validation regex; throw on invalid expressions

### DIFF
--- a/modules/utils.ts
+++ b/modules/utils.ts
@@ -1,6 +1,7 @@
 import os from 'os';
 import { createHash } from 'crypto';
 
+import { parseExpression } from 'cron-parser';
 import { nanoid } from 'nanoid';
 import ms from 'ms';
 
@@ -307,9 +308,12 @@ export function restoreHierarchy(obj: StringAnyType): StringAnyType {
  * @private
  */
 export function isValidCron(cronExpression: string): boolean {
-  const cronRegex =
-    /^(\*|([0-5]?\d)) (\*|([01]?\d|2[0-3])) (\*|([12]?\d|3[01])) (\*|([1-9]|1[0-2])) (\*|([0-6](?:-[0-6])?(?:,[0-6])?))$/;
-  return cronRegex.test(cronExpression);
+  try {
+    parseExpression(cronExpression);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/services/pipe/functions/cron.ts
+++ b/services/pipe/functions/cron.ts
@@ -2,8 +2,6 @@ import { parseExpression } from 'cron-parser';
 
 import { HMSH_FIDELITY_SECONDS } from '../../../modules/enums';
 import { isValidCron } from '../../../modules/utils';
-import { ILogger } from '../../../types/logger';
-import { LoggerService } from '../../logger';
 
 /**
  * Provides cron-related utility functions based on the
@@ -14,17 +12,15 @@ import { LoggerService } from '../../logger';
  * Invoked in mapping rules using `{@cron.<method>}` syntax.
  */
 class CronHandler {
-  static logger: ILogger = new LoggerService('hotmesh', 'cron');
 
   /**
-   * Safely calculates the delay in seconds until the next execution
-   * of a cron job. Calculates the next date and time (per the system
-   * clock) that satisfies the cron expression, then returns the value
-   * in seconds from now. Fails silently and returns `-1` if the cron
-   * expression is invalid or the next execution time is in the past.
+   * Calculates the delay in seconds until the next execution
+   * of a cron job. Throws on invalid expressions rather than
+   * degrading silently.
    *
    * @param {string} cronExpression - The cron expression to parse (e.g. `'0 0 * * *'`)
-   * @returns {number} The delay in seconds until the next cron job execution (minimum `HMSH_FIDELITY_SECONDS`), or `-1` on error
+   * @returns {number} The delay in seconds until the next cron job execution (minimum `HMSH_FIDELITY_SECONDS`)
+   * @throws {Error} If the cron expression is invalid
    * @example
    * ```yaml
    * cron_next_result:
@@ -34,29 +30,17 @@ class CronHandler {
    * ```
    */
   nextDelay(cronExpression: string): number {
-    try {
-      if (!isValidCron(cronExpression)) {
-        return -1;
-      }
-      const interval = parseExpression(cronExpression, { utc: true });
-      const nextDate = interval.next().toDate();
-      const now = new Date();
-      const delay = (nextDate.getTime() - now.getTime()) / 1000;
-      if (delay <= 0) {
-        return -1;
-      }
-      if (delay < HMSH_FIDELITY_SECONDS) {
-        return HMSH_FIDELITY_SECONDS;
-      }
-      const iDelay = Math.round(delay);
-      return iDelay;
-    } catch (error) {
-      CronHandler.logger.error(
-        'Error calculating next cron job execution  delay:',
-        { error },
-      );
-      return -1;
+    if (!isValidCron(cronExpression)) {
+      throw new Error(`Invalid cron expression: ${cronExpression}`);
     }
+    const interval = parseExpression(cronExpression, { utc: true });
+    const nextDate = interval.next().toDate();
+    const now = new Date();
+    const delay = (nextDate.getTime() - now.getTime()) / 1000;
+    if (delay <= 0) {
+      return HMSH_FIDELITY_SECONDS;
+    }
+    return Math.max(Math.round(delay), HMSH_FIDELITY_SECONDS);
   }
 }
 

--- a/services/virtual/index.ts
+++ b/services/virtual/index.ts
@@ -464,10 +464,12 @@ class Virtual {
     if (isValidCron(params.options.interval)) {
       //cron syntax
       cron = params.options.interval;
-      const nextDelay = new CronHandler().nextDelay(cron);
-      delay = nextDelay > 0 ? nextDelay : undefined;
+      delay = new CronHandler().nextDelay(cron);
     } else {
       const seconds = s(params.options.interval);
+      if (isNaN(seconds)) {
+        throw new Error(`Invalid cron/interval expression: ${params.options.interval}`);
+      }
       interval = Math.max(seconds, HMSH_FIDELITY_SECONDS);
       delay = params.options.delay ? s(params.options.delay) : undefined;
     }

--- a/tests/unit/modules/utils.test.ts
+++ b/tests/unit/modules/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import * as utils from '../../../modules/utils';
+import { CronHandler } from '../../../services/pipe/functions/cron';
 import { StreamStatus } from '../../../types/stream';
 
 describe('utils module', () => {
@@ -63,6 +64,79 @@ describe('utils module', () => {
       expect(
         utils.matchesStatus(StreamStatus.PENDING, StreamStatus.PENDING),
       ).toBe(true);
+    });
+  });
+
+  describe('isValidCron function', () => {
+    // These plain expressions worked with the old regex too
+    it('should accept a simple every-minute expression', () => {
+      expect(utils.isValidCron('* * * * *')).toBe(true);
+    });
+
+    it('should accept a fixed-time expression', () => {
+      expect(utils.isValidCron('0 12 * * *')).toBe(true);
+    });
+
+    // These are the expressions the old regex REJECTED, causing the bug
+    it('should accept step values (*/15)', () => {
+      expect(utils.isValidCron('*/15 * * * *')).toBe(true);
+    });
+
+    it('should accept step values (*/1)', () => {
+      expect(utils.isValidCron('*/1 * * * *')).toBe(true);
+    });
+
+    it('should accept ranges in minutes (1-30)', () => {
+      expect(utils.isValidCron('1-30 * * * *')).toBe(true);
+    });
+
+    it('should accept ranges in hours (9-17)', () => {
+      expect(utils.isValidCron('0 9-17 * * *')).toBe(true);
+    });
+
+    it('should accept lists (1,15,30)', () => {
+      expect(utils.isValidCron('1,15,30 * * * *')).toBe(true);
+    });
+
+    it('should accept combined range-step (1-30/5)', () => {
+      expect(utils.isValidCron('1-30/5 * * * *')).toBe(true);
+    });
+
+    // Invalid expressions should still return false
+    it('should reject garbage strings', () => {
+      expect(utils.isValidCron('not a cron')).toBe(false);
+    });
+
+    it('should reject out-of-range values', () => {
+      expect(utils.isValidCron('60 * * * *')).toBe(false);
+    });
+
+    it('should reject invalid field values', () => {
+      expect(utils.isValidCron('abc def ghi jkl mno')).toBe(false);
+    });
+  });
+
+  describe('CronHandler.nextDelay function', () => {
+    it('should return a positive number for a valid cron expression', () => {
+      const handler = new CronHandler();
+      const delay = handler.nextDelay('0 0 * * *');
+      expect(delay).toBeGreaterThan(0);
+    });
+
+    it('should return a positive number for step values', () => {
+      const handler = new CronHandler();
+      const delay = handler.nextDelay('*/15 * * * *');
+      expect(delay).toBeGreaterThan(0);
+    });
+
+    it('should throw on an invalid cron expression', () => {
+      const handler = new CronHandler();
+      expect(() => handler.nextDelay('not valid')).toThrow('Invalid cron expression');
+    });
+
+    it('should throw on undefined input', () => {
+      const handler = new CronHandler();
+      expect(() => handler.nextDelay(undefined as any)).toThrow('Invalid cron expression');
     });
   });
 


### PR DESCRIPTION
## Summary
- Replace broken `isValidCron` regex with `cron-parser` validation — standard cron features (step values `*/15`, ranges `1-30`, lists `1,3,5`) were rejected, causing expressions like `*/1 * * * *` to fall through to the `ms()` parser, producing NaN intervals and zero-delay infinite loops
- Make `CronHandler.nextDelay()` throw on invalid expressions instead of returning `-1`, which silently degraded cron jobs to 5-second polling loops via `Math.max(-1, HMSH_FIDELITY_SECONDS)`
- Add NaN guard at the `ms()` fallback site in `services/virtual/index.ts` as defense-in-depth

## Test plan
- [x] `isValidCron` accepts step values, ranges, lists, and combined expressions
- [x] `isValidCron` rejects garbage and out-of-range values
- [x] `CronHandler.nextDelay` returns positive delay for valid cron expressions
- [x] `CronHandler.nextDelay` throws on invalid or undefined input
- [x] Stash/unstash confirmed: old code produces NaN loop, fixed code returns correct delays
- [x] `* * * * *` and `*/1 * * * *` both work correctly (every minute)