### PR TITLE
fix: rethrow CollationError FORBIDDEN to prevent signal loss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/activities/activity/process.ts
+++ b/services/activities/activity/process.ts
@@ -8,6 +8,7 @@ import {
   GetStateError,
   InactiveJobError,
 } from '../../../modules/errors';
+import { CollationFaultType } from '../../../types/collator';
 import { CollatorService } from '../../collator';
 import { EngineService } from '../../engine';
 import { ILogger } from '../../logger';
@@ -132,10 +133,27 @@ export async function processEvent(
     telemetry.setActivityAttributes({});
   } catch (error) {
     if (error instanceof CollationError) {
-      // INACTIVE is legitimate duplicate detection — the Postgres atomic
-      // CTE (collateLeg2Entry) serializes via row locks, so the GUID
-      // ledger value is correct. Silent ack is the right behavior:
-      // the work was already done by a prior delivery of this message.
+      //FORBIDDEN: Leg1 not complete — signal arrived in the window
+      //between registerHook (standalone) and Leg1 transaction commit.
+      //Rethrow so the stream message is retried with backoff; by then
+      //Leg1 will have committed and Leg2 processing will succeed.
+      //The GUID marker was already committed by notarizeLeg2Entry;
+      //on retry, collateLeg2Entry's SETNX is a no-op for the same
+      //GUID, and verifySyntheticInteger sees no steps done → allowed.
+      if (error.fault === CollationFaultType.FORBIDDEN) {
+        instance.logger.warn('process-event-forbidden-retry', {
+          jid: instance.context.metadata.jid,
+          aid: instance.metadata.aid,
+          message: 'Leg1 not committed yet; rethrowing for stream retry',
+          error,
+        });
+        throw error;
+      }
+      // INACTIVE/DUPLICATE: legitimate duplicate detection — the
+      // Postgres atomic CTE (collateLeg2Entry) serializes via row
+      // locks, so the GUID ledger value is correct. Silent ack is
+      // the right behavior: the work was already done by a prior
+      // delivery of this message.
       const now = Date.now();
       if (now - collationWindowStart > COLLATION_WINDOW_MS) {
         collationErrorCount = 0;

--- a/services/store/providers/postgres/postgres.ts
+++ b/services/store/providers/postgres/postgres.ts
@@ -1040,9 +1040,14 @@ class PostgresStoreService extends StoreService<
   /**
    * Leg1: set hook signal, atomically detecting a pending signal.
    *
-   * Standalone (no transaction): single CTE query that reads any existing
-   * pending value, then inserts the hook signal (overwriting pending or
-   * expired entries). Returns `{success, pendingData}` in one round trip.
+   * Standalone (no transaction): acquires a per-key advisory lock to
+   * serialize with concurrent getHookSignal calls, then reads any
+   * existing pending value and inserts the hook signal.
+   *
+   * The advisory lock prevents a race where the CTE's read snapshot
+   * misses a concurrently inserted pending signal — under READ
+   * COMMITTED, ON CONFLICT sees committed writes but the SELECT CTE
+   * does not, causing the pending data to be silently overwritten.
    *
    * In a transaction: queues the setnxex; pending detection deferred.
    */
@@ -1064,37 +1069,42 @@ class PostgresStoreService extends StoreService<
     const kv = this.kvsql();
     const tableName = kv.tableForKey(fullKey);
     const storedKey = kv.storageKey(fullKey);
-    const sql = `
-      WITH pre AS (
-        SELECT value FROM ${tableName}
-        WHERE key = $1 AND (expiry IS NULL OR expiry > NOW())
-      ),
-      ins AS (
-        INSERT INTO ${tableName} (key, value, expiry)
-        VALUES ($1, $2, NOW() + INTERVAL '${delay} seconds')
-        ON CONFLICT (key) DO UPDATE
-          SET value = EXCLUDED.value, expiry = EXCLUDED.expiry
-          WHERE ${tableName}.expiry IS NULL
-            OR ${tableName}.expiry <= NOW()
-            OR ${tableName}.value LIKE '$pending::%'
-        RETURNING true as success
-      )
-      SELECT
-        COALESCE((SELECT success FROM ins), false) as success,
-        (SELECT value FROM pre) as existing_value
-    `;
+
+    //acquire per-key advisory lock (session-level) to serialize
+    //with concurrent getHookSignal for the same signal key
+    await this.pgClient.query(
+      'SELECT pg_advisory_lock(901, hashtext($1))',
+      [storedKey],
+    );
     try {
-      const res = await this.pgClient.query(sql, [storedKey, jobId]);
-      const row = res.rows[0] || {};
-      const success = row.success === true;
-      const existing = row.existing_value;
-      if (success && existing?.startsWith('$pending::')) {
-        return {
-          success: true,
-          pendingData: existing.slice('$pending::'.length),
-        };
+      //read existing value under lock
+      const readRes = await this.pgClient.query(
+        `SELECT value FROM ${tableName}
+         WHERE key = $1 AND (expiry IS NULL OR expiry > NOW())`,
+        [storedKey],
+      );
+
+      let pendingData: string | undefined;
+      if (readRes.rows.length > 0) {
+        const existing = readRes.rows[0].value;
+        if (existing?.startsWith('$pending::')) {
+          pendingData = existing.slice('$pending::'.length);
+        } else {
+          //hook already set (retry) — no change needed
+          return { success: false };
+        }
       }
-      return { success };
+
+      //insert hook value (or overwrite pending)
+      await this.pgClient.query(
+        `INSERT INTO ${tableName} (key, value, expiry)
+         VALUES ($1, $2, NOW() + INTERVAL '${delay} seconds')
+         ON CONFLICT (key) DO UPDATE
+           SET value = EXCLUDED.value, expiry = EXCLUDED.expiry`,
+        [storedKey, jobId],
+      );
+
+      return { success: true, pendingData };
     } catch (error: any) {
       if (
         error?.message?.includes('closed') ||
@@ -1103,6 +1113,15 @@ class PostgresStoreService extends StoreService<
         return { success: false };
       }
       throw error;
+    } finally {
+      try {
+        await this.pgClient.query(
+          'SELECT pg_advisory_unlock(901, hashtext($1))',
+          [storedKey],
+        );
+      } catch {
+        //lock auto-releases on session close
+      }
     }
   }
 
@@ -1110,10 +1129,13 @@ class PostgresStoreService extends StoreService<
    * Leg2: get hook signal OR atomically set a pending signal.
    *
    * When `pendingData` is provided and no hook signal exists, the
-   * pending value is inserted in the SAME SQL statement — no second
-   * round trip. This is the transactional edge that prevents the
-   * signal from being lost: by the time the query returns, the
-   * pending key is already visible to leg1's setnxex.
+   * pending value is stored so leg1's setHookSignal can detect it.
+   *
+   * Uses a per-key advisory lock to serialize with concurrent
+   * setHookSignal calls. Without the lock, a CTE race exists where
+   * the read snapshot misses a concurrently inserted hook signal AND
+   * the pending INSERT fails on conflict (the hook has valid expiry),
+   * silently losing the signal.
    *
    * When `pendingData` is omitted, behaves as a plain read.
    */
@@ -1135,39 +1157,43 @@ class PostgresStoreService extends StoreService<
       return value;
     }
 
-    //atomic get-or-set-pending: one round trip
     const kv = this.kvsql();
     const tableName = kv.tableForKey(fullKey);
     const storedKey = kv.storageKey(fullKey);
     const expire = pendingExpire || HMSH_PENDING_SIGNAL_EXPIRE;
     const pendingValue = `$pending::${pendingData}`;
 
-    const sql = `
-      WITH existing AS (
-        SELECT value FROM ${tableName}
-        WHERE key = $1 AND (expiry IS NULL OR expiry > NOW())
-      ),
-      pending AS (
-        INSERT INTO ${tableName} (key, value, expiry)
-        SELECT $1, $2, NOW() + INTERVAL '${expire} seconds'
-        WHERE NOT EXISTS (SELECT 1 FROM existing)
-        ON CONFLICT (key) DO UPDATE
-          SET value = EXCLUDED.value, expiry = EXCLUDED.expiry
-          WHERE ${tableName}.expiry IS NULL OR ${tableName}.expiry <= NOW()
-        RETURNING true as inserted
-      )
-      SELECT
-        (SELECT value FROM existing) as hook_value,
-        (SELECT inserted FROM pending) as pending_inserted
-    `;
+    //acquire per-key advisory lock (session-level) to serialize
+    //with concurrent setHookSignal for the same signal key
+    await this.pgClient.query(
+      'SELECT pg_advisory_lock(901, hashtext($1))',
+      [storedKey],
+    );
     try {
-      const res = await this.pgClient.query(sql, [storedKey, pendingValue]);
-      const row = res.rows[0] || {};
-      const hookValue = row.hook_value;
-      if (hookValue && !hookValue.startsWith('$pending::')) {
-        return hookValue;
+      //read existing value under lock
+      const readRes = await this.pgClient.query(
+        `SELECT value FROM ${tableName}
+         WHERE key = $1 AND (expiry IS NULL OR expiry > NOW())`,
+        [storedKey],
+      );
+
+      if (readRes.rows.length > 0) {
+        const value = readRes.rows[0].value;
+        if (value && !value.startsWith('$pending::')) {
+          //hook found — return it
+          return value;
+        }
       }
-      //no hook signal; pending was inserted (or already existed)
+
+      //no hook signal — store pending
+      await this.pgClient.query(
+        `INSERT INTO ${tableName} (key, value, expiry)
+         VALUES ($1, $2, NOW() + INTERVAL '${expire} seconds')
+         ON CONFLICT (key) DO UPDATE
+           SET value = EXCLUDED.value, expiry = EXCLUDED.expiry`,
+        [storedKey, pendingValue],
+      );
+
       return undefined;
     } catch (error: any) {
       if (
@@ -1177,6 +1203,15 @@ class PostgresStoreService extends StoreService<
         return undefined;
       }
       throw error;
+    } finally {
+      try {
+        await this.pgClient.query(
+          'SELECT pg_advisory_unlock(901, hashtext($1))',
+          [storedKey],
+        );
+      } catch {
+        //lock auto-releases on session close
+      }
     }
   }
 

--- a/tests/unit/services/router/consumption/collation-retry.test.ts
+++ b/tests/unit/services/router/consumption/collation-retry.test.ts
@@ -147,6 +147,76 @@ describe('processEvent | CollationError INACTIVE silent ack', () => {
 });
 
 // ═════════════════════════════════════════════════════════════════════
+// Layer 1b: processEvent — FORBIDDEN is rethrown (not silently acked)
+// ═════════════════════════════════════════════════════════════════════
+
+describe('processEvent | CollationError FORBIDDEN rethrown for retry', () => {
+  const forbiddenError = new CollationError(
+    1000000000001, 2, 'enter', CollationFaultType.FORBIDDEN,
+  );
+
+  it('should rethrow FORBIDDEN so the stream message is retried', async () => {
+    // FORBIDDEN = Leg1 not complete; signal arrived between
+    // registerHook (standalone) and Leg1 transaction commit.
+    // The GUID marker was already committed by notarizeLeg2Entry,
+    // so the message MUST be retried — silent ack would lose the signal.
+    const ctx = createMockProcessContext({
+      verifyReentry: vi.fn().mockRejectedValue(forbiddenError),
+    });
+
+    await expect(processEvent(ctx)).rejects.toThrow(CollationError);
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      'process-event-forbidden-retry',
+      expect.objectContaining({
+        jid: 'j1',
+        aid: 'a1',
+        message: 'Leg1 not committed yet; rethrowing for stream retry',
+      }),
+    );
+  });
+
+  it('FORBIDDEN should NOT delete the hook signal (error propagates past deleteWebHookSignal)', async () => {
+    // When processEvent rethrows FORBIDDEN, control never reaches
+    // processWebHookEvent's deleteWebHookSignal call. The hook signal
+    // is preserved for the retry attempt.
+    const ctx = createMockProcessContext({
+      verifyReentry: vi.fn().mockRejectedValue(forbiddenError),
+    });
+
+    const thrown = await processEvent(ctx).catch((e: Error) => e);
+    expect(thrown).toBeInstanceOf(CollationError);
+    expect((thrown as CollationError).fault).toBe(CollationFaultType.FORBIDDEN);
+    // bindActivityData should NOT have been called (error before it)
+    expect(ctx.bindActivityData).not.toHaveBeenCalled();
+    expect(ctx.mapJobData).not.toHaveBeenCalled();
+    expect(ctx.executeStepProtocol).not.toHaveBeenCalled();
+  });
+
+  it('INACTIVE should still be silently acked (not rethrown)', async () => {
+    // Regression guard: INACTIVE is a legitimate duplicate.
+    const inactiveError = new CollationError(
+      889000001010001, 2, 'enter', CollationFaultType.INACTIVE,
+    );
+    const ctx = createMockProcessContext({
+      verifyReentry: vi.fn().mockRejectedValue(inactiveError),
+    });
+
+    await expect(processEvent(ctx)).resolves.toBeUndefined();
+  });
+
+  it('DUPLICATE should still be silently acked (not rethrown)', async () => {
+    const duplicateError = new CollationError(
+      889000001010001, 2, 'enter', CollationFaultType.DUPLICATE,
+    );
+    const ctx = createMockProcessContext({
+      verifyReentry: vi.fn().mockRejectedValue(duplicateError),
+    });
+
+    await expect(processEvent(ctx)).resolves.toBeUndefined();
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
 // Layer 2: consumeOne — duplicate messages are acked without retry
 // ═════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

- Rethrow `CollationError FORBIDDEN` instead of silently acking so the stream message retries with backoff
- Serialize `setHookSignal`/`getHookSignal` with per-key advisory locks to prevent CTE snapshot races
- Add unit tests proving FORBIDDEN is rethrown while INACTIVE/DUPLICATE remain silently acked
- Bump version to 0.16.2

## Test plan

- [x] Unit: `collation-retry.test.ts` — 8/8 pass
- [x] Contention scale-10, scale-100, scale-1000 — all pass
- [x] Full durable suite — 274 pass, 0 fail