### PR TITLE
Fix poison loop on duplicate child spawn; add cycle cap

### DIFF
--- a/modules/enums.ts
+++ b/modules/enums.ts
@@ -156,6 +156,8 @@ export const MAX_DELAY = 2147483647; // Maximum allowed delay in milliseconds fo
 export const HMSH_MAX_RETRIES = parseInt(process.env.HMSH_MAX_RETRIES, 10) || 3;
 export const HMSH_POISON_MESSAGE_THRESHOLD =
   parseInt(process.env.HMSH_POISON_MESSAGE_THRESHOLD, 10) || 5;
+export const HMSH_MAX_CYCLES =
+  parseInt(process.env.HMSH_MAX_CYCLES, 10) || 10_000;
 export const HMSH_MAX_TIMEOUT_MS =
   parseInt(process.env.HMSH_MAX_TIMEOUT_MS, 10) || 60000;
 export const HMSH_GRADUATED_INTERVAL_MS =

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/collator/index.ts
+++ b/services/collator/index.ts
@@ -1,4 +1,5 @@
 import { CollationError, InactiveJobError } from '../../modules/errors';
+import { HMSH_MAX_CYCLES } from '../../modules/enums';
 import { CollationFaultType, CollationStage } from '../../types/collator';
 import { ActivityDuplex } from '../../types/activity';
 import { HotMeshGraph } from '../../types/hotmesh';
@@ -75,6 +76,17 @@ class CollatorService {
     const ancestors = activity.config.ancestors;
     const ancestorIndex = ancestors.indexOf(targetActivityId);
     const dimensions = activity.metadata.dad.split(','); //e.g., `,0,0,1,0`
+
+    // Safety cap: prevent infinite cycle loops
+    const currentCycle = parseInt(dimensions[ancestorIndex] || '0', 10);
+    if (currentCycle >= HMSH_MAX_CYCLES) {
+      throw new Error(
+        `Cycle limit exceeded for job ${activity.context.metadata.jid} ` +
+        `(${currentCycle} >= HMSH_MAX_CYCLES=${HMSH_MAX_CYCLES}) at DAD ${activity.metadata.dad}. ` +
+        `Set HMSH_MAX_CYCLES env var to increase the limit.`,
+      );
+    }
+
     dimensions.length = ancestorIndex + 1;
     dimensions.push('0');
     return dimensions.join(',');

--- a/services/engine/dispatch.ts
+++ b/services/engine/dispatch.ts
@@ -14,6 +14,7 @@
  *   (default)  → Worker.processEvent          (worker response)
  */
 
+import { DuplicateJobError } from '../../modules/errors';
 import { Hook } from '../activities/hook';
 import { Trigger } from '../activities/trigger';
 import { Await } from '../activities/await';
@@ -140,7 +141,23 @@ async function dispatchAwait(
     streamData.data,
     context as JobState,
   )) as Trigger;
-  await handler.process();
+  try {
+    await handler.process();
+  } catch (error) {
+    if (error instanceof DuplicateJobError) {
+      // The child workflow already exists from a prior spawn attempt
+      // (crash recovery). This AWAIT message is a replay — the child
+      // will deliver its RESULT back to the parent via the normal path.
+      // Acknowledge the message so it doesn't loop.
+      instance.logger.info('dispatch-await-child-exists', {
+        childJobId: error.jobId,
+        parentJobId: streamData.metadata.jid,
+        parentDad: streamData.metadata.dad,
+      });
+      return;
+    }
+    throw error;
+  }
 }
 
 async function dispatchResult(

--- a/tests/functional/dispatch/dispatch.test.ts
+++ b/tests/functional/dispatch/dispatch.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+
+import { DuplicateJobError } from '../../../modules/errors';
+import { processStreamMessage } from '../../../services/engine/dispatch';
+import { StreamDataType, StreamStatus } from '../../../types/stream';
+
+/**
+ * Simulates the crash-recovery scenario where a child workflow
+ * already exists when the engine replays an AWAIT message.
+ *
+ * Without the fix: DuplicateJobError propagates, the stream message
+ * is nack'd, and the engine retries indefinitely (poison loop).
+ *
+ * With the fix: DuplicateJobError is caught in dispatchAwait,
+ * the message is acknowledged, and the child delivers its result
+ * via the normal RESULT path.
+ */
+describe('dispatch | AWAIT duplicate child handling', () => {
+  it('should not throw when Trigger.process raises DuplicateJobError', async () => {
+    const logs: Array<{ event: string; data: any }> = [];
+
+    // Mock engine instance with a Trigger that throws DuplicateJobError
+    const mockInstance = {
+      logger: {
+        debug: (event: string, data?: any) => logs.push({ event, data }),
+        info: (event: string, data?: any) => logs.push({ event, data }),
+        error: (event: string, data?: any) => logs.push({ event, data }),
+      },
+      initActivity: async () => ({
+        process: async () => {
+          throw new DuplicateJobError('child-job-123');
+        },
+      }),
+    };
+
+    const streamData = {
+      metadata: {
+        jid: 'parent-job-456',
+        gid: 'guid-abc',
+        dad: ',0,5,0',
+        aid: 'collator',
+        topic: 'child.workflow',
+        await: true,
+      },
+      type: StreamDataType.AWAIT,
+      status: StreamStatus.SUCCESS,
+      code: 200,
+      data: {},
+    };
+
+    // This should NOT throw — the DuplicateJobError should be caught
+    await expect(
+      processStreamMessage(mockInstance as any, streamData as any),
+    ).resolves.toBeUndefined();
+
+    // Verify the info log was emitted
+    const dupLog = logs.find((l) => l.event === 'dispatch-await-child-exists');
+    expect(dupLog).toBeDefined();
+    expect(dupLog?.data?.childJobId).toBe('child-job-123');
+    expect(dupLog?.data?.parentJobId).toBe('parent-job-456');
+  });
+
+  it('should still throw non-DuplicateJobError errors', async () => {
+    const mockInstance = {
+      logger: {
+        debug: () => {},
+        info: () => {},
+        error: () => {},
+      },
+      initActivity: async () => ({
+        process: async () => {
+          throw new Error('unexpected failure');
+        },
+      }),
+    };
+
+    const streamData = {
+      metadata: {
+        jid: 'parent-job-789',
+        gid: 'guid-def',
+        dad: ',0,0',
+        aid: 'trigger',
+        topic: 'child.workflow',
+        await: true,
+      },
+      type: StreamDataType.AWAIT,
+      status: StreamStatus.SUCCESS,
+      code: 200,
+      data: {},
+    };
+
+    await expect(
+      processStreamMessage(mockInstance as any, streamData as any),
+    ).rejects.toThrow('unexpected failure');
+  });
+});


### PR DESCRIPTION
## Summary
- Catch DuplicateJobError in dispatchAwait so replayed child spawns are acknowledged instead of looping
- Add HMSH_MAX_CYCLES env var (default 10,000) to cap cycle dimensions
- Bump to 0.19.1