### PR TITLE
Make trigger migration atomic; bump to 0.20.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/stream/providers/postgres/kvtables.ts
+++ b/services/stream/providers/postgres/kvtables.ts
@@ -261,6 +261,13 @@ async function ensureProcedures(
  * statement-level form. Recreating a trigger takes an ACCESS EXCLUSIVE
  * lock on the table, so only do it when the installed trigger is still
  * row-level (tgtype bit 0 set); subsequent boots are a no-op.
+ *
+ * The function replacement and trigger swap MUST commit atomically:
+ * between them, the still-installed row-level trigger would invoke the
+ * statement-level function body, whose transition-table reference
+ * (new_rows) errors under FOR EACH ROW — failing every concurrent
+ * INSERT until the swap lands (or indefinitely, if the migrating
+ * process dies between the two statements).
  */
 async function ensureStatementLevelTriggers(
   client: any,
@@ -278,7 +285,14 @@ async function ensureStatementLevelTriggers(
     [schemaName],
   );
   if (parseInt(result.rows[0].row_level, 10) > 0) {
-    await createNotificationTriggers(client, schemaName);
+    await client.query('BEGIN');
+    try {
+      await createNotificationTriggers(client, schemaName);
+      await client.query('COMMIT');
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    }
   }
 }
 


### PR DESCRIPTION
Wraps the one-time row-to-statement trigger migration in a transaction. Without it, concurrent INSERTs fail in the window between the function replace and trigger swap (and indefinitely if the migrating process dies between them). Verified by reverting a live schema to 0.19.5 row-level triggers and running deploySchema end-to-end; durable tests pass.