### PR TITLE
Postgres optimizations, throttle cleanup, engine_streams jid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.17.5",
+  "version": "0.18.0",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/hotmesh/quorum.ts
+++ b/services/hotmesh/quorum.ts
@@ -8,7 +8,6 @@ import {
   ThrottleMessage,
   ThrottleOptions,
 } from '../../types/quorum';
-import { MAX_DELAY } from '../../modules/enums';
 
 interface QuorumContext {
   engine: EngineService | null;
@@ -33,19 +32,14 @@ export async function throttle(
   instance: QuorumContext,
   options: ThrottleOptions,
 ): Promise<boolean> {
-  let throttleValue: number;
-  if (options.throttle === -1) {
-    throttleValue = MAX_DELAY;
-  } else {
-    throttleValue = options.throttle;
-  }
+  const throttleValue = options.throttle;
   if (
     !Number.isInteger(throttleValue) ||
-    throttleValue < 0 ||
-    throttleValue > MAX_DELAY
+    (throttleValue < -1) ||
+    (throttleValue !== -1 && throttleValue < 0)
   ) {
     throw new Error(
-      `Throttle must be a non-negative integer and not exceed ${MAX_DELAY} ms; send -1 to throttle indefinitely`,
+      'Throttle must be -1 (pause) or a non-negative integer (ms delay); 0 = resume',
     );
   }
   const throttleMessage: ThrottleMessage = {

--- a/services/router/config/index.ts
+++ b/services/router/config/index.ts
@@ -25,11 +25,11 @@ export class RouterConfigManager {
   static validateThrottle(delayInMillis: number): void {
     if (
       !Number.isInteger(delayInMillis) ||
-      delayInMillis < 0 ||
-      delayInMillis > MAX_DELAY
+      (delayInMillis < -1) ||
+      (delayInMillis > MAX_DELAY)
     ) {
       throw new Error(
-        `Throttle must be a non-negative integer and not exceed ${MAX_DELAY} ms; send -1 to throttle indefinitely`,
+        'Throttle must be -1 (pause) or a non-negative integer (ms delay); 0 = resume',
       );
     }
   }

--- a/services/router/throttling/index.ts
+++ b/services/router/throttling/index.ts
@@ -1,5 +1,3 @@
-import { MAX_DELAY } from '../config';
-
 export class ThrottleManager {
   private throttle = 0;
   private isSleeping = false;
@@ -16,13 +14,15 @@ export class ThrottleManager {
   }
 
   setThrottle(delayInMillis: number): void {
+    const wasPaused = this.throttle < 0;
     const wasDecreased = delayInMillis < this.throttle;
     this.throttle = delayInMillis;
 
-    // If the throttle was decreased, and we're in the middle of a sleep cycle, adjust immediately
-    if (wasDecreased) {
+    // Interrupt sleep when: resuming from pause, or delay was decreased
+    if (wasPaused || wasDecreased) {
       if (this.sleepTimeout) {
         clearTimeout(this.sleepTimeout);
+        this.sleepTimeout = null;
       }
       if (this.innerPromiseResolve) {
         this.innerPromiseResolve();
@@ -31,7 +31,7 @@ export class ThrottleManager {
   }
 
   isPaused(): boolean {
-    return this.throttle === MAX_DELAY;
+    return this.throttle < 0;
   }
 
   /**
@@ -42,17 +42,31 @@ export class ThrottleManager {
    * to sleep until the new termination point. This
    * allows for dynamic, elastic throttling with smooth
    * acceleration and deceleration.
+   *
+   * When paused (throttle < 0), waits indefinitely via a bare
+   * promise — no setTimeout timer. Resumes instantly when
+   * setThrottle() is called with a non-negative value.
    */
   async customSleep(): Promise<void> {
     if (this.throttle === 0) return;
     if (this.isSleeping) return;
     this.isSleeping = true;
-    const startTime = Date.now(); //anchor the origin
+
+    if (this.throttle < 0) {
+      // Paused: wait indefinitely until setThrottle interrupts
+      await new Promise<void>((resolve) => {
+        this.innerPromiseResolve = resolve;
+      });
+      this.resetThrottleState();
+      return;
+    }
+
+    const startTime = Date.now();
 
     await new Promise<void>(async (outerResolve) => {
       this.sleepPromiseResolve = outerResolve;
       let elapsedTime = Date.now() - startTime;
-      while (elapsedTime < this.throttle) {
+      while (elapsedTime < this.throttle && this.throttle > 0) {
         await new Promise<void>((innerResolve) => {
           this.innerPromiseResolve = innerResolve;
           this.sleepTimeout = setTimeout(

--- a/services/store/providers/postgres/kvtables.ts
+++ b/services/store/providers/postgres/kvtables.ts
@@ -206,6 +206,18 @@ export const KVTables = (context: PostgresStoreService) => ({
       `);
     }
 
+    // v0.17.6: add dedicated is_live partial index for hot-path queries
+    const { rows: idxRows } = await client.query(
+      `SELECT 1 FROM pg_indexes WHERE indexname = 'idx_jobs_key_live' AND schemaname = $1 LIMIT 1`,
+      [schemaName],
+    );
+    if (idxRows.length === 0) {
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS idx_jobs_key_live
+        ON ${jobsTable} (key) WHERE is_live;
+      `);
+    }
+
   },
 
   async createTables(
@@ -324,14 +336,16 @@ export const KVTables = (context: PostgresStoreService) => ({
               ON ${fullTableName} USING GIN (context);
             `);
 
-            // Create partitions using a DO block
+            // Create partitions with fillfactor 70: reserves 30% page space
+            // for HOT updates (status update cycle in setStatusAndCollateGuid)
             await client.query(`
               DO $$
               BEGIN
                 FOR i IN 0..7 LOOP
                   EXECUTE format(
                     'CREATE TABLE IF NOT EXISTS ${fullTableName}_part_%s PARTITION OF ${fullTableName}
-                    FOR VALUES WITH (modulus 8, remainder %s)',
+                    FOR VALUES WITH (modulus 8, remainder %s)
+                    WITH (fillfactor = 70)',
                     i, i
                   );
                 END LOOP;
@@ -344,9 +358,20 @@ export const KVTables = (context: PostgresStoreService) => ({
               ON ${fullTableName} (key, expired_at) INCLUDE (is_live);
             `);
 
+            // Dedicated partial index for the hot-path (WHERE key = $1 AND is_live).
+            // Covers the uniqueness trigger, hget, hgetall, hincrbyfloat, and
+            // the upsert — all of which use AND is_live directly.
+            await client.query(`
+              CREATE INDEX IF NOT EXISTS idx_${tableDef.name}_key_live
+              ON ${fullTableName} (key)
+              WHERE is_live;
+            `);
+
+            // status in INCLUDE (not key) so semaphore increments don't
+            // force index key updates — allows HOT on the hottest write path.
             await client.query(`
               CREATE INDEX IF NOT EXISTS idx_${tableDef.name}_entity_status
-              ON ${fullTableName} (entity, status);
+              ON ${fullTableName} (entity) INCLUDE (status);
             `);
 
             await client.query(`
@@ -394,7 +419,7 @@ export const KVTables = (context: PostgresStoreService) => ({
                   IF EXISTS (
                     SELECT 1 FROM ${fullTableName}
                     WHERE key = NEW.key
-                    AND (expired_at IS NULL OR expired_at > NOW())
+                    AND is_live
                     AND id <> NEW.id
                   ) THEN
                     RAISE EXCEPTION 'A live job with key % already exists.', NEW.key;
@@ -472,14 +497,16 @@ export const KVTables = (context: PostgresStoreService) => ({
                   EXECUTE FUNCTION ${schemaName}.update_attributes_updated_at();
             `);
 
-            // Create partitions for attributes table
+            // Create partitions with fillfactor 70: reserves 30% page space
+            // for HOT updates (frequent upserts in hincrbyfloat/collateLeg2Entry)
             await client.query(`
               DO $$
               BEGIN
                 FOR i IN 0..7 LOOP
                   EXECUTE format(
                     'CREATE TABLE IF NOT EXISTS ${attributesTableName}_part_%s PARTITION OF ${attributesTableName}
-                    FOR VALUES WITH (modulus 8, remainder %s)',
+                    FOR VALUES WITH (modulus 8, remainder %s)
+                    WITH (fillfactor = 70)',
                     i, i
                   );
                 END LOOP;

--- a/services/store/providers/postgres/kvtypes/hash/basic.ts
+++ b/services/store/providers/postgres/kvtypes/hash/basic.ts
@@ -599,31 +599,20 @@ export function _hgetall(
   const isJobsTableResult = isJobsTable(tableName);
 
   if (isJobsTableResult) {
+    // Single CTE: reads jobs row once, then joins attributes
     const sql = `
       WITH valid_job AS (
         SELECT id, status, context
         FROM ${tableName}
         WHERE key = $1 AND is_live
-      ),
-      job_data AS (
-        SELECT 'status' AS field, status::text AS value
-        FROM ${tableName}
-        WHERE key = $1 AND is_live
-
-        UNION ALL
-
-        SELECT 'context' AS field, context::text AS value
-        FROM ${tableName}
-        WHERE key = $1 AND is_live
-      ),
-      attribute_data AS (
-        SELECT symbol || dimension AS field, value
-        FROM ${tableName}_attributes
-        WHERE job_id IN (SELECT id FROM valid_job)
       )
-      SELECT * FROM job_data
+      SELECT 'status' AS field, status::text AS value FROM valid_job
       UNION ALL
-      SELECT * FROM attribute_data;
+      SELECT 'context' AS field, context::text AS value FROM valid_job
+      UNION ALL
+      SELECT symbol || dimension AS field, value
+      FROM ${tableName}_attributes
+      WHERE job_id = (SELECT id FROM valid_job);
     `;
     return { sql, params: [key] };
   } else {

--- a/services/store/providers/postgres/kvtypes/zset.ts
+++ b/services/store/providers/postgres/kvtypes/zset.ts
@@ -119,6 +119,19 @@ export const zsetModule = (context: any) => ({
   ): { sql: string; params: any[] } {
     const tableName = context.tableForKey(key, 'sorted_set');
     const selectColumns = facet === 'WITHSCORES' ? 'member, score' : 'member';
+
+    // Fast path: (0, -1) means "get all" — skip COUNT/ROW_NUMBER entirely
+    if (start === 0 && stop === -1) {
+      const sql = `
+        SELECT ${selectColumns}
+        FROM ${tableName}
+        WHERE key = $1 AND (expiry IS NULL OR expiry > NOW())
+        ORDER BY score ASC, member ASC;
+      `;
+      return { sql, params: [context.storageKey(key)] };
+    }
+
+    // General case: negative indices require COUNT for resolution
     const sql = `
       WITH total_entries AS (
         SELECT COUNT(*) - 1 AS max_index FROM ${tableName}

--- a/services/store/providers/postgres/postgres.ts
+++ b/services/store/providers/postgres/postgres.ts
@@ -675,11 +675,10 @@ class PostgresStoreService extends StoreService<
     this.serializer.resetSymbols(symKeys, symVals, dIds);
 
     const hashData = this.serializer.package(state, symbolNames);
-    if (status !== null) {
-      hashData[':'] = status.toString();
-    } else {
-      delete hashData[':'];
-    }
+    // ':' (status) is NOT written to jobs_attributes — jobs.status is
+    // maintained by setStatus/setStatusAndCollateGuid. The attribute row
+    // was redundant, never read, and contended on every activity.
+    delete hashData[':'];
     await this.kvsql(transaction).hset(hashKey, hashData);
     return jobId;
   }

--- a/services/store/providers/postgres/postgres.ts
+++ b/services/store/providers/postgres/postgres.ts
@@ -1567,7 +1567,7 @@ class PostgresStoreService extends StoreService<
     const resolveRate = (response: StringStringType, topic: string) => {
       const rate = topic in response ? Number(response[topic]) : 0;
       if (isNaN(rate)) return 0;
-      if (rate == -1) return MAX_DELAY;
+      if (rate < 0) return -1;
       return Math.max(Math.min(rate, MAX_DELAY), 0);
     };
 

--- a/services/stream/providers/postgres/kvtables.ts
+++ b/services/stream/providers/postgres/kvtables.ts
@@ -212,6 +212,24 @@ async function ensureIndexes(
     ON ${workerTable} (stream_name, priority DESC, visible_at, id)
     WHERE expired_at IS NULL;
   `);
+
+  // v0.18.0: add jid column to engine_streams for job tracing
+  const { rows: jidCol } = await client.query(
+    `SELECT 1 FROM information_schema.columns
+     WHERE table_schema = $1 AND table_name = 'engine_streams' AND column_name = 'jid'
+     LIMIT 1`,
+    [schemaName],
+  );
+  if (jidCol.length === 0) {
+    await client.query(
+      `ALTER TABLE ${engineTable} ADD COLUMN jid TEXT NOT NULL DEFAULT ''`,
+    );
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_engine_streams_jid_created
+      ON ${engineTable} (jid, created_at)
+      WHERE jid != '';
+    `);
+  }
 }
 
 async function createTables(
@@ -226,6 +244,7 @@ async function createTables(
     CREATE TABLE IF NOT EXISTS ${engineTable} (
       id BIGSERIAL,
       stream_name TEXT NOT NULL,
+      jid TEXT NOT NULL DEFAULT '',
       message TEXT NOT NULL,
       created_at TIMESTAMPTZ DEFAULT NOW(),
       reserved_at TIMESTAMPTZ,
@@ -284,6 +303,13 @@ async function createTables(
     CREATE INDEX IF NOT EXISTS idx_engine_streams_dead_lettered
     ON ${engineTable} (dead_lettered_at, stream_name)
     WHERE dead_lettered_at IS NOT NULL;
+  `);
+
+  // All engine messages for a job, ordered by time
+  await client.query(`
+    CREATE INDEX IF NOT EXISTS idx_engine_streams_jid_created
+    ON ${engineTable} (jid, created_at)
+    WHERE jid != '';
   `);
 
   // ---- WORKER_STREAMS table ----

--- a/services/stream/providers/postgres/kvtables.ts
+++ b/services/stream/providers/postgres/kvtables.ts
@@ -246,7 +246,8 @@ async function createTables(
     await client.query(`
       CREATE TABLE IF NOT EXISTS ${schemaName}.engine_streams_part_${i}
       PARTITION OF ${engineTable}
-      FOR VALUES WITH (modulus 8, remainder ${i});
+      FOR VALUES WITH (modulus 8, remainder ${i})
+      WITH (fillfactor = 70);
     `);
   }
 
@@ -317,7 +318,8 @@ async function createTables(
     await client.query(`
       CREATE TABLE IF NOT EXISTS ${schemaName}.worker_streams_part_${i}
       PARTITION OF ${workerTable}
-      FOR VALUES WITH (modulus 8, remainder ${i});
+      FOR VALUES WITH (modulus 8, remainder ${i})
+      WITH (fillfactor = 70);
     `);
   }
 

--- a/services/stream/providers/postgres/messages.ts
+++ b/services/stream/providers/postgres/messages.ts
@@ -145,29 +145,29 @@ export function buildPublishSQL(
   const hasVisibilityDelays = parsedMessages.some(pm => pm.visibilityDelayMs > 0);
 
   if (isEngine) {
-    // Engine table: no group_name, no workflow_name
+    // Engine table: includes jid for job tracing
     if (noneHaveConfig && !hasVisibilityDelays) {
-      insertColumns = '(stream_name, message, priority)';
+      insertColumns = '(stream_name, jid, message, priority)';
       parsedMessages.forEach((pm) => {
         const paramOffset = params.length + 1;
-        valuesClauses.push(`($1, $${paramOffset}, $${paramOffset + 1})`);
-        params.push(pm.message, pm.priority);
+        valuesClauses.push(`($1, $${paramOffset}, $${paramOffset + 1}, $${paramOffset + 2})`);
+        params.push(pm.jid, pm.message, pm.priority);
       });
     } else if (noneHaveConfig && hasVisibilityDelays) {
-      insertColumns = '(stream_name, message, priority, visible_at, retry_attempt)';
+      insertColumns = '(stream_name, jid, message, priority, visible_at, retry_attempt)';
       parsedMessages.forEach((pm) => {
         const paramOffset = params.length + 1;
         if (pm.visibilityDelayMs > 0) {
           const visibleAtSQL = `NOW() + INTERVAL '${pm.visibilityDelayMs} milliseconds'`;
-          valuesClauses.push(`($1, $${paramOffset}, $${paramOffset + 1}, ${visibleAtSQL}, $${paramOffset + 2})`);
-          params.push(pm.message, pm.priority, pm.retryAttempt);
+          valuesClauses.push(`($1, $${paramOffset}, $${paramOffset + 1}, $${paramOffset + 2}, ${visibleAtSQL}, $${paramOffset + 3})`);
+          params.push(pm.jid, pm.message, pm.priority, pm.retryAttempt);
         } else {
-          valuesClauses.push(`($1, $${paramOffset}, $${paramOffset + 1}, DEFAULT, $${paramOffset + 2})`);
-          params.push(pm.message, pm.priority, pm.retryAttempt);
+          valuesClauses.push(`($1, $${paramOffset}, $${paramOffset + 1}, $${paramOffset + 2}, DEFAULT, $${paramOffset + 3})`);
+          params.push(pm.jid, pm.message, pm.priority, pm.retryAttempt);
         }
       });
     } else {
-      insertColumns = '(stream_name, message, priority, max_retry_attempts, backoff_coefficient, maximum_interval_seconds, visible_at, retry_attempt)';
+      insertColumns = '(stream_name, jid, message, priority, max_retry_attempts, backoff_coefficient, maximum_interval_seconds, visible_at, retry_attempt)';
       parsedMessages.forEach((pm) => {
         const visibleAtClause = pm.visibilityDelayMs > 0
           ? `NOW() + INTERVAL '${pm.visibilityDelayMs} milliseconds'`
@@ -175,8 +175,9 @@ export function buildPublishSQL(
 
         if (pm.hasExplicitConfig) {
           const paramOffset = params.length + 1;
-          valuesClauses.push(`($1, $${paramOffset}, $${paramOffset + 1}, $${paramOffset + 2}, $${paramOffset + 3}, $${paramOffset + 4}, ${visibleAtClause}, $${paramOffset + 5})`);
+          valuesClauses.push(`($1, $${paramOffset}, $${paramOffset + 1}, $${paramOffset + 2}, $${paramOffset + 3}, $${paramOffset + 4}, $${paramOffset + 5}, ${visibleAtClause}, $${paramOffset + 6})`);
           params.push(
+            pm.jid,
             pm.message,
             pm.priority,
             pm.retry.max_retry_attempts,
@@ -186,8 +187,8 @@ export function buildPublishSQL(
           );
         } else {
           const paramOffset = params.length + 1;
-          valuesClauses.push(`($1, $${paramOffset}, $${paramOffset + 1}, DEFAULT, DEFAULT, DEFAULT, ${visibleAtClause}, $${paramOffset + 2})`);
-          params.push(pm.message, pm.priority, pm.retryAttempt);
+          valuesClauses.push(`($1, $${paramOffset}, $${paramOffset + 1}, $${paramOffset + 2}, DEFAULT, DEFAULT, DEFAULT, ${visibleAtClause}, $${paramOffset + 3})`);
+          params.push(pm.jid, pm.message, pm.priority, pm.retryAttempt);
         }
       });
     }

--- a/tests/functional/quorum/postgres.test.ts
+++ b/tests/functional/quorum/postgres.test.ts
@@ -198,6 +198,82 @@ describe('FUNCTIONAL | Quorum | Postgres', () => {
       hotMesh.quorum?.unsub(callback);
     });
 
+    it('pause (-1) stores -1 directly, not MAX_DELAY', async () => {
+      await hotMesh.throttle({ throttle: -1 });
+      await sleepFor(1000);
+
+      const savedRate = await hotMesh.engine?.store?.getThrottleRate(':');
+      expect(savedRate).toBe(-1);
+    });
+
+    it('resume from pause: -1 → 0', async () => {
+      // Ensure paused from previous test
+      const pausedRate = await hotMesh.engine?.store?.getThrottleRate(':');
+      expect(pausedRate).toBe(-1);
+
+      await hotMesh.throttle({ throttle: 0 });
+      await sleepFor(1000);
+
+      const resumedRate = await hotMesh.engine?.store?.getThrottleRate(':');
+      expect(resumedRate).toBe(0);
+    });
+
+    it('topic-scoped pause stores -1 for that topic only', async () => {
+      // First resume globally
+      await hotMesh.throttle({ throttle: 0 });
+      await sleepFor(500);
+
+      // Pause a specific topic
+      await hotMesh.throttle({ topic: 'calculation.execute', throttle: -1 });
+      await sleepFor(1000);
+
+      const topicRate = await hotMesh.engine?.store?.getThrottleRate(
+        'calculation.execute',
+      );
+      expect(topicRate).toBe(-1);
+
+      // Global rate should still be 0 (resumed)
+      const globalRate = await hotMesh.engine?.store?.getThrottleRate(':');
+      expect(globalRate).toBe(0);
+
+      // Clean up: resume the topic
+      await hotMesh.throttle({ topic: 'calculation.execute', throttle: 0 });
+      await sleepFor(500);
+    });
+
+    it('broadcasts -1 directly (not MAX_DELAY) to quorum', async () => {
+      let receivedThrottle: number | undefined;
+      const callback = (topic: string, message: QuorumMessage) => {
+        if (message.type === 'throttle') {
+          receivedThrottle = (message as ThrottleMessage).throttle;
+        }
+      };
+      hotMesh.quorum?.sub(callback);
+
+      await hotMesh.throttle({ throttle: -1 });
+      await sleepFor(1000);
+
+      hotMesh.quorum?.unsub(callback);
+      expect(receivedThrottle).toBe(-1);
+
+      // Clean up
+      await hotMesh.throttle({ throttle: 0 });
+      await sleepFor(500);
+    });
+
+    it('ThrottleManager.isPaused() returns true for -1', async () => {
+      const { ThrottleManager } = await import('../../../services/router/throttling');
+      const mgr = new ThrottleManager(0);
+
+      expect(mgr.isPaused()).toBe(false);
+      mgr.setThrottle(5000);
+      expect(mgr.isPaused()).toBe(false);
+      mgr.setThrottle(-1);
+      expect(mgr.isPaused()).toBe(true);
+      mgr.setThrottle(0);
+      expect(mgr.isPaused()).toBe(false);
+    });
+
     it('sends a `rollcall` message to WORKER quorum members', async () => {
       let count = 0;
       const callback = (topic: string, message: QuorumMessage) => {

--- a/types/quorum.ts
+++ b/types/quorum.ts
@@ -33,12 +33,8 @@ export type ThrottleOptions = {
   guid?: string;
   /** target a worker quorum */
   topic?: string;
-  /** entity/noun */
-  entity?: string;
-  /** in milliseconds; set to -1 for indefinite throttle */
+  /** delay in milliseconds: 0 = resume, -1 = pause, >0 = delay per message */
   throttle: number;
-  /** namespace */
-  namespace?: string;
 };
 
 /**


### PR DESCRIPTION
## Summary
- Re-introduce safe Postgres optimizations reverted in #173 (fillfactor, partial indexes, CTE simplification, zset fast path)
- Clean up throttle system: -1 means pause throughout the stack (no more MAX_DELAY artifact)
- Add jid column to engine_streams for job tracing; bump to 0.18.0