### PR TITLE
revert Postgres stream/store optimizations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/store/providers/postgres/kvtables.ts
+++ b/services/store/providers/postgres/kvtables.ts
@@ -206,24 +206,6 @@ export const KVTables = (context: PostgresStoreService) => ({
       `);
     }
 
-    // v0.15.2: add dedicated is_live partial index for hot-path queries
-    const { rows: idxRows } = await client.query(
-      `SELECT 1 FROM pg_indexes WHERE indexname = 'idx_jobs_key_live' AND schemaname = $1 LIMIT 1`,
-      [schemaName],
-    );
-    if (idxRows.length === 0) {
-      await client.query(`
-        CREATE INDEX IF NOT EXISTS idx_jobs_key_live
-        ON ${jobsTable} (key) WHERE is_live;
-      `);
-    }
-
-    // v0.15.2: partial index for sorted_set scheduler hot path
-    await client.query(`
-      CREATE INDEX IF NOT EXISTS idx_task_schedules_active
-      ON ${schemaName}.task_schedules (key, score)
-      WHERE expiry IS NULL;
-    `);
   },
 
   async createTables(
@@ -335,43 +317,29 @@ export const KVTables = (context: PostgresStoreService) => ({
               ON ${fullTableName} USING GIN (context);
             `);
 
-            // Create partitions with fillfactor 70: reserves 30% page space
-            // for HOT updates (status update cycle in setStatusAndCollateGuid)
+            // Create partitions using a DO block
             await client.query(`
               DO $$
               BEGIN
                 FOR i IN 0..7 LOOP
                   EXECUTE format(
                     'CREATE TABLE IF NOT EXISTS ${fullTableName}_part_%s PARTITION OF ${fullTableName}
-                    FOR VALUES WITH (modulus 8, remainder %s)
-                    WITH (fillfactor = 70)',
+                    FOR VALUES WITH (modulus 8, remainder %s)',
                     i, i
                   );
                 END LOOP;
               END$$;
             `);
 
-            // Original index for queries that filter on expired_at directly
-            // (e.g. _hmget's WHERE expired_at IS NULL OR expired_at > NOW())
+            // Create optimized indexes
             await client.query(`
               CREATE INDEX IF NOT EXISTS idx_${tableDef.name}_key_expired_at
               ON ${fullTableName} (key, expired_at) INCLUDE (is_live);
             `);
 
-            // Dedicated partial index for the hot-path (WHERE key = $1 AND is_live).
-            // Covers the uniqueness trigger, hget, hgetall, hincrbyfloat, and
-            // the two-pass upsert — all of which use AND is_live directly.
-            await client.query(`
-              CREATE INDEX IF NOT EXISTS idx_${tableDef.name}_key_live
-              ON ${fullTableName} (key)
-              WHERE is_live;
-            `);
-
-            // status in INCLUDE (not key) so semaphore increments don't
-            // force index key updates — allows HOT on the hottest write path.
             await client.query(`
               CREATE INDEX IF NOT EXISTS idx_${tableDef.name}_entity_status
-              ON ${fullTableName} (entity) INCLUDE (status);
+              ON ${fullTableName} (entity, status);
             `);
 
             await client.query(`
@@ -409,9 +377,7 @@ export const KVTables = (context: PostgresStoreService) => ({
               FOR EACH ROW EXECUTE PROCEDURE ${schemaName}.update_is_live();
             `);
 
-            // Enforce uniqueness of live jobs via trigger.
-            // Uses is_live partial index for the EXISTS check (existing rows
-            // have is_live maintained by trg_update_is_live).
+            // Create function to enforce uniqueness of live jobs
             await client.query(`
               CREATE OR REPLACE FUNCTION ${schemaName}.enforce_live_job_uniqueness()
               RETURNS TRIGGER AS $$
@@ -421,7 +387,7 @@ export const KVTables = (context: PostgresStoreService) => ({
                   IF EXISTS (
                     SELECT 1 FROM ${fullTableName}
                     WHERE key = NEW.key
-                    AND is_live
+                    AND (expired_at IS NULL OR expired_at > NOW())
                     AND id <> NEW.id
                   ) THEN
                     RAISE EXCEPTION 'A live job with key % already exists.', NEW.key;
@@ -499,16 +465,14 @@ export const KVTables = (context: PostgresStoreService) => ({
                   EXECUTE FUNCTION ${schemaName}.update_attributes_updated_at();
             `);
 
-            // Create partitions with fillfactor 70: reserves 30% page space
-            // for HOT updates (frequent upserts in hincrbyfloat/collateLeg2Entry)
+            // Create partitions for attributes table
             await client.query(`
               DO $$
               BEGIN
                 FOR i IN 0..7 LOOP
                   EXECUTE format(
                     'CREATE TABLE IF NOT EXISTS ${attributesTableName}_part_%s PARTITION OF ${attributesTableName}
-                    FOR VALUES WITH (modulus 8, remainder %s)
-                    WITH (fillfactor = 70)',
+                    FOR VALUES WITH (modulus 8, remainder %s)',
                     i, i
                   );
                 END LOOP;
@@ -556,14 +520,6 @@ export const KVTables = (context: PostgresStoreService) => ({
             await client.query(`
               CREATE INDEX IF NOT EXISTS idx_${tableDef.name}_key_score_member
               ON ${fullTableName} (key, score, member);
-            `);
-            // Partial index for the scheduler hot path (zrangebyscore).
-            // Most entries have no expiry; this avoids the OR filter that
-            // prevents clean index-only scans.
-            await client.query(`
-              CREATE INDEX IF NOT EXISTS idx_${tableDef.name}_active
-              ON ${fullTableName} (key, score)
-              WHERE expiry IS NULL;
             `);
             break;
 

--- a/services/store/providers/postgres/kvtypes/hash/basic.ts
+++ b/services/store/providers/postgres/kvtypes/hash/basic.ts
@@ -371,19 +371,11 @@ export function _hset(
       `;
       params.push(key, fields[':'], options?.entity ?? null);
     } else {
-      // Two-pass upsert: UPDATE existing live job, INSERT only if no
-      // live job exists. Avoids ON CONFLICT seq_scan on partitioned
-      // tables that lack a unique partial index.
+      // Update existing job or insert new one
       sql = `
-        WITH existing AS (
-          UPDATE ${targetTable}
-          SET status = $2
-          WHERE key = $1 AND is_live
-          RETURNING 1
-        )
         INSERT INTO ${targetTable} (id, key, status, entity)
-        SELECT gen_random_uuid(), $1, $2, $3
-        WHERE NOT EXISTS (SELECT 1 FROM existing)
+        VALUES (gen_random_uuid(), $1, $2, $3)
+        ON CONFLICT (key) WHERE is_live DO UPDATE SET status = EXCLUDED.status
         RETURNING 1 as count
       `;
       params.push(key, fields[':'], options?.entity ?? null);
@@ -607,20 +599,31 @@ export function _hgetall(
   const isJobsTableResult = isJobsTable(tableName);
 
   if (isJobsTableResult) {
-    // Single CTE: reads jobs row once, then joins attributes
     const sql = `
       WITH valid_job AS (
         SELECT id, status, context
         FROM ${tableName}
         WHERE key = $1 AND is_live
+      ),
+      job_data AS (
+        SELECT 'status' AS field, status::text AS value
+        FROM ${tableName}
+        WHERE key = $1 AND is_live
+
+        UNION ALL
+
+        SELECT 'context' AS field, context::text AS value
+        FROM ${tableName}
+        WHERE key = $1 AND is_live
+      ),
+      attribute_data AS (
+        SELECT symbol || dimension AS field, value
+        FROM ${tableName}_attributes
+        WHERE job_id IN (SELECT id FROM valid_job)
       )
-      SELECT 'status' AS field, status::text AS value FROM valid_job
+      SELECT * FROM job_data
       UNION ALL
-      SELECT 'context' AS field, context::text AS value FROM valid_job
-      UNION ALL
-      SELECT symbol || dimension AS field, value
-      FROM ${tableName}_attributes
-      WHERE job_id = (SELECT id FROM valid_job);
+      SELECT * FROM attribute_data;
     `;
     return { sql, params: [key] };
   } else {

--- a/services/store/providers/postgres/kvtypes/zset.ts
+++ b/services/store/providers/postgres/kvtypes/zset.ts
@@ -119,19 +119,6 @@ export const zsetModule = (context: any) => ({
   ): { sql: string; params: any[] } {
     const tableName = context.tableForKey(key, 'sorted_set');
     const selectColumns = facet === 'WITHSCORES' ? 'member, score' : 'member';
-
-    // Fast path: (0, -1) means "get all" — skip COUNT/ROW_NUMBER entirely
-    if (start === 0 && stop === -1) {
-      const sql = `
-        SELECT ${selectColumns}
-        FROM ${tableName}
-        WHERE key = $1 AND (expiry IS NULL OR expiry > NOW())
-        ORDER BY score ASC, member ASC;
-      `;
-      return { sql, params: [context.storageKey(key)] };
-    }
-
-    // General case: negative indices require COUNT for resolution
     const sql = `
       WITH total_entries AS (
         SELECT COUNT(*) - 1 AS max_index FROM ${tableName}

--- a/services/store/providers/postgres/postgres.ts
+++ b/services/store/providers/postgres/postgres.ts
@@ -676,10 +676,11 @@ class PostgresStoreService extends StoreService<
     this.serializer.resetSymbols(symKeys, symVals, dIds);
 
     const hashData = this.serializer.package(state, symbolNames);
-    // ':' (status) is NOT written to jobs_attributes — jobs.status is
-    // maintained by setStatus/setStatusAndCollateGuid. The attribute row
-    // was redundant, never read, and contended on every activity.
-    delete hashData[':'];
+    if (status !== null) {
+      hashData[':'] = status.toString();
+    } else {
+      delete hashData[':'];
+    }
     await this.kvsql(transaction).hset(hashKey, hashData);
     return jobId;
   }

--- a/services/stream/providers/postgres/kvtables.ts
+++ b/services/stream/providers/postgres/kvtables.ts
@@ -192,33 +192,23 @@ async function createTables(
   `);
 
   for (let i = 0; i < 8; i++) {
-    // fillfactor 70: reserves 30% page space for HOT updates (reserve/ack cycle)
     await client.query(`
       CREATE TABLE IF NOT EXISTS ${schemaName}.engine_streams_part_${i}
       PARTITION OF ${engineTable}
-      FOR VALUES WITH (modulus 8, remainder ${i})
-      WITH (fillfactor = 70);
+      FOR VALUES WITH (modulus 8, remainder ${i});
     `);
   }
 
-  // Dedicated dequeue index: columns match the hot-path query exactly
-  // (stream_name = $1, visible_at <= NOW(), ORDER BY id) with partial
-  // filter on reserved_at IS NULL AND expired_at IS NULL.
-  // Replaces the old active_messages index that had reserved_at as a
-  // column (redundant with the WHERE filter, displacing visible_at).
   await client.query(`
-    CREATE INDEX IF NOT EXISTS idx_engine_streams_dequeue
-    ON ${engineTable} (stream_name, visible_at, id)
+    CREATE INDEX IF NOT EXISTS idx_engine_streams_active_messages
+    ON ${engineTable} (stream_name, reserved_at, visible_at, id)
     WHERE reserved_at IS NULL AND expired_at IS NULL;
   `);
 
-  // Stale-reservation recovery: covers the timed-out reservation path
-  // (reserved_at < NOW() - INTERVAL) separately from the hot path so
-  // the planner can use each index cleanly without an OR.
   await client.query(`
-    CREATE INDEX IF NOT EXISTS idx_engine_streams_stale_reservations
-    ON ${engineTable} (stream_name, reserved_at, visible_at, id)
-    WHERE reserved_at IS NOT NULL AND expired_at IS NULL;
+    CREATE INDEX IF NOT EXISTS idx_engine_streams_message_fetch
+    ON ${engineTable} (stream_name, visible_at, id)
+    WHERE expired_at IS NULL;
   `);
 
   await client.query(`
@@ -280,27 +270,23 @@ async function createTables(
   `);
 
   for (let i = 0; i < 8; i++) {
-    // fillfactor 70: reserves 30% page space for HOT updates (reserve/ack cycle)
     await client.query(`
       CREATE TABLE IF NOT EXISTS ${schemaName}.worker_streams_part_${i}
       PARTITION OF ${workerTable}
-      FOR VALUES WITH (modulus 8, remainder ${i})
-      WITH (fillfactor = 70);
+      FOR VALUES WITH (modulus 8, remainder ${i});
     `);
   }
 
-  // Dedicated dequeue index (see engine_streams comments above)
   await client.query(`
-    CREATE INDEX IF NOT EXISTS idx_worker_streams_dequeue
-    ON ${workerTable} (stream_name, visible_at, id)
+    CREATE INDEX IF NOT EXISTS idx_worker_streams_active_messages
+    ON ${workerTable} (stream_name, reserved_at, visible_at, id)
     WHERE reserved_at IS NULL AND expired_at IS NULL;
   `);
 
-  // Stale-reservation recovery (see engine_streams comments above)
   await client.query(`
-    CREATE INDEX IF NOT EXISTS idx_worker_streams_stale_reservations
-    ON ${workerTable} (stream_name, reserved_at, visible_at, id)
-    WHERE reserved_at IS NOT NULL AND expired_at IS NULL;
+    CREATE INDEX IF NOT EXISTS idx_worker_streams_message_fetch
+    ON ${workerTable} (stream_name, visible_at, id)
+    WHERE expired_at IS NULL;
   `);
 
   await client.query(`

--- a/services/stream/providers/postgres/messages.ts
+++ b/services/stream/providers/postgres/messages.ts
@@ -276,18 +276,13 @@ export async function fetchMessages(
       const batchSize = options?.batchSize || 1;
       const reservationTimeout = options?.reservationTimeout || HMSH_RESERVATION_TIMEOUT_S;
 
-      // Two-pass dequeue: stale reservations first (FIFO — they have
-      // lower ids and have waited longest), then fresh messages. Split
-      // avoids an OR that prevents the planner from using partial
-      // indexes cleanly. Stale check is a fast no-op (empty index scan)
-      // when there are no timed-out reservations.
-      let res = await client.query(
+      const res = await client.query(
         `UPDATE ${tableName}
          SET reserved_at = NOW(), reserved_by = $3
          WHERE id IN (
            SELECT id FROM ${tableName}
            WHERE stream_name = $1
-             AND reserved_at < NOW() - INTERVAL '${reservationTimeout} seconds'
+             AND (reserved_at IS NULL OR reserved_at < NOW() - INTERVAL '${reservationTimeout} seconds')
              AND expired_at IS NULL
              AND visible_at <= NOW()
            ORDER BY id
@@ -297,26 +292,6 @@ export async function fetchMessages(
          RETURNING ${returningClause}`,
         [streamName, batchSize, consumerName],
       );
-
-      // Fresh messages: unreserved, visible, not expired
-      if (res.rows.length === 0) {
-        res = await client.query(
-          `UPDATE ${tableName}
-           SET reserved_at = NOW(), reserved_by = $3
-           WHERE id IN (
-             SELECT id FROM ${tableName}
-             WHERE stream_name = $1
-               AND reserved_at IS NULL
-               AND expired_at IS NULL
-               AND visible_at <= NOW()
-             ORDER BY id
-             LIMIT $2
-             FOR UPDATE SKIP LOCKED
-           )
-           RETURNING ${returningClause}`,
-          [streamName, batchSize, consumerName],
-        );
-      }
 
       const messages: StreamMessage[] = res.rows.map((row: any) => {
         const data = parseStreamMessage(row.message);

--- a/services/stream/providers/postgres/procedures.ts
+++ b/services/stream/providers/postgres/procedures.ts
@@ -54,16 +54,13 @@ export function getCreateProceduresSQL(schemaName: string): string[] {
     SET search_path = ${schemaName}, pg_temp
     AS $$
     ${STREAM_ACCESS_CHECK}
-      -- Two-pass dequeue: stale reservations first (FIFO — lower ids,
-      -- waited longest), then fresh. Split avoids OR that prevents
-      -- partial index usage. Stale check is a fast no-op when empty.
       RETURN QUERY
       UPDATE ${workerTable} ws
       SET reserved_at = NOW(), reserved_by = p_consumer_id
       WHERE ws.id IN (
         SELECT ws2.id FROM ${workerTable} ws2
         WHERE ws2.stream_name = p_stream_name
-          AND ws2.reserved_at < NOW() - (p_reservation_timeout_sec || ' seconds')::INTERVAL
+          AND (ws2.reserved_at IS NULL OR ws2.reserved_at < NOW() - (p_reservation_timeout_sec || ' seconds')::INTERVAL)
           AND ws2.expired_at IS NULL
           AND ws2.visible_at <= NOW()
         ORDER BY ws2.id
@@ -72,25 +69,6 @@ export function getCreateProceduresSQL(schemaName: string): string[] {
       )
       RETURNING ws.id, ws.message, ws.workflow_name, ws.max_retry_attempts,
                 ws.backoff_coefficient, ws.maximum_interval_seconds, ws.retry_attempt;
-
-      -- Fresh messages: unreserved, visible, not expired
-      IF NOT FOUND THEN
-        RETURN QUERY
-        UPDATE ${workerTable} ws
-        SET reserved_at = NOW(), reserved_by = p_consumer_id
-        WHERE ws.id IN (
-          SELECT ws2.id FROM ${workerTable} ws2
-          WHERE ws2.stream_name = p_stream_name
-            AND ws2.reserved_at IS NULL
-            AND ws2.expired_at IS NULL
-            AND ws2.visible_at <= NOW()
-          ORDER BY ws2.id
-          LIMIT p_batch_size
-          FOR UPDATE SKIP LOCKED
-        )
-        RETURNING ws.id, ws.message, ws.workflow_name, ws.max_retry_attempts,
-                  ws.backoff_coefficient, ws.maximum_interval_seconds, ws.retry_attempt;
-      END IF;
     END;
     $$;`,
 

--- a/tests/durable/contention/postgres.test.ts
+++ b/tests/durable/contention/postgres.test.ts
@@ -151,6 +151,8 @@ describe('DURABLE | Contention | Postgres', () => {
 
   it(`scale-10: ${TARGET_SMALL} concurrent assembly-line workflows`, async () => {
     const client = new Client({ connection });
+    const t0 = Date.now();
+    console.log(`[scale-10] Starting ${TARGET_SMALL} workflows...`);
     const startPromises = Array.from({ length: TARGET_SMALL }, (_, i) => {
       return client.workflow.start({
         args: [`Widget-10-${i}`, STATIONS],
@@ -161,7 +163,13 @@ describe('DURABLE | Contention | Postgres', () => {
       });
     });
     const handles = await Promise.all(startPromises) as WorkflowHandleService[];
-    const results = await Promise.all(handles.map((h) => h.result()));
+    console.log(`[scale-10] [${((Date.now() - t0) / 1000).toFixed(1)}s] All ${TARGET_SMALL} enqueued. Waiting for results...`);
+    let doneCount = 0;
+    const results = await Promise.all(handles.map((h) => h.result().then((r) => {
+      doneCount++;
+      console.log(`[scale-10] [${((Date.now() - t0) / 1000).toFixed(1)}s] Completed: ${doneCount}/${TARGET_SMALL}`);
+      return r;
+    })));
     const completed = results.filter(
       (r) => r && typeof r === 'object' && 'results' in r,
     );
@@ -196,6 +204,8 @@ describe('DURABLE | Contention | Postgres', () => {
 
   it('scale-100-analysis: 100 concurrent with distribution analysis', async () => {
     const client = new Client({ connection });
+    const t0 = Date.now();
+    console.log(`[scale-100] Starting 100 workflows...`);
     const startPromises = Array.from({ length: 100 }, (_, i) => {
       return client.workflow.start({
         args: [`Widget-100-${i}`, STATIONS],
@@ -206,7 +216,15 @@ describe('DURABLE | Contention | Postgres', () => {
       });
     });
     const handles = await Promise.all(startPromises) as WorkflowHandleService[];
-    const results = await Promise.all(handles.map((h) => h.result()));
+    console.log(`[scale-100] [${((Date.now() - t0) / 1000).toFixed(1)}s] All 100 enqueued. Waiting for results...`);
+    let doneCount = 0;
+    const results = await Promise.all(handles.map((h) => h.result().then((r) => {
+      doneCount++;
+      if (doneCount % 10 === 0 || doneCount === 100) {
+        console.log(`[scale-100] [${((Date.now() - t0) / 1000).toFixed(1)}s] Completed: ${doneCount}/100`);
+      }
+      return r;
+    })));
     const completed = results.filter(
       (r) => r && typeof r === 'object' && 'results' in r,
     );

--- a/tests/durable/contention/src/workflows.ts
+++ b/tests/durable/contention/src/workflows.ts
@@ -38,7 +38,8 @@ export async function stepIterator(
   const ctx = Durable.workflow.workflowInfo();
   const results: StationResult[] = [];
 
-  for (const [i, step] of steps.entries()) {
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
     const signalId = `step-${i}-${ctx.workflowId}`;
     const childWorkflowId = `ws-${ctx.workflowId}-${i}`;
 
@@ -59,7 +60,6 @@ export async function stepIterator(
 
     const result = await Durable.workflow.condition<StationResult>(
       signalId,
-      '120s',
     );
     if (result === false) {
       throw new Error(`Timed out waiting for step ${i} (${step.stationName})`);


### PR DESCRIPTION
Reverts PRs #169 and #170. Two-pass dequeue starved fresh messages, causing signal loss.