### PR TITLE
fix: inline retry for hook signal race (FORBIDDEN)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.16.3",
+      "version": "0.16.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/activities/hook.ts
+++ b/services/activities/hook.ts
@@ -12,7 +12,9 @@ import {
   StreamDataType,
   StreamStatus,
 } from '../../types/stream';
-import { guid } from '../../modules/utils';
+import { CollationError } from '../../modules/errors';
+import { CollationFaultType } from '../../types/collator';
+import { guid, sleepFor } from '../../modules/utils';
 
 import { Activity } from './activity';
 
@@ -337,9 +339,38 @@ class Hook extends Activity {
       this.context.metadata.jid = jobId;
       this.context.metadata.gid = gId;
       this.context.metadata.dad = dad;
-      await this.processEvent(status, code, 'hook');
-      if (code === 200) {
-        await taskService.deleteWebHookSignal(this.config.hook.topic, data);
+
+      // Inline retry for FORBIDDEN: Leg2 arrived in the window between
+      // setHookSignal (standalone) and Leg1 transaction.exec(). The 100B
+      // ledger digit is not yet visible. Leg1 needs only milliseconds to
+      // commit — retry here, inside the message processing loop, before
+      // consumeOne's finally block acks the message. Stream-level retry
+      // won't help: ENGINE consumers have no retry policy, so shouldRetry
+      // returns [false, 0] and the message is ack'd with no retry.
+      const MAX_FORBIDDEN_RETRIES = 5;
+      const FORBIDDEN_RETRY_DELAY_MS = 50;
+      for (let attempt = 0; attempt <= MAX_FORBIDDEN_RETRIES; attempt++) {
+        try {
+          await this.processEvent(status, code, 'hook');
+          if (code === 200) {
+            await taskService.deleteWebHookSignal(this.config.hook.topic, data);
+          }
+          return;
+        } catch (error) {
+          if (error instanceof CollationError &&
+              error.fault === CollationFaultType.FORBIDDEN &&
+              attempt < MAX_FORBIDDEN_RETRIES) {
+            this.logger.warn('hook-webhook-forbidden-inline-retry', {
+              attempt: attempt + 1,
+              maxAttempts: MAX_FORBIDDEN_RETRIES,
+              jid: this.context.metadata.jid,
+              aid: this.metadata.aid,
+            });
+            await sleepFor(FORBIDDEN_RETRY_DELAY_MS * (attempt + 1));
+            continue;
+          }
+          throw error;
+        }
       }
     }
   }

--- a/tests/durable/signal-race/postgres.test.ts
+++ b/tests/durable/signal-race/postgres.test.ts
@@ -12,7 +12,7 @@ import * as workflows from './src/workflows';
 
 const { Connection, Client, Worker } = Durable;
 
-const CONCURRENCY = 50;
+const CONCURRENCY = 100;
 
 describe('DURABLE | signal-race | Postgres', () => {
   let postgresClient: ProviderNativeClient;
@@ -71,14 +71,23 @@ describe('DURABLE | signal-race | Postgres', () => {
       }),
     ]);
 
+    const t0 = Date.now();
+    console.log(`[signal-race] All ${CONCURRENCY * 2} workflows launched. Waiting for results...`);
+
     const handles = await Promise.all(allPromises);
     const parentHandles = handles.filter(
       (_, i) => i % 2 === 0,
     ) as WorkflowHandleService[];
 
-    // Collect all parent results — they should all resolve with signal data
+    let doneCount = 0;
     const results = await Promise.all(
-      parentHandles.map((h) => h.result()),
+      parentHandles.map((h) => h.result().then((r) => {
+        doneCount++;
+        if (doneCount % 20 === 0 || doneCount === CONCURRENCY) {
+          console.log(`[signal-race] [${((Date.now() - t0) / 1000).toFixed(1)}s] Completed: ${doneCount}/${CONCURRENCY}`);
+        }
+        return r;
+      })),
     );
 
     const completed = results.filter((r) => r !== 'timed_out');

--- a/tests/durable/signal-race/src/workflows.ts
+++ b/tests/durable/signal-race/src/workflows.ts
@@ -8,7 +8,6 @@ export async function parent(id: string): Promise<string> {
   const signalId = `race-signal-${id}`;
   const result = await Durable.workflow.condition<{ value: string }>(
     signalId,
-    '30s',
   );
   if (result === false) return 'timed_out';
   return result.value;


### PR DESCRIPTION
Prevents signal loss when Leg2 arrives before Leg1 commits.