### PR TITLE
Postgres dequeue optimization: fillfactor, dedicated indexes, two-pass query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.14.10",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.14.10",
+      "version": "0.15.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.14.10",
+  "version": "0.15.1",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/stream/providers/postgres/kvtables.ts
+++ b/services/stream/providers/postgres/kvtables.ts
@@ -192,23 +192,33 @@ async function createTables(
   `);
 
   for (let i = 0; i < 8; i++) {
+    // fillfactor 70: reserves 30% page space for HOT updates (reserve/ack cycle)
     await client.query(`
       CREATE TABLE IF NOT EXISTS ${schemaName}.engine_streams_part_${i}
       PARTITION OF ${engineTable}
-      FOR VALUES WITH (modulus 8, remainder ${i});
+      FOR VALUES WITH (modulus 8, remainder ${i})
+      WITH (fillfactor = 70);
     `);
   }
 
+  // Dedicated dequeue index: columns match the hot-path query exactly
+  // (stream_name = $1, visible_at <= NOW(), ORDER BY id) with partial
+  // filter on reserved_at IS NULL AND expired_at IS NULL.
+  // Replaces the old active_messages index that had reserved_at as a
+  // column (redundant with the WHERE filter, displacing visible_at).
   await client.query(`
-    CREATE INDEX IF NOT EXISTS idx_engine_streams_active_messages
-    ON ${engineTable} (stream_name, reserved_at, visible_at, id)
+    CREATE INDEX IF NOT EXISTS idx_engine_streams_dequeue
+    ON ${engineTable} (stream_name, visible_at, id)
     WHERE reserved_at IS NULL AND expired_at IS NULL;
   `);
 
+  // Stale-reservation recovery: covers the timed-out reservation path
+  // (reserved_at < NOW() - INTERVAL) separately from the hot path so
+  // the planner can use each index cleanly without an OR.
   await client.query(`
-    CREATE INDEX IF NOT EXISTS idx_engine_streams_message_fetch
-    ON ${engineTable} (stream_name, visible_at, id)
-    WHERE expired_at IS NULL;
+    CREATE INDEX IF NOT EXISTS idx_engine_streams_stale_reservations
+    ON ${engineTable} (stream_name, reserved_at, visible_at, id)
+    WHERE reserved_at IS NOT NULL AND expired_at IS NULL;
   `);
 
   await client.query(`
@@ -270,23 +280,27 @@ async function createTables(
   `);
 
   for (let i = 0; i < 8; i++) {
+    // fillfactor 70: reserves 30% page space for HOT updates (reserve/ack cycle)
     await client.query(`
       CREATE TABLE IF NOT EXISTS ${schemaName}.worker_streams_part_${i}
       PARTITION OF ${workerTable}
-      FOR VALUES WITH (modulus 8, remainder ${i});
+      FOR VALUES WITH (modulus 8, remainder ${i})
+      WITH (fillfactor = 70);
     `);
   }
 
+  // Dedicated dequeue index (see engine_streams comments above)
   await client.query(`
-    CREATE INDEX IF NOT EXISTS idx_worker_streams_active_messages
-    ON ${workerTable} (stream_name, reserved_at, visible_at, id)
+    CREATE INDEX IF NOT EXISTS idx_worker_streams_dequeue
+    ON ${workerTable} (stream_name, visible_at, id)
     WHERE reserved_at IS NULL AND expired_at IS NULL;
   `);
 
+  // Stale-reservation recovery (see engine_streams comments above)
   await client.query(`
-    CREATE INDEX IF NOT EXISTS idx_worker_streams_message_fetch
-    ON ${workerTable} (stream_name, visible_at, id)
-    WHERE expired_at IS NULL;
+    CREATE INDEX IF NOT EXISTS idx_worker_streams_stale_reservations
+    ON ${workerTable} (stream_name, reserved_at, visible_at, id)
+    WHERE reserved_at IS NOT NULL AND expired_at IS NULL;
   `);
 
   await client.query(`

--- a/services/stream/providers/postgres/messages.ts
+++ b/services/stream/providers/postgres/messages.ts
@@ -276,13 +276,18 @@ export async function fetchMessages(
       const batchSize = options?.batchSize || 1;
       const reservationTimeout = options?.reservationTimeout || HMSH_RESERVATION_TIMEOUT_S;
 
-      const res = await client.query(
+      // Two-pass dequeue: stale reservations first (FIFO — they have
+      // lower ids and have waited longest), then fresh messages. Split
+      // avoids an OR that prevents the planner from using partial
+      // indexes cleanly. Stale check is a fast no-op (empty index scan)
+      // when there are no timed-out reservations.
+      let res = await client.query(
         `UPDATE ${tableName}
          SET reserved_at = NOW(), reserved_by = $3
          WHERE id IN (
            SELECT id FROM ${tableName}
            WHERE stream_name = $1
-             AND (reserved_at IS NULL OR reserved_at < NOW() - INTERVAL '${reservationTimeout} seconds')
+             AND reserved_at < NOW() - INTERVAL '${reservationTimeout} seconds'
              AND expired_at IS NULL
              AND visible_at <= NOW()
            ORDER BY id
@@ -292,6 +297,26 @@ export async function fetchMessages(
          RETURNING ${returningClause}`,
         [streamName, batchSize, consumerName],
       );
+
+      // Fresh messages: unreserved, visible, not expired
+      if (res.rows.length === 0) {
+        res = await client.query(
+          `UPDATE ${tableName}
+           SET reserved_at = NOW(), reserved_by = $3
+           WHERE id IN (
+             SELECT id FROM ${tableName}
+             WHERE stream_name = $1
+               AND reserved_at IS NULL
+               AND expired_at IS NULL
+               AND visible_at <= NOW()
+             ORDER BY id
+             LIMIT $2
+             FOR UPDATE SKIP LOCKED
+           )
+           RETURNING ${returningClause}`,
+          [streamName, batchSize, consumerName],
+        );
+      }
 
       const messages: StreamMessage[] = res.rows.map((row: any) => {
         const data = parseStreamMessage(row.message);

--- a/services/stream/providers/postgres/procedures.ts
+++ b/services/stream/providers/postgres/procedures.ts
@@ -54,13 +54,16 @@ export function getCreateProceduresSQL(schemaName: string): string[] {
     SET search_path = ${schemaName}, pg_temp
     AS $$
     ${STREAM_ACCESS_CHECK}
+      -- Two-pass dequeue: stale reservations first (FIFO — lower ids,
+      -- waited longest), then fresh. Split avoids OR that prevents
+      -- partial index usage. Stale check is a fast no-op when empty.
       RETURN QUERY
       UPDATE ${workerTable} ws
       SET reserved_at = NOW(), reserved_by = p_consumer_id
       WHERE ws.id IN (
         SELECT ws2.id FROM ${workerTable} ws2
         WHERE ws2.stream_name = p_stream_name
-          AND (ws2.reserved_at IS NULL OR ws2.reserved_at < NOW() - (p_reservation_timeout_sec || ' seconds')::INTERVAL)
+          AND ws2.reserved_at < NOW() - (p_reservation_timeout_sec || ' seconds')::INTERVAL
           AND ws2.expired_at IS NULL
           AND ws2.visible_at <= NOW()
         ORDER BY ws2.id
@@ -69,6 +72,25 @@ export function getCreateProceduresSQL(schemaName: string): string[] {
       )
       RETURNING ws.id, ws.message, ws.workflow_name, ws.max_retry_attempts,
                 ws.backoff_coefficient, ws.maximum_interval_seconds, ws.retry_attempt;
+
+      -- Fresh messages: unreserved, visible, not expired
+      IF NOT FOUND THEN
+        RETURN QUERY
+        UPDATE ${workerTable} ws
+        SET reserved_at = NOW(), reserved_by = p_consumer_id
+        WHERE ws.id IN (
+          SELECT ws2.id FROM ${workerTable} ws2
+          WHERE ws2.stream_name = p_stream_name
+            AND ws2.reserved_at IS NULL
+            AND ws2.expired_at IS NULL
+            AND ws2.visible_at <= NOW()
+          ORDER BY ws2.id
+          LIMIT p_batch_size
+          FOR UPDATE SKIP LOCKED
+        )
+        RETURNING ws.id, ws.message, ws.workflow_name, ws.max_retry_attempts,
+                  ws.backoff_coefficient, ws.maximum_interval_seconds, ws.retry_attempt;
+      END IF;
     END;
     $$;`,
 


### PR DESCRIPTION
## Summary
- **fillfactor=70** on stream partition tables to enable HOT updates during the reserve/ack cycle, reducing dead tuple accumulation and vacuum pressure
- **Dedicated dequeue index** `(stream_name, visible_at, id) WHERE reserved_at IS NULL AND expired_at IS NULL` replaces the misaligned `active_messages` index that the planner was ignoring (23 scans out of ~90K queries)
- **Separate stale-reservation index** for crashed consumer recovery, enabling clean partial index usage on both paths
- **Two-pass dequeue query** (stale-first for FIFO ordering, then fresh) replaces the single OR query that prevented partial index usage
- **Removes redundant `message_fetch` index** that overlapped with the new dequeue index
- Package version bump to 0.15.1

## Benchmark (1K concurrent workflows, fresh volumes each run)

| Metric | Legacy | Optimized | Change |
|--------|--------|-----------|--------|
| idx_tup_read | 283,195,785 | 53,140,419 | **-81% (5.3x)** |
| dead_tuples | 1,381 | 908 | **-34%** |
| wall_clock | ~200s | ~200s | same |
| errors | 0 | 0 | same |

## Test plan
- [x] `docker compose down -v && docker compose up -d` fresh volume baseline (legacy): scale-10 + scale-100 pass
- [x] `docker compose down -v && docker compose up -d` fresh volume optimized: scale-10 + scale-100 pass
- [x] `CONTENTION_1K=1` legacy: 1000 workflows complete, 0 errors
- [x] `CONTENTION_1K=1` optimized: 1000 workflows complete, 0 errors
- [x] `tests/functional/stream/providers/postgres/postgres.test.ts`: 33/33 pass (including reclaim and stale message tests)
- [x] Full test suite: only pre-existing cron/pipe failures (confirmed on legacy)