### PR TITLE
Fix stream_depth to exclude processed messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/stream/providers/postgres/stats.ts
+++ b/services/stream/providers/postgres/stats.ts
@@ -59,6 +59,7 @@ export async function getStreamDepths(
       `SELECT stream_name, COUNT(*) AS count
        FROM ${tableName}
        WHERE stream_name = ANY($1::text[])
+         AND expired_at IS NULL
        GROUP BY stream_name`,
       [streams],
     );


### PR DESCRIPTION
## Summary
- Add `AND expired_at IS NULL` to stream depth query so roll call reports actual queue depth, not total historical row count
- Bump to 0.18.1