### PR TITLE
fix: atomic CTE for signal registry; eliminate advisory lock race

### DIFF
--- a/services/activities/hook.ts
+++ b/services/activities/hook.ts
@@ -422,6 +422,22 @@ class Hook extends Activity {
           await this.processEvent(status, code, 'hook');
           if (code === 200) {
             await taskService.deleteWebHookSignal(this.config.hook.topic, data);
+            //clean up orphan pending on the sibling signal topic
+            //  wfs.wait delivered → remove wfs.signal pending
+            //  wfs.signal delivered → remove wfs.wait pending
+            const topic = this.config.hook.topic;
+            const siblingTopic = topic.includes('.wfs.wait')
+              ? topic.replace('.wfs.wait', '.wfs.signal')
+              : topic.includes('.wfs.signal')
+                ? topic.replace('.wfs.signal', '.wfs.wait')
+                : null;
+            if (siblingTopic) {
+              try {
+                await taskService.deleteWebHookSignal(siblingTopic, data);
+              } catch {
+                //sibling entry may not exist — ignore
+              }
+            }
           }
           return;
         } catch (error) {

--- a/services/durable/client.ts
+++ b/services/durable/client.ts
@@ -280,23 +280,23 @@ export class ClientService {
         data,
         ...(expire ? { $expire: expire } : {}),
       };
-      //try inline waiter (v14+: single condition handled without collator)
-      try {
-        const waitTopic = `${ns}.wfs.wait`;
-        await (
-          await this.getHotMeshClient(waitTopic, namespace)
-        ).signal(waitTopic, payload);
-      } catch {
-        //no hook rule for wfs.wait (pre-v14 or Promise.all) — ignore
-      }
-      //also signal collator path (Promise.all or pre-v14 single conditions)
+      //send collator topic first (creates pending if no collator),
+      //then inline waiter topic (delivers and cleans up collator pending)
       try {
         const signalTopic = `${ns}.wfs.signal`;
-        return await (
+        await (
           await this.getHotMeshClient(signalTopic, namespace)
         ).signal(signalTopic, payload);
       } catch {
-        //no hook rule for wfs.signal — ignore
+        //no hook rule — ignore
+      }
+      try {
+        const waitTopic = `${ns}.wfs.wait`;
+        return await (
+          await this.getHotMeshClient(waitTopic, namespace)
+        ).signal(waitTopic, payload);
+      } catch {
+        //no hook rule — ignore
       }
     },
 

--- a/services/durable/handle.ts
+++ b/services/durable/handle.ts
@@ -7,7 +7,6 @@ import {
 } from '../../types/exporter';
 import { JobInterruptOptions, JobOutput } from '../../types/job';
 import { StreamError } from '../../types/stream';
-
 import { ExporterService } from './exporter';
 
 /**
@@ -139,23 +138,23 @@ export class WorkflowHandleService {
       data,
       ...(expire ? { $expire: expire } : {}),
     };
-    //try inline waiter (v14+: single condition handled without collator)
-    try {
-      await this.hotMesh.signal(
-        `${this.hotMesh.appId}.wfs.wait`,
-        payload,
-      );
-    } catch {
-      //no hook rule for wfs.wait (pre-v14 or Promise.all) — ignore
-    }
-    //also signal collator path (Promise.all or pre-v14 single conditions)
+    //send collator topic first (creates pending if no collator),
+    //then inline waiter topic (delivers and cleans up collator pending)
     try {
       await this.hotMesh.signal(
         `${this.hotMesh.appId}.wfs.signal`,
         payload,
       );
     } catch {
-      //no hook rule for wfs.signal — ignore
+      //no hook rule — ignore
+    }
+    try {
+      await this.hotMesh.signal(
+        `${this.hotMesh.appId}.wfs.wait`,
+        payload,
+      );
+    } catch {
+      //no hook rule — ignore
     }
   }
 

--- a/services/durable/workflow/signal.ts
+++ b/services/durable/workflow/signal.ts
@@ -77,20 +77,17 @@ export async function signal(
       data,
       ...(expire ? { $expire: expire } : {}),
     };
-    //try inline waiter (v14+: single condition handled without collator)
+    //send collator topic first (creates pending if no collator),
+    //then inline waiter topic (delivers and cleans up collator pending)
     try {
-      await hotMeshClient.signal(`${namespace}.wfs.wait`, payload);
+      await hotMeshClient.signal(`${namespace}.wfs.signal`, payload);
     } catch {
-      //no hook rule for wfs.wait (pre-v14 or Promise.all) — ignore
+      //no hook rule — ignore
     }
-    //also signal collator path (Promise.all or pre-v14 single conditions)
     try {
-      return await hotMeshClient.signal(
-        `${namespace}.wfs.signal`,
-        payload,
-      );
+      return await hotMeshClient.signal(`${namespace}.wfs.wait`, payload);
     } catch {
-      //no hook rule for wfs.signal — ignore
+      //no hook rule — ignore
     }
   }
 }

--- a/services/store/providers/postgres/postgres.ts
+++ b/services/store/providers/postgres/postgres.ts
@@ -1063,49 +1063,56 @@ class PostgresStoreService extends StoreService<
     const delay = Math.max(hook.expire, HMSH_SIGNAL_EXPIRE);
 
     if (transaction) {
-      await this.kvsql(transaction).setnxex(fullKey, jobId, delay);
-      return { success: true };
-    }
-
-    const kv = this.kvsql();
-    const tableName = kv.tableForKey(fullKey);
-    const storedKey = kv.storageKey(fullKey);
-
-    //acquire per-key advisory lock (session-level) to serialize
-    //with concurrent getHookSignal for the same signal key
-    await this.pgClient.query(
-      'SELECT pg_advisory_lock(901, hashtext($1))',
-      [storedKey],
-    );
-    try {
-      //read existing value under lock
-      const readRes = await this.pgClient.query(
-        `SELECT value FROM ${tableName}
-         WHERE key = $1 AND (expiry IS NULL OR expiry > NOW())`,
-        [storedKey],
-      );
-
-      let pendingData: string | undefined;
-      if (readRes.rows.length > 0) {
-        const existing = readRes.rows[0].value;
-        if (existing?.startsWith('$pending::')) {
-          pendingData = existing.slice('$pending::'.length);
-        } else {
-          //hook already set (retry) — no change needed
-          return { success: false };
-        }
-      }
-
-      //insert hook value (or overwrite pending)
-      await this.pgClient.query(
+      //in-transaction: unconditional upsert (overwrites $pending)
+      const kv = this.kvsql();
+      const tableName = kv.tableForKey(fullKey);
+      const storedKey = kv.storageKey(fullKey);
+      (transaction as any).addCommand(
         `INSERT INTO ${tableName} (key, value, expiry)
          VALUES ($1, $2, NOW() + INTERVAL '${delay} seconds')
          ON CONFLICT (key) DO UPDATE
            SET value = EXCLUDED.value, expiry = EXCLUDED.expiry`,
         [storedKey, jobId],
+        'boolean',
+      );
+      return { success: true };
+    }
+
+    //standalone: atomic CTE — read prior value + upsert in one statement.
+    //eliminates the advisory lock TOCTOU race (reentrant on same session).
+    const kv = this.kvsql();
+    const tableName = kv.tableForKey(fullKey);
+    const storedKey = kv.storageKey(fullKey);
+
+    try {
+      const result = await this.pgClient.query(
+        `WITH prior AS (
+          SELECT value FROM ${tableName}
+          WHERE key = $1 AND (expiry IS NULL OR expiry > NOW())
+        )
+        INSERT INTO ${tableName} (key, value, expiry)
+        VALUES ($1, $2, NOW() + INTERVAL '${delay} seconds')
+        ON CONFLICT (key) DO UPDATE
+          SET value = EXCLUDED.value, expiry = EXCLUDED.expiry
+        RETURNING (SELECT value FROM prior) as prior_value`,
+        [storedKey, jobId],
       );
 
-      return { success: true, pendingData };
+      const priorValue = result.rows[0]?.prior_value;
+      if (priorValue?.startsWith('$pending::')) {
+        this.logger.debug('hook-signal-pending-consumed', {
+          key: signalKey,
+        });
+        return {
+          success: true,
+          pendingData: priorValue.slice('$pending::'.length),
+        };
+      }
+      if (priorValue && !priorValue.startsWith('$pending::')) {
+        //hook already set by a previous Leg1 (idempotent)
+        return { success: false };
+      }
+      return { success: true };
     } catch (error: any) {
       if (
         error?.message?.includes('closed') ||
@@ -1114,15 +1121,6 @@ class PostgresStoreService extends StoreService<
         return { success: false };
       }
       throw error;
-    } finally {
-      try {
-        await this.pgClient.query(
-          'SELECT pg_advisory_unlock(901, hashtext($1))',
-          [storedKey],
-        );
-      } catch {
-        //lock auto-releases on session close
-      }
     }
   }
 
@@ -1158,43 +1156,45 @@ class PostgresStoreService extends StoreService<
       return value;
     }
 
+    //atomic CTE: check for hook, store $pending if not found.
+    //eliminates the advisory lock TOCTOU race (reentrant on same session).
     const kv = this.kvsql();
     const tableName = kv.tableForKey(fullKey);
     const storedKey = kv.storageKey(fullKey);
     const expire = pendingExpire || HMSH_PENDING_SIGNAL_EXPIRE;
     const pendingValue = `$pending::${pendingData}`;
 
-    //acquire per-key advisory lock (session-level) to serialize
-    //with concurrent setHookSignal for the same signal key
-    await this.pgClient.query(
-      'SELECT pg_advisory_lock(901, hashtext($1))',
-      [storedKey],
-    );
     try {
-      //read existing value under lock
-      const readRes = await this.pgClient.query(
-        `SELECT value FROM ${tableName}
-         WHERE key = $1 AND (expiry IS NULL OR expiry > NOW())`,
-        [storedKey],
-      );
-
-      if (readRes.rows.length > 0) {
-        const value = readRes.rows[0].value;
-        if (value && !value.startsWith('$pending::')) {
-          //hook found — return it
-          return value;
-        }
-      }
-
-      //no hook signal — store pending
-      await this.pgClient.query(
-        `INSERT INTO ${tableName} (key, value, expiry)
-         VALUES ($1, $2, NOW() + INTERVAL '${expire} seconds')
-         ON CONFLICT (key) DO UPDATE
-           SET value = EXCLUDED.value, expiry = EXCLUDED.expiry`,
+      const result = await this.pgClient.query(
+        `WITH prior AS (
+          SELECT value FROM ${tableName}
+          WHERE key = $1 AND (expiry IS NULL OR expiry > NOW())
+        )
+        INSERT INTO ${tableName} (key, value, expiry)
+        VALUES ($1, $2, NOW() + INTERVAL '${expire} seconds')
+        ON CONFLICT (key) DO UPDATE
+          SET value = CASE
+            WHEN ${tableName}.value LIKE '$pending::%' THEN EXCLUDED.value
+            ELSE ${tableName}.value
+          END,
+          expiry = CASE
+            WHEN ${tableName}.value LIKE '$pending::%' THEN EXCLUDED.expiry
+            ELSE ${tableName}.expiry
+          END
+        RETURNING (SELECT value FROM prior) as prior_value`,
         [storedKey, pendingValue],
       );
 
+      const priorValue = result.rows[0]?.prior_value;
+      if (priorValue && !priorValue.startsWith('$pending::')) {
+        //hook found — return the composite job key
+        return priorValue;
+      }
+      //no hook — $pending was stored (or updated existing pending)
+      this.logger.debug('hook-signal-pending-stored', {
+        topic,
+        resolved,
+      });
       return undefined;
     } catch (error: any) {
       if (
@@ -1204,15 +1204,6 @@ class PostgresStoreService extends StoreService<
         return undefined;
       }
       throw error;
-    } finally {
-      try {
-        await this.pgClient.query(
-          'SELECT pg_advisory_unlock(901, hashtext($1))',
-          [storedKey],
-        );
-      } catch {
-        //lock auto-releases on session close
-      }
     }
   }
 

--- a/services/task/index.ts
+++ b/services/task/index.ts
@@ -192,6 +192,7 @@ class TaskService {
     return rules?.[topic]?.[0] as HookRule;
   }
 
+
   async registerWebHook(
     topic: string,
     context: JobState,


### PR DESCRIPTION
## Summary
- Replace advisory lock read-then-write in setHookSignal/getHookSignal with single-statement atomic CTEs
- Clean up orphan signal_registry entries via cross-topic cleanup after delivery
- Reverse signal send order (wfs.signal first, wfs.wait second) for correct cleanup sequencing

## Root cause
`pg_advisory_lock` is reentrant for the same Postgres session. When engine routers share a connection (same Node.js process), Leg1 and Leg2 both "acquire" the lock simultaneously via async interleaving. The multi-step read-check-write could be corrupted: one side's $pending entry silently overwritten by the other side's upsert without extracting the pending data. Signal lost.

## Fix
Single-statement `WITH prior AS (SELECT ...) INSERT ... ON CONFLICT DO UPDATE ... RETURNING (SELECT value FROM prior)` captures the pre-upsert value atomically. No round-trips between Node.js and Postgres, no interleaving possible.

## Test plan
- [x] 28/28 durable test files pass (274/274 tests)
- [x] Signal-race functional tests pass (Direction A + B with monkeypatched delays)
- [x] 100-workflow concurrent signal-race stress test passes
- [x] Zero stale signal_registry rows after full test suite
- [x] CTE prior_value capture verified against Postgres directly