### PR TITLE
Fix concurrent DDL race on container startup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.19.3",
+      "version": "0.19.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/dba/index.ts
+++ b/services/dba/index.ts
@@ -128,6 +128,21 @@ class DBA {
   constructor() {}
 
   /**
+   * Derives a deterministic advisory lock ID from an appId.
+   * Uses a different offset than the stream/store lock IDs to
+   * avoid collisions with those deployment locks.
+   * @private
+   */
+  static getAdvisoryLockId(appId: string): number {
+    let hash = 0x44424130; // 'DBA0' — distinct namespace
+    for (let i = 0; i < appId.length; i++) {
+      hash = (hash << 5) - hash + appId.charCodeAt(i);
+      hash |= 0;
+    }
+    return Math.abs(hash);
+  }
+
+  /**
    * Sanitizes an appId for use as a Postgres schema name.
    * Mirrors the naming logic used during table deployment.
    * @private
@@ -365,8 +380,25 @@ class DBA {
     const schema = DBA.safeName(appId);
     const { client, release } = await DBA.getClient(connection);
     try {
-      await client.query(DBA.getMigrationSQL(schema));
-      await client.query(DBA.getPruneFunctionSQL(schema));
+      // Guard DDL with an advisory lock. CREATE INDEX IF NOT EXISTS
+      // is not atomic under concurrent transactions — two sessions
+      // can both see the index as absent, causing a unique_violation
+      // on pg_class_relname_nsp_index.
+      const lockId = DBA.getAdvisoryLockId(appId);
+      const lockResult = await client.query(
+        'SELECT pg_try_advisory_lock($1) AS locked',
+        [lockId],
+      );
+      if (lockResult.rows[0].locked) {
+        try {
+          await client.query(DBA.getMigrationSQL(schema));
+          await client.query(DBA.getPruneFunctionSQL(schema));
+        } finally {
+          await client.query('SELECT pg_advisory_unlock($1)', [lockId]);
+        }
+      }
+      // If another session holds the lock it is already running
+      // the same idempotent DDL — safe to skip.
     } finally {
       await release();
     }

--- a/services/store/providers/postgres/kvtables.ts
+++ b/services/store/providers/postgres/kvtables.ts
@@ -34,15 +34,13 @@ export const KVTables = (context: PostgresStoreService) => ({
     }
 
     try {
-      // First, check if tables already exist (no lock needed)
       const tablesExist = await this.checkIfTablesExist(client, appName);
-      if (tablesExist) {
-        // Tables exist; apply any pending migrations
-        await this.migrate(client, appName);
-        return;
-      }
 
-      // Tables don't exist, need to acquire lock and create them
+      // Acquire advisory lock for ALL DDL: table creation and
+      // migrations. CREATE INDEX IF NOT EXISTS is not atomic under
+      // concurrent transactions — two sessions can both see the
+      // index as absent and both attempt creation, causing a
+      // unique_violation on pg_class_relname_nsp_index.
       const lockId = this.getAdvisoryLockId(appName);
       const lockResult = await client.query(
         'SELECT pg_try_advisory_lock($1) AS locked',
@@ -50,23 +48,29 @@ export const KVTables = (context: PostgresStoreService) => ({
       );
 
       if (lockResult.rows[0].locked) {
-        // Begin transaction
-        await client.query('BEGIN');
+        try {
+          if (!tablesExist) {
+            // Begin transaction
+            await client.query('BEGIN');
 
-        // Double-check tables don't exist (race condition safety)
-        const tablesStillMissing = !(await this.checkIfTablesExist(
-          client,
-          appName,
-        ));
-        if (tablesStillMissing) {
-          await this.createTables(client, appName);
+            // Double-check tables don't exist (race condition safety)
+            const tablesStillMissing = !(await this.checkIfTablesExist(
+              client,
+              appName,
+            ));
+            if (tablesStillMissing) {
+              await this.createTables(client, appName);
+            }
+
+            // Commit transaction
+            await client.query('COMMIT');
+          }
+
+          // Always run migrations under the lock
+          await this.migrate(client, appName);
+        } finally {
+          await client.query('SELECT pg_advisory_unlock($1)', [lockId]);
         }
-
-        // Commit transaction
-        await client.query('COMMIT');
-
-        // Release the lock
-        await client.query('SELECT pg_advisory_unlock($1)', [lockId]);
       } else {
         // Release the client before waiting
         if (releaseClient && client.release) {
@@ -235,6 +239,14 @@ export const KVTables = (context: PostgresStoreService) => ({
 
         switch (tableDef.type) {
           case 'relational_app':
+            // Public tables are shared across all appIds. Use a fixed
+            // advisory lock to prevent concurrent CREATE TABLE races
+            // from different appId deployments (each has its own
+            // per-appId lock, but those don't overlap).
+            await client.query(
+              'SELECT pg_advisory_xact_lock($1)',
+              [0x484D5348], // 'HMSH' — fixed lock for public tables
+            );
             await client.query(`
               CREATE TABLE IF NOT EXISTS ${fullTableName} (
                 app_id TEXT PRIMARY KEY,

--- a/services/stream/providers/postgres/kvtables.ts
+++ b/services/stream/providers/postgres/kvtables.ts
@@ -22,15 +22,13 @@ export async function deploySchema(
 
   try {
     const schemaName = appId.replace(/[^a-zA-Z0-9_]/g, '_');
-
-    // First, check if tables already exist (no lock needed)
     const tablesExist = await checkIfTablesExist(client, schemaName);
-    if (tablesExist) {
-      await ensureIndexes(client, schemaName);
-      return;
-    }
 
-    // Tables don't exist, need to acquire lock and create them
+    // Acquire advisory lock for ALL DDL: table creation, index
+    // migrations, and trigger setup. CREATE INDEX IF NOT EXISTS is
+    // not atomic under concurrent transactions — two sessions can
+    // both see the index as absent and both attempt creation,
+    // causing a unique_violation on pg_class_relname_nsp_index.
     const lockId = getAdvisoryLockId(appId);
     const lockResult = await client.query(
       'SELECT pg_try_advisory_lock($1) AS locked',
@@ -39,19 +37,24 @@ export async function deploySchema(
 
     if (lockResult.rows[0].locked) {
       try {
-        await client.query('BEGIN');
+        if (!tablesExist) {
+          await client.query('BEGIN');
 
-        // Double-check tables don't exist (race condition safety)
-        const tablesStillMissing = !(await checkIfTablesExist(
-          client,
-          schemaName,
-        ));
-        if (tablesStillMissing) {
-          await createTables(client, schemaName);
-          await createNotificationTriggers(client, schemaName);
+          // Double-check tables don't exist (race condition safety)
+          const tablesStillMissing = !(await checkIfTablesExist(
+            client,
+            schemaName,
+          ));
+          if (tablesStillMissing) {
+            await createTables(client, schemaName);
+            await createNotificationTriggers(client, schemaName);
+          }
+
+          await client.query('COMMIT');
         }
 
-        await client.query('COMMIT');
+        // Always run index migrations under the lock
+        await ensureIndexes(client, schemaName);
       } finally {
         await client.query('SELECT pg_advisory_unlock($1)', [lockId]);
       }


### PR DESCRIPTION
Guard ensureIndexes, migrate, and DBA.deploy with advisory locks to prevent pg_class_relname_nsp_index duplicate key errors during rolling deploys with multiple concurrent containers.