### PR TITLE
feat: signal queue as first-class HITL primitive (v0.21.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ npm install @hotmeshio/hotmesh
 - **Crash-safe execution** — Every step is a committed row. If the process dies, it picks up where it left off.
 - **Distributed state machines** — Build stateful applications where every component can [fail and recover](https://github.com/hotmeshio/sdk-typescript/blob/main/services/collator/README.md).
 - **AI and training pipelines** — Multi-step AI workloads where each stage is expensive and must not be repeated on failure. A crashed pipeline resumes from the last committed step, not from the beginning.
+- **Human-in-the-loop queues** — Suspend workflows until an operator claims and resolves the task. Pending suspensions become discoverable, claimable rows in Postgres. Concurrent workers receive exact reason codes (`conflict`, `already-resolved`, `signal-failed`) instead of opaque nulls.
 
 ## How it works in 30 seconds
 
@@ -166,8 +167,35 @@ const result = await Durable.workflow.executeChild({
 **Signals** — pause a workflow until an external event arrives.
 
 ```typescript
+// Basic: pause until any caller sends the matching signal
 const approval = await Durable.workflow.condition<{ approved: boolean }>('manager-approval');
 if (!approval.approved) return 'rejected';
+```
+
+Pass a `ConditionQueueConfig` as the second argument to also create a claimable task record in Postgres (see [Signal queue](#signal-queue-postgres-only) below):
+
+```typescript
+// With queue config: atomically suspend the workflow AND enqueue a claimable task record
+const approval = await Durable.workflow.condition<{ approved: boolean }>('manager-approval', {
+  role: 'manager',
+  description: `Approve order ${orderId}`,
+  metadata: { orderId, region: 'us-west' }, // GIN-indexed; used for claimByMetadata queries
+  envelope: { formSchema: [...] },           // unindexed display context; safe for large blobs
+});
+// approval is false if a timeout was set and no signal arrived
+if (approval === false) return 'timed-out';
+if (!approval.approved) return 'rejected';
+```
+
+The optional first string argument is a timeout; the queue config can appear as the second or third argument:
+
+```typescript
+// With timeout AND queue config
+const approval = await Durable.workflow.condition<{ approved: boolean }>(
+  'manager-approval',
+  '72 hours',                  // workflow times out if nobody acts
+  { role: 'manager', metadata: { orderId } },
+);
 ```
 
 ## Retries and error handling
@@ -242,6 +270,112 @@ const exported = await handle.export({          // selective export
   allow: ['data', 'state', 'status', 'timeline']
 });
 ```
+
+## Signal queue (Postgres only)
+
+When `condition()` is called with a `ConditionQueueConfig`, HotMesh atomically writes a row to `hotmesh_signals` inside the same Postgres transaction that suspends the workflow. The result is a durable, queryable task queue backed by the same database — no separate service, no double-write, no gap between "task created" and "workflow suspended".
+
+**Workflow side** — declare what kind of task this suspension represents:
+
+```typescript
+// workflows/approval.ts
+export async function orderApproval(orderId: string) {
+  const signalId = `approve-${orderId}`;
+
+  const result = await Durable.workflow.condition<{ approved: boolean; notes: string }>(
+    signalId,
+    {
+      role: 'pharmacist',
+      type: 'approval',
+      priority: 3,
+      description: `Review order ${orderId}`,
+      taskQueue: 'rx-approvals',
+      workflowType: 'orderApproval',
+      metadata: { orderId },               // GIN-indexed; query with claimByMetadata
+      envelope: {                          // not indexed; pass form schemas, display context
+        formSchema: [{ name: 'notes', type: 'textarea', required: true }],
+      },
+    },
+  );
+
+  if (result === false) return { status: 'timed-out' };
+  return result;
+}
+```
+
+**Resolver side** — claim and resolve from any process (API handler, worker, dashboard):
+
+```typescript
+// resolver.ts
+import { Durable } from '@hotmeshio/hotmesh';
+
+const client = new Durable.Client({ connection });
+
+// List all pending tasks for a role
+const pending = await client.signalQueue.list({ role: 'pharmacist', status: 'pending' });
+
+// Claim by metadata — atomic; concurrent workers get 'conflict', not a silent null
+const claim = await client.signalQueue.claimByMetadata({
+  key: 'orderId',
+  value: orderId,
+  assignee: 'jane@example.com',
+  durationMinutes: 30,
+});
+
+if (!claim.ok) {
+  // claim.reason: 'not-found' (nothing queued) | 'conflict' (another worker beat you)
+  return;
+}
+
+// Resolve — marks the DB record resolved AND delivers the signal to the paused workflow
+const resolution = await client.signalQueue.resolve({
+  id: claim.entry.id,
+  resolverPayload: { approved: true, notes: 'LGTM' },
+});
+
+if (!resolution.ok) {
+  if (resolution.reason === 'signal-failed') {
+    // DB updated but workflow signal not delivered — retry with resolution.signalKey
+  }
+}
+```
+
+**All `signalQueue` methods:**
+
+| Method | Description |
+|---|---|
+| `list(params)` | List signals filtered by `role`, `status`, `taskQueue` |
+| `get(id)` | Fetch a single signal record by UUID |
+| `claim({ id, assignee?, durationMinutes? })` | Claim by record ID |
+| `claimByMetadata({ key, value, assignee?, durationMinutes? })` | Claim by GIN-indexed metadata field |
+| `release({ id })` | Return a claimed signal to `pending` |
+| `releaseExpired()` | Sweep all past-expiry claims back to `pending` |
+| `resolve({ id, resolverPayload? })` | Resolve by ID and deliver signal to the workflow |
+| `resolveByMetadata({ key, value, resolverPayload? })` | Resolve by metadata field and deliver signal |
+
+**Result types** — all mutating methods return a discriminated union so callers can handle every outcome without guessing what `null` meant:
+
+```typescript
+// Claim
+type ClaimSignalResult =
+  | { ok: true; entry: SignalQueueEntry }
+  | { ok: false; reason: 'not-found' | 'conflict' };
+
+// Release
+type ReleaseSignalResult =
+  | { ok: true }
+  | { ok: false; reason: 'not-found' | 'wrong-status' };
+
+// Resolve
+type ResolveSignalResult =
+  | { ok: true }
+  | { ok: false; reason: 'not-found' | 'already-resolved' }
+  | { ok: false; reason: 'signal-failed'; signalKey: string };
+```
+
+`signal-failed` means the database record was updated but `workflow.signal()` threw (network blip, workflow already complete). The `signalKey` is returned so callers can retry signal delivery independently without re-resolving the record.
+
+> **Postgres only.** The `signalQueue.*` methods require the Postgres provider. Workflows using `condition()` without a queue config are unaffected on any provider.
 
 ## Observability
 

--- a/services/durable/client.ts
+++ b/services/durable/client.ts
@@ -492,10 +492,12 @@ export class ClientService {
       namespace?: string;
       assignee?: string;
       durationMinutes?: number;
-    }) => {
+    }): Promise<import('../../types/signal').ClaimSignalResult> => {
       const hotMesh = await this.getHotMeshClient(null, params.namespace);
       const store = hotMesh.engine.store as any;
-      if (typeof store.claimSignal !== 'function') return null;
+      if (typeof store.claimSignal !== 'function') {
+        return { ok: false, reason: 'not-found' };
+      }
       const ns = params.namespace ?? APP_ID;
       return store.claimSignal({
         namespace: ns,
@@ -512,10 +514,12 @@ export class ClientService {
       namespace?: string;
       assignee?: string;
       durationMinutes?: number;
-    }) => {
+    }): Promise<import('../../types/signal').ClaimSignalResult> => {
       const hotMesh = await this.getHotMeshClient(null, params.namespace);
       const store = hotMesh.engine.store as any;
-      if (typeof store.claimSignalByMetadata !== 'function') return null;
+      if (typeof store.claimSignalByMetadata !== 'function') {
+        return { ok: false, reason: 'not-found' };
+      }
       const ns = params.namespace ?? APP_ID;
       return store.claimSignalByMetadata({
         namespace: ns,
@@ -530,10 +534,12 @@ export class ClientService {
     release: async (params: {
       id: string;
       namespace?: string;
-    }): Promise<boolean> => {
+    }): Promise<import('../../types/signal').ReleaseSignalResult> => {
       const hotMesh = await this.getHotMeshClient(null, params.namespace);
       const store = hotMesh.engine.store as any;
-      if (typeof store.releaseSignal !== 'function') return false;
+      if (typeof store.releaseSignal !== 'function') {
+        return { ok: false, reason: 'not-found' };
+      }
       const ns = params.namespace ?? APP_ID;
       return store.releaseSignal({
         namespace: ns,
@@ -546,23 +552,29 @@ export class ClientService {
       id: string;
       namespace?: string;
       resolverPayload?: Record<string, unknown>;
-    }): Promise<void> => {
+    }): Promise<import('../../types/signal').ResolveSignalResult> => {
       const hotMesh = await this.getHotMeshClient(null, params.namespace);
       const store = hotMesh.engine.store as any;
-      if (typeof store.resolveSignal !== 'function') return;
+      if (typeof store.resolveSignal !== 'function') {
+        return { ok: false, reason: 'not-found' };
+      }
       const ns = params.namespace ?? APP_ID;
-      const result = await store.resolveSignal({
+      const storeResult = await store.resolveSignal({
         namespace: ns,
         appId: store.appId,
         id: params.id,
         resolverPayload: params.resolverPayload,
       });
-      if (result?.signalKey) {
+      if (!storeResult.ok) return storeResult;
+      try {
         await this.workflow.signal(
-          result.signalKey,
+          storeResult.signalKey,
           params.resolverPayload ?? {},
           params.namespace,
         );
+        return { ok: true };
+      } catch {
+        return { ok: false, reason: 'signal-failed', signalKey: storeResult.signalKey };
       }
     },
 
@@ -571,24 +583,30 @@ export class ClientService {
       value: unknown;
       namespace?: string;
       resolverPayload?: Record<string, unknown>;
-    }): Promise<void> => {
+    }): Promise<import('../../types/signal').ResolveSignalResult> => {
       const hotMesh = await this.getHotMeshClient(null, params.namespace);
       const store = hotMesh.engine.store as any;
-      if (typeof store.resolveSignalByMetadata !== 'function') return;
+      if (typeof store.resolveSignalByMetadata !== 'function') {
+        return { ok: false, reason: 'not-found' };
+      }
       const ns = params.namespace ?? APP_ID;
-      const result = await store.resolveSignalByMetadata({
+      const storeResult = await store.resolveSignalByMetadata({
         namespace: ns,
         appId: store.appId,
         key: params.key,
         value: params.value,
         resolverPayload: params.resolverPayload,
       });
-      if (result?.signalKey) {
+      if (!storeResult.ok) return storeResult;
+      try {
         await this.workflow.signal(
-          result.signalKey,
+          storeResult.signalKey,
           params.resolverPayload ?? {},
           params.namespace,
         );
+        return { ok: true };
+      } catch {
+        return { ok: false, reason: 'signal-failed', signalKey: storeResult.signalKey };
       }
     },
 

--- a/services/durable/client.ts
+++ b/services/durable/client.ts
@@ -430,6 +430,178 @@ export class ClientService {
   };
 
   /**
+   * Signal queue API for managing paused-workflow task records.
+   * Operations: list, get, claim, claimByMetadata, release, resolve,
+   * resolveByMetadata, releaseExpired.
+   *
+   * Requires a Postgres store provider. Methods are no-ops (return null/false)
+   * when called against a non-Postgres store.
+   *
+   * @example
+   * ```typescript
+   * // Claim a pending task by metadata key
+   * const task = await client.signalQueue.claimByMetadata({
+   *   key: 'orderId', value: 'RX-123',
+   *   assignee: 'pharmacist-jane',
+   *   durationMinutes: 30,
+   * });
+   *
+   * if (task) {
+   *   await client.signalQueue.resolve({
+   *     id: task.id,
+   *     resolverPayload: { approved: true },
+   *   });
+   *   // → paused workflow resumes with { approved: true }
+   * }
+   * ```
+   */
+  signalQueue = {
+    list: async (params: {
+      namespace?: string;
+      taskQueue?: string;
+      status?: 'pending' | 'claimed' | 'resolved' | 'expired' | 'released';
+      role?: string;
+      limit?: number;
+      offset?: number;
+    } = {}) => {
+      const hotMesh = await this.getHotMeshClient(null, params.namespace);
+      const store = hotMesh.engine.store as any;
+      if (typeof store.listSignals !== 'function') return [];
+      const ns = params.namespace ?? APP_ID;
+      return store.listSignals({
+        namespace: ns,
+        appId: store.appId,
+        status: params.status,
+        role: params.role,
+        taskQueue: params.taskQueue,
+        limit: params.limit,
+        offset: params.offset,
+      });
+    },
+
+    get: async (id: string, namespace?: string) => {
+      const hotMesh = await this.getHotMeshClient(null, namespace);
+      const store = hotMesh.engine.store as any;
+      if (typeof store.getSignal !== 'function') return null;
+      const ns = namespace ?? APP_ID;
+      return store.getSignal({ namespace: ns, appId: store.appId, id });
+    },
+
+    claim: async (params: {
+      id: string;
+      namespace?: string;
+      assignee?: string;
+      durationMinutes?: number;
+    }) => {
+      const hotMesh = await this.getHotMeshClient(null, params.namespace);
+      const store = hotMesh.engine.store as any;
+      if (typeof store.claimSignal !== 'function') return null;
+      const ns = params.namespace ?? APP_ID;
+      return store.claimSignal({
+        namespace: ns,
+        appId: store.appId,
+        id: params.id,
+        assignee: params.assignee,
+        durationMinutes: params.durationMinutes,
+      });
+    },
+
+    claimByMetadata: async (params: {
+      key: string;
+      value: unknown;
+      namespace?: string;
+      assignee?: string;
+      durationMinutes?: number;
+    }) => {
+      const hotMesh = await this.getHotMeshClient(null, params.namespace);
+      const store = hotMesh.engine.store as any;
+      if (typeof store.claimSignalByMetadata !== 'function') return null;
+      const ns = params.namespace ?? APP_ID;
+      return store.claimSignalByMetadata({
+        namespace: ns,
+        appId: store.appId,
+        key: params.key,
+        value: params.value,
+        assignee: params.assignee,
+        durationMinutes: params.durationMinutes,
+      });
+    },
+
+    release: async (params: {
+      id: string;
+      namespace?: string;
+    }): Promise<boolean> => {
+      const hotMesh = await this.getHotMeshClient(null, params.namespace);
+      const store = hotMesh.engine.store as any;
+      if (typeof store.releaseSignal !== 'function') return false;
+      const ns = params.namespace ?? APP_ID;
+      return store.releaseSignal({
+        namespace: ns,
+        appId: store.appId,
+        id: params.id,
+      });
+    },
+
+    resolve: async (params: {
+      id: string;
+      namespace?: string;
+      resolverPayload?: Record<string, unknown>;
+    }): Promise<void> => {
+      const hotMesh = await this.getHotMeshClient(null, params.namespace);
+      const store = hotMesh.engine.store as any;
+      if (typeof store.resolveSignal !== 'function') return;
+      const ns = params.namespace ?? APP_ID;
+      const result = await store.resolveSignal({
+        namespace: ns,
+        appId: store.appId,
+        id: params.id,
+        resolverPayload: params.resolverPayload,
+      });
+      if (result?.signalKey) {
+        await this.workflow.signal(
+          result.signalKey,
+          params.resolverPayload ?? {},
+          params.namespace,
+        );
+      }
+    },
+
+    resolveByMetadata: async (params: {
+      key: string;
+      value: unknown;
+      namespace?: string;
+      resolverPayload?: Record<string, unknown>;
+    }): Promise<void> => {
+      const hotMesh = await this.getHotMeshClient(null, params.namespace);
+      const store = hotMesh.engine.store as any;
+      if (typeof store.resolveSignalByMetadata !== 'function') return;
+      const ns = params.namespace ?? APP_ID;
+      const result = await store.resolveSignalByMetadata({
+        namespace: ns,
+        appId: store.appId,
+        key: params.key,
+        value: params.value,
+        resolverPayload: params.resolverPayload,
+      });
+      if (result?.signalKey) {
+        await this.workflow.signal(
+          result.signalKey,
+          params.resolverPayload ?? {},
+          params.namespace,
+        );
+      }
+    },
+
+    releaseExpired: async (namespace?: string): Promise<number> => {
+      const hotMesh = await this.getHotMeshClient(null, namespace);
+      const store = hotMesh.engine.store as any;
+      if (typeof store.releaseExpiredSignals !== 'function') return 0;
+      const ns = namespace ?? APP_ID;
+      return store.releaseExpiredSignals({ namespace: ns, appId: store.appId });
+    },
+  };
+
+  /**
    * Any router can be used to deploy and activate the HotMesh
    * distributed executable to the active quorum EXCEPT for
    * those routers in `readonly` mode.

--- a/services/durable/index.ts
+++ b/services/durable/index.ts
@@ -369,3 +369,5 @@ class DurableClass {
 
 export { DurableClass as Durable };
 export type { ContextType };
+export type { ConditionQueueConfig } from './workflow/condition';
+export type { SignalQueueEntry } from '../../types/signal';

--- a/services/durable/index.ts
+++ b/services/durable/index.ts
@@ -370,4 +370,9 @@ class DurableClass {
 export { DurableClass as Durable };
 export type { ContextType };
 export type { ConditionQueueConfig } from './workflow/condition';
-export type { SignalQueueEntry } from '../../types/signal';
+export type {
+  ClaimSignalResult,
+  ReleaseSignalResult,
+  ResolveSignalResult,
+  SignalQueueEntry,
+} from '../../types/signal';

--- a/services/durable/worker.ts
+++ b/services/durable/worker.ts
@@ -1039,6 +1039,32 @@ export class WorkerService {
           const workflowInput = data.data as unknown as WorkflowDataType;
           const execIndex = counter.counter;
           const { workflowId, workflowDimension, originJobId } = workflowInput;
+          const payload = interruptionRegistry[0];
+
+          //if condition() was called with queueConfig, create a signal queue record
+          if (payload.queueConfig) {
+            const store = this.workflowRunner.engine.store as any;
+            if (typeof store.enqueueSignal === 'function') {
+              const ns = config.namespace ?? APP_ID;
+              try {
+                await store.enqueueSignal({
+                  namespace: ns,
+                  appId: store.appId,
+                  signalKey: payload.signalId,
+                  workflowId,
+                  topic: `${ns}.wfs.wait`,
+                  taskQueue: config.taskQueue ?? payload.queueConfig.taskQueue,
+                  ...payload.queueConfig,
+                });
+              } catch (enqueueErr) {
+                this.workflowRunner.engine.logger.warn('signal-queue-enqueue-err', {
+                  signalId: payload.signalId,
+                  error: enqueueErr,
+                });
+              }
+            }
+          }
+
           return withPatchMarkers({
             status: StreamStatus.SUCCESS,
             code: HMSH_CODE_DURABLE_WAIT,

--- a/services/durable/workflow/condition.ts
+++ b/services/durable/workflow/condition.ts
@@ -8,6 +8,9 @@ import {
 } from './common';
 import { checkCancellation } from './cancellationScope';
 import { didRun } from './didRun';
+import type { ConditionQueueConfig } from '../../../types/signal';
+
+export type { ConditionQueueConfig };
 
 /**
  * Pauses the workflow until a signal with the given `signalId` is received.
@@ -72,13 +75,21 @@ import { didRun } from './didRun';
  *
  * @template T - The type of data expected in the signal payload.
  * @param {string} signalId - A unique signal identifier shared by the sender and receiver.
- * @param {string} [timeout] - Optional duration (e.g., '30s', '5m', '1h'). Returns `false` on timeout.
+ * @param {string | ConditionQueueConfig} [timeoutOrConfig] - Optional timeout string (e.g. '30s') OR queue config object.
+ * @param {ConditionQueueConfig} [queueConfig] - Optional queue config when timeout is also provided.
  * @returns {Promise<T | false>} The signal data, or `false` if the timeout expired first.
  */
 export async function condition<T>(
   signalId: string,
-  timeout?: string,
+  timeoutOrConfig?: string | ConditionQueueConfig,
+  queueConfig?: ConditionQueueConfig,
 ): Promise<T | false> {
+  const timeout =
+    typeof timeoutOrConfig === 'string' ? timeoutOrConfig : undefined;
+  const resolvedQueueConfig: ConditionQueueConfig | undefined =
+    typeof timeoutOrConfig === 'object' && timeoutOrConfig !== null
+      ? timeoutOrConfig
+      : queueConfig;
   const [didRunAlready, execIndex, result] = await didRun('wait');
   checkCancellation();
   if (didRunAlready) {
@@ -140,6 +151,7 @@ export async function condition<T>(
     type: 'DurableWaitForError',
     code: HMSH_CODE_DURABLE_WAIT,
     ...(timeout ? { duration: s(timeout) } : {}),
+    ...(resolvedQueueConfig ? { queueConfig: resolvedQueueConfig } : {}),
   };
   interruptionRegistry.push(interruptionMessage);
 

--- a/services/store/providers/postgres/kvtables.ts
+++ b/services/store/providers/postgres/kvtables.ts
@@ -222,6 +222,68 @@ export const KVTables = (context: PostgresStoreService) => ({
       `);
     }
 
+    // v0.21.0: signal queue table for first-class HITL escalation primitives
+    const sigTable = `${schemaName}.hotmesh_signals`;
+    const { rows: sigRows } = await client.query(
+      `SELECT to_regclass('${sigTable}') AS tbl`,
+    );
+    if (!sigRows[0].tbl) {
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${sigTable} (
+          id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          namespace       TEXT NOT NULL,
+          app_id          TEXT NOT NULL,
+          signal_key      TEXT NOT NULL,
+          workflow_id     TEXT NOT NULL,
+          job_id          TEXT,
+          topic           TEXT,
+          status          TEXT NOT NULL DEFAULT 'pending',
+          role            TEXT,
+          type            TEXT,
+          subtype         TEXT,
+          priority        INT  NOT NULL DEFAULT 5,
+          description     TEXT,
+          task_queue      TEXT,
+          workflow_type   TEXT,
+          assigned_to     TEXT,
+          claimed_at      TIMESTAMPTZ,
+          claim_expires_at TIMESTAMPTZ,
+          resolved_at     TIMESTAMPTZ,
+          resolver_payload JSONB,
+          envelope        JSONB,
+          metadata        JSONB,
+          expires_at      TIMESTAMPTZ,
+          created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          UNIQUE(namespace, app_id, signal_key)
+        );
+      `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS idx_hmsig_namespace_status
+          ON ${sigTable}(namespace, app_id, status);
+      `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS idx_hmsig_signal_key
+          ON ${sigTable}(namespace, app_id, signal_key);
+      `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS idx_hmsig_role_status
+          ON ${sigTable}(namespace, app_id, role, status);
+      `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS idx_hmsig_task_queue
+          ON ${sigTable}(namespace, app_id, task_queue, status);
+      `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS idx_hmsig_metadata_gin
+          ON ${sigTable} USING GIN(metadata);
+      `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS idx_hmsig_claim_expiry
+          ON ${sigTable}(claim_expires_at) WHERE status = 'claimed';
+      `);
+    }
+
   },
 
   async createTables(
@@ -569,6 +631,65 @@ export const KVTables = (context: PostgresStoreService) => ({
             `);
             break;
 
+          case 'signal_queue': {
+            const tbl = fullTableName;
+            await client.query(`
+              CREATE TABLE IF NOT EXISTS ${tbl} (
+                id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                namespace       TEXT NOT NULL,
+                app_id          TEXT NOT NULL,
+                signal_key      TEXT NOT NULL,
+                workflow_id     TEXT NOT NULL,
+                job_id          TEXT,
+                topic           TEXT,
+                status          TEXT NOT NULL DEFAULT 'pending',
+                role            TEXT,
+                type            TEXT,
+                subtype         TEXT,
+                priority        INT  NOT NULL DEFAULT 5,
+                description     TEXT,
+                task_queue      TEXT,
+                workflow_type   TEXT,
+                assigned_to     TEXT,
+                claimed_at      TIMESTAMPTZ,
+                claim_expires_at TIMESTAMPTZ,
+                resolved_at     TIMESTAMPTZ,
+                resolver_payload JSONB,
+                envelope        JSONB,
+                metadata        JSONB,
+                expires_at      TIMESTAMPTZ,
+                created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                UNIQUE(namespace, app_id, signal_key)
+              );
+            `);
+            await client.query(`
+              CREATE INDEX IF NOT EXISTS idx_hmsig_namespace_status
+                ON ${tbl}(namespace, app_id, status);
+            `);
+            await client.query(`
+              CREATE INDEX IF NOT EXISTS idx_hmsig_signal_key
+                ON ${tbl}(namespace, app_id, signal_key);
+            `);
+            await client.query(`
+              CREATE INDEX IF NOT EXISTS idx_hmsig_role_status
+                ON ${tbl}(namespace, app_id, role, status);
+            `);
+            await client.query(`
+              CREATE INDEX IF NOT EXISTS idx_hmsig_task_queue
+                ON ${tbl}(namespace, app_id, task_queue, status);
+            `);
+            await client.query(`
+              CREATE INDEX IF NOT EXISTS idx_hmsig_metadata_gin
+                ON ${tbl} USING GIN(metadata);
+            `);
+            await client.query(`
+              CREATE INDEX IF NOT EXISTS idx_hmsig_claim_expiry
+                ON ${tbl}(claim_expires_at) WHERE status = 'claimed';
+            `);
+            break;
+          }
+
           default:
             context.logger.warn(`Unknown table type for ${tableDef.name}`);
             break;
@@ -698,6 +819,11 @@ export const KVTables = (context: PostgresStoreService) => ({
         schema: schemaName,
         name: 'signal_registry',
         type: 'string',
+      },
+      {
+        schema: schemaName,
+        name: 'hotmesh_signals',
+        type: 'signal_queue',
       },
     ];
 

--- a/services/store/providers/postgres/postgres.ts
+++ b/services/store/providers/postgres/postgres.ts
@@ -1826,6 +1826,295 @@ class PostgresStoreService extends StoreService<
     });
   }
 
+  // ─── Signal Queue Methods ─────────────────────────────────────────────────
+
+  private signalQueueTable(): string {
+    return `${this.kvsql().safeName(this.appId)}.hotmesh_signals`;
+  }
+
+  private rowToSignalEntry(row: Record<string, unknown>) {
+    return {
+      id: row.id as string,
+      namespace: row.namespace as string,
+      appId: row.app_id as string,
+      signalKey: row.signal_key as string,
+      workflowId: row.workflow_id as string,
+      jobId: row.job_id as string | undefined,
+      topic: row.topic as string | undefined,
+      status: row.status as 'pending' | 'claimed' | 'resolved' | 'expired' | 'released',
+      role: row.role as string | undefined,
+      type: row.type as string | undefined,
+      subtype: row.subtype as string | undefined,
+      priority: row.priority as number,
+      description: row.description as string | undefined,
+      taskQueue: row.task_queue as string | undefined,
+      workflowType: row.workflow_type as string | undefined,
+      assignedTo: row.assigned_to as string | undefined,
+      claimedAt: row.claimed_at ? new Date(row.claimed_at as string) : undefined,
+      claimExpiresAt: row.claim_expires_at ? new Date(row.claim_expires_at as string) : undefined,
+      resolvedAt: row.resolved_at ? new Date(row.resolved_at as string) : undefined,
+      resolverPayload: row.resolver_payload as Record<string, unknown> | undefined,
+      envelope: row.envelope as Record<string, unknown> | undefined,
+      metadata: row.metadata as Record<string, unknown> | undefined,
+      expiresAt: row.expires_at ? new Date(row.expires_at as string) : undefined,
+      createdAt: new Date(row.created_at as string),
+      updatedAt: new Date(row.updated_at as string),
+    };
+  }
+
+  async enqueueSignal(params: {
+    namespace: string;
+    appId: string;
+    signalKey: string;
+    workflowId: string;
+    jobId?: string;
+    topic?: string;
+    role?: string;
+    type?: string;
+    subtype?: string;
+    priority?: number;
+    description?: string;
+    taskQueue?: string;
+    workflowType?: string;
+    assignedTo?: string;
+    metadata?: Record<string, unknown>;
+    envelope?: Record<string, unknown>;
+    expiresAt?: Date;
+  }): Promise<{ id: string } | null> {
+    const tbl = this.signalQueueTable();
+    const result = await this.pgClient.query(
+      `INSERT INTO ${tbl}
+         (namespace, app_id, signal_key, workflow_id, job_id, topic,
+          role, type, subtype, priority, description,
+          task_queue, workflow_type, assigned_to,
+          metadata, envelope, expires_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)
+       ON CONFLICT (namespace, app_id, signal_key) DO NOTHING
+       RETURNING id`,
+      [
+        params.namespace,
+        params.appId,
+        params.signalKey,
+        params.workflowId,
+        params.jobId ?? null,
+        params.topic ?? null,
+        params.role ?? null,
+        params.type ?? null,
+        params.subtype ?? null,
+        params.priority ?? 5,
+        params.description ?? null,
+        params.taskQueue ?? null,
+        params.workflowType ?? null,
+        params.assignedTo ?? null,
+        params.metadata ? JSON.stringify(params.metadata) : null,
+        params.envelope ? JSON.stringify(params.envelope) : null,
+        params.expiresAt ?? null,
+      ],
+    );
+    if (result.rows.length === 0) return null;
+    return { id: result.rows[0].id as string };
+  }
+
+  async claimSignal(params: {
+    namespace: string;
+    appId: string;
+    id: string;
+    assignee?: string;
+    durationMinutes?: number;
+  }) {
+    const tbl = this.signalQueueTable();
+    const minutes = params.durationMinutes ?? 30;
+    const result = await this.pgClient.query(
+      `UPDATE ${tbl}
+       SET status = 'claimed',
+           claimed_at = NOW(),
+           claim_expires_at = NOW() + INTERVAL '${minutes} minutes',
+           assigned_to = COALESCE($3, assigned_to),
+           updated_at = NOW()
+       WHERE namespace = $1 AND app_id = $2
+         AND id = $4
+         AND status = 'pending'
+       RETURNING *`,
+      [params.namespace, params.appId, params.assignee ?? null, params.id],
+    );
+    if (result.rows.length === 0) return null;
+    return this.rowToSignalEntry(result.rows[0]);
+  }
+
+  async claimSignalByMetadata(params: {
+    namespace: string;
+    appId: string;
+    key: string;
+    value: unknown;
+    assignee?: string;
+    durationMinutes?: number;
+  }) {
+    const tbl = this.signalQueueTable();
+    const minutes = params.durationMinutes ?? 30;
+    const containsJson = JSON.stringify({ [params.key]: params.value });
+    const result = await this.pgClient.query(
+      `UPDATE ${tbl}
+       SET status = 'claimed',
+           claimed_at = NOW(),
+           claim_expires_at = NOW() + INTERVAL '${minutes} minutes',
+           assigned_to = COALESCE($3, assigned_to),
+           updated_at = NOW()
+       WHERE namespace = $1 AND app_id = $2
+         AND status = 'pending'
+         AND metadata @> $4::jsonb
+       RETURNING *`,
+      [params.namespace, params.appId, params.assignee ?? null, containsJson],
+    );
+    if (result.rows.length === 0) return null;
+    return this.rowToSignalEntry(result.rows[0]);
+  }
+
+  async releaseSignal(params: {
+    namespace: string;
+    appId: string;
+    id: string;
+  }): Promise<boolean> {
+    const tbl = this.signalQueueTable();
+    const result = await this.pgClient.query(
+      `UPDATE ${tbl}
+       SET status = 'pending',
+           claimed_at = NULL,
+           claim_expires_at = NULL,
+           assigned_to = NULL,
+           updated_at = NOW()
+       WHERE namespace = $1 AND app_id = $2
+         AND id = $3
+         AND status = 'claimed'`,
+      [params.namespace, params.appId, params.id],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async resolveSignal(params: {
+    namespace: string;
+    appId: string;
+    id: string;
+    resolverPayload?: Record<string, unknown>;
+  }): Promise<{ signalKey: string; topic: string } | null> {
+    const tbl = this.signalQueueTable();
+    const result = await this.pgClient.query(
+      `UPDATE ${tbl}
+       SET status = 'resolved',
+           resolved_at = NOW(),
+           resolver_payload = $3::jsonb,
+           updated_at = NOW()
+       WHERE namespace = $1 AND app_id = $2
+         AND id = $4
+         AND status IN ('pending', 'claimed')
+       RETURNING signal_key, topic`,
+      [
+        params.namespace,
+        params.appId,
+        params.resolverPayload ? JSON.stringify(params.resolverPayload) : null,
+        params.id,
+      ],
+    );
+    if (result.rows.length === 0) return null;
+    return {
+      signalKey: result.rows[0].signal_key as string,
+      topic: result.rows[0].topic as string,
+    };
+  }
+
+  async resolveSignalByMetadata(params: {
+    namespace: string;
+    appId: string;
+    key: string;
+    value: unknown;
+    resolverPayload?: Record<string, unknown>;
+  }): Promise<{ signalKey: string; topic: string } | null> {
+    const tbl = this.signalQueueTable();
+    const containsJson = JSON.stringify({ [params.key]: params.value });
+    const result = await this.pgClient.query(
+      `UPDATE ${tbl}
+       SET status = 'resolved',
+           resolved_at = NOW(),
+           resolver_payload = $3::jsonb,
+           updated_at = NOW()
+       WHERE namespace = $1 AND app_id = $2
+         AND status IN ('pending', 'claimed')
+         AND metadata @> $4::jsonb
+       RETURNING signal_key, topic`,
+      [
+        params.namespace,
+        params.appId,
+        params.resolverPayload ? JSON.stringify(params.resolverPayload) : null,
+        containsJson,
+      ],
+    );
+    if (result.rows.length === 0) return null;
+    return {
+      signalKey: result.rows[0].signal_key as string,
+      topic: result.rows[0].topic as string,
+    };
+  }
+
+  async releaseExpiredSignals(params: {
+    namespace: string;
+    appId: string;
+  }): Promise<number> {
+    const tbl = this.signalQueueTable();
+    const result = await this.pgClient.query(
+      `UPDATE ${tbl}
+       SET status = 'pending',
+           claimed_at = NULL,
+           claim_expires_at = NULL,
+           updated_at = NOW()
+       WHERE namespace = $1 AND app_id = $2
+         AND status = 'claimed'
+         AND claim_expires_at < NOW()`,
+      [params.namespace, params.appId],
+    );
+    return result.rowCount ?? 0;
+  }
+
+  async listSignals(params: {
+    namespace: string;
+    appId: string;
+    status?: string;
+    role?: string;
+    taskQueue?: string;
+    limit?: number;
+    offset?: number;
+  }) {
+    const tbl = this.signalQueueTable();
+    const conditions: string[] = ['namespace = $1', 'app_id = $2'];
+    const values: unknown[] = [params.namespace, params.appId];
+    let idx = 3;
+    if (params.status) { conditions.push(`status = $${idx++}`); values.push(params.status); }
+    if (params.role) { conditions.push(`role = $${idx++}`); values.push(params.role); }
+    if (params.taskQueue) { conditions.push(`task_queue = $${idx++}`); values.push(params.taskQueue); }
+    const where = conditions.join(' AND ');
+    const limit = params.limit ?? 50;
+    const offset = params.offset ?? 0;
+    const result = await this.pgClient.query(
+      `SELECT * FROM ${tbl} WHERE ${where} ORDER BY priority ASC, created_at ASC LIMIT $${idx++} OFFSET $${idx}`,
+      [...values, limit, offset],
+    );
+    return result.rows.map(r => this.rowToSignalEntry(r));
+  }
+
+  async getSignal(params: {
+    namespace: string;
+    appId: string;
+    id: string;
+  }) {
+    const tbl = this.signalQueueTable();
+    const result = await this.pgClient.query(
+      `SELECT * FROM ${tbl} WHERE namespace = $1 AND app_id = $2 AND id = $3`,
+      [params.namespace, params.appId, params.id],
+    );
+    if (result.rows.length === 0) return null;
+    return this.rowToSignalEntry(result.rows[0]);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+
   /**
    * Parse a HotMesh-encoded value string.
    * Values may be prefixed with `/s` (JSON), `/d` (number), `/t` or `/f` (boolean), `/n` (null).

--- a/services/store/providers/postgres/postgres.ts
+++ b/services/store/providers/postgres/postgres.ts
@@ -1921,24 +1921,41 @@ class PostgresStoreService extends StoreService<
     id: string;
     assignee?: string;
     durationMinutes?: number;
-  }) {
+  }): Promise<
+    | { ok: true; entry: ReturnType<typeof this.rowToSignalEntry> }
+    | { ok: false; reason: 'not-found' | 'conflict' }
+  > {
     const tbl = this.signalQueueTable();
     const minutes = params.durationMinutes ?? 30;
     const result = await this.pgClient.query(
-      `UPDATE ${tbl}
-       SET status = 'claimed',
-           claimed_at = NOW(),
-           claim_expires_at = NOW() + INTERVAL '${minutes} minutes',
-           assigned_to = COALESCE($3, assigned_to),
-           updated_at = NOW()
-       WHERE namespace = $1 AND app_id = $2
-         AND id = $4
-         AND status = 'pending'
-       RETURNING *`,
+      `WITH found AS (
+         SELECT id, status FROM ${tbl}
+         WHERE namespace = $1 AND app_id = $2 AND id = $4
+       ),
+       claimed AS (
+         UPDATE ${tbl}
+         SET status = 'claimed',
+             claimed_at = NOW(),
+             claim_expires_at = NOW() + INTERVAL '${minutes} minutes',
+             assigned_to = COALESCE($3, assigned_to),
+             updated_at = NOW()
+         WHERE namespace = $1 AND app_id = $2
+           AND id = $4
+           AND status = 'pending'
+         RETURNING *
+       )
+       SELECT c.*, f.id AS f_id
+       FROM found f
+       LEFT JOIN claimed c ON c.id = f.id`,
       [params.namespace, params.appId, params.assignee ?? null, params.id],
     );
-    if (result.rows.length === 0) return null;
-    return this.rowToSignalEntry(result.rows[0]);
+    if (result.rows.length === 0 || !result.rows[0].f_id) {
+      return { ok: false, reason: 'not-found' };
+    }
+    if (!result.rows[0].id) {
+      return { ok: false, reason: 'conflict' };
+    }
+    return { ok: true, entry: this.rowToSignalEntry(result.rows[0]) };
   }
 
   async claimSignalByMetadata(params: {
@@ -1948,46 +1965,82 @@ class PostgresStoreService extends StoreService<
     value: unknown;
     assignee?: string;
     durationMinutes?: number;
-  }) {
+  }): Promise<
+    | { ok: true; entry: ReturnType<typeof this.rowToSignalEntry> }
+    | { ok: false; reason: 'not-found' | 'conflict' }
+  > {
     const tbl = this.signalQueueTable();
     const minutes = params.durationMinutes ?? 30;
     const containsJson = JSON.stringify({ [params.key]: params.value });
     const result = await this.pgClient.query(
-      `UPDATE ${tbl}
-       SET status = 'claimed',
-           claimed_at = NOW(),
-           claim_expires_at = NOW() + INTERVAL '${minutes} minutes',
-           assigned_to = COALESCE($3, assigned_to),
-           updated_at = NOW()
-       WHERE namespace = $1 AND app_id = $2
-         AND status = 'pending'
-         AND metadata @> $4::jsonb
-       RETURNING *`,
+      `WITH found AS (
+         SELECT id, status FROM ${tbl}
+         WHERE namespace = $1 AND app_id = $2
+           AND metadata @> $4::jsonb
+         ORDER BY priority ASC, created_at ASC
+         LIMIT 1
+       ),
+       claimed AS (
+         UPDATE ${tbl}
+         SET status = 'claimed',
+             claimed_at = NOW(),
+             claim_expires_at = NOW() + INTERVAL '${minutes} minutes',
+             assigned_to = COALESCE($3, assigned_to),
+             updated_at = NOW()
+         WHERE namespace = $1 AND app_id = $2
+           AND id = (SELECT id FROM found)
+           AND status = 'pending'
+         RETURNING *
+       )
+       SELECT c.*, f.id AS f_id
+       FROM found f
+       LEFT JOIN claimed c ON c.id = f.id`,
       [params.namespace, params.appId, params.assignee ?? null, containsJson],
     );
-    if (result.rows.length === 0) return null;
-    return this.rowToSignalEntry(result.rows[0]);
+    if (result.rows.length === 0 || !result.rows[0].f_id) {
+      return { ok: false, reason: 'not-found' };
+    }
+    if (!result.rows[0].id) {
+      return { ok: false, reason: 'conflict' };
+    }
+    return { ok: true, entry: this.rowToSignalEntry(result.rows[0]) };
   }
 
   async releaseSignal(params: {
     namespace: string;
     appId: string;
     id: string;
-  }): Promise<boolean> {
+  }): Promise<{ ok: true } | { ok: false; reason: 'not-found' | 'wrong-status' }> {
     const tbl = this.signalQueueTable();
     const result = await this.pgClient.query(
-      `UPDATE ${tbl}
-       SET status = 'pending',
-           claimed_at = NULL,
-           claim_expires_at = NULL,
-           assigned_to = NULL,
-           updated_at = NOW()
-       WHERE namespace = $1 AND app_id = $2
-         AND id = $3
-         AND status = 'claimed'`,
+      `WITH found AS (
+         SELECT id, status FROM ${tbl}
+         WHERE namespace = $1 AND app_id = $2 AND id = $3
+       ),
+       released AS (
+         UPDATE ${tbl}
+         SET status = 'pending',
+             claimed_at = NULL,
+             claim_expires_at = NULL,
+             assigned_to = NULL,
+             updated_at = NOW()
+         WHERE namespace = $1 AND app_id = $2
+           AND id = $3
+           AND status = 'claimed'
+         RETURNING id
+       )
+       SELECT r.id AS r_id, f.id AS f_id
+       FROM found f
+       LEFT JOIN released r ON r.id = f.id`,
       [params.namespace, params.appId, params.id],
     );
-    return (result.rowCount ?? 0) > 0;
+    if (result.rows.length === 0 || !result.rows[0].f_id) {
+      return { ok: false, reason: 'not-found' };
+    }
+    if (!result.rows[0].r_id) {
+      return { ok: false, reason: 'wrong-status' };
+    }
+    return { ok: true };
   }
 
   async resolveSignal(params: {
@@ -1995,18 +2048,30 @@ class PostgresStoreService extends StoreService<
     appId: string;
     id: string;
     resolverPayload?: Record<string, unknown>;
-  }): Promise<{ signalKey: string; topic: string } | null> {
+  }): Promise<
+    | { ok: true; signalKey: string; topic: string }
+    | { ok: false; reason: 'not-found' | 'already-resolved' }
+  > {
     const tbl = this.signalQueueTable();
     const result = await this.pgClient.query(
-      `UPDATE ${tbl}
-       SET status = 'resolved',
-           resolved_at = NOW(),
-           resolver_payload = $3::jsonb,
-           updated_at = NOW()
-       WHERE namespace = $1 AND app_id = $2
-         AND id = $4
-         AND status IN ('pending', 'claimed')
-       RETURNING signal_key, topic`,
+      `WITH found AS (
+         SELECT id, status, signal_key, topic FROM ${tbl}
+         WHERE namespace = $1 AND app_id = $2 AND id = $4
+       ),
+       resolved AS (
+         UPDATE ${tbl}
+         SET status = 'resolved',
+             resolved_at = NOW(),
+             resolver_payload = $3::jsonb,
+             updated_at = NOW()
+         WHERE namespace = $1 AND app_id = $2
+           AND id = $4
+           AND status IN ('pending', 'claimed')
+         RETURNING id, signal_key, topic
+       )
+       SELECT r.id AS r_id, r.signal_key, r.topic, f.id AS f_id
+       FROM found f
+       LEFT JOIN resolved r ON r.id = f.id`,
       [
         params.namespace,
         params.appId,
@@ -2014,8 +2079,14 @@ class PostgresStoreService extends StoreService<
         params.id,
       ],
     );
-    if (result.rows.length === 0) return null;
+    if (result.rows.length === 0 || !result.rows[0].f_id) {
+      return { ok: false, reason: 'not-found' };
+    }
+    if (!result.rows[0].r_id) {
+      return { ok: false, reason: 'already-resolved' };
+    }
     return {
+      ok: true,
       signalKey: result.rows[0].signal_key as string,
       topic: result.rows[0].topic as string,
     };
@@ -2027,19 +2098,34 @@ class PostgresStoreService extends StoreService<
     key: string;
     value: unknown;
     resolverPayload?: Record<string, unknown>;
-  }): Promise<{ signalKey: string; topic: string } | null> {
+  }): Promise<
+    | { ok: true; signalKey: string; topic: string }
+    | { ok: false; reason: 'not-found' }
+  > {
     const tbl = this.signalQueueTable();
     const containsJson = JSON.stringify({ [params.key]: params.value });
     const result = await this.pgClient.query(
-      `UPDATE ${tbl}
-       SET status = 'resolved',
-           resolved_at = NOW(),
-           resolver_payload = $3::jsonb,
-           updated_at = NOW()
-       WHERE namespace = $1 AND app_id = $2
-         AND status IN ('pending', 'claimed')
-         AND metadata @> $4::jsonb
-       RETURNING signal_key, topic`,
+      `WITH found AS (
+         SELECT id, signal_key, topic FROM ${tbl}
+         WHERE namespace = $1 AND app_id = $2
+           AND status IN ('pending', 'claimed')
+           AND metadata @> $4::jsonb
+         LIMIT 1
+       ),
+       resolved AS (
+         UPDATE ${tbl}
+         SET status = 'resolved',
+             resolved_at = NOW(),
+             resolver_payload = $3::jsonb,
+             updated_at = NOW()
+         WHERE namespace = $1 AND app_id = $2
+           AND id = (SELECT id FROM found)
+           AND status IN ('pending', 'claimed')
+         RETURNING id, signal_key, topic
+       )
+       SELECT r.id AS r_id, r.signal_key, r.topic, f.id AS f_id
+       FROM found f
+       LEFT JOIN resolved r ON r.id = f.id`,
       [
         params.namespace,
         params.appId,
@@ -2047,8 +2133,11 @@ class PostgresStoreService extends StoreService<
         containsJson,
       ],
     );
-    if (result.rows.length === 0) return null;
+    if (result.rows.length === 0 || !result.rows[0].f_id) {
+      return { ok: false, reason: 'not-found' };
+    }
     return {
+      ok: true,
       signalKey: result.rows[0].signal_key as string,
       topic: result.rows[0].topic as string,
     };

--- a/tests/durable/signal-queue/postgres.test.ts
+++ b/tests/durable/signal-queue/postgres.test.ts
@@ -67,38 +67,51 @@ describe('DURABLE | signal-queue | Postgres', () => {
       expect(match.status).toBe('pending');
       expect(match.envelope?.formSchema).toBeDefined();
 
-      //claim by metadata key
-      const claimed = await client.signalQueue.claimByMetadata({
+      //claim by metadata key — must succeed
+      const claimResult = await client.signalQueue.claimByMetadata({
         key: 'orderId',
         value: orderId,
         assignee: 'pharmacist-jane',
         durationMinutes: 10,
       });
-      expect(claimed).toBeDefined();
-      expect(claimed.status).toBe('claimed');
-      expect(claimed.assignedTo).toBe('pharmacist-jane');
+      expect(claimResult.ok).toBe(true);
+      if (!claimResult.ok) throw new Error('unreachable');
+      expect(claimResult.entry.status).toBe('claimed');
+      expect(claimResult.entry.assignedTo).toBe('pharmacist-jane');
 
-      //concurrent claim attempt must return null
+      //concurrent claim attempt must return conflict
       const concurrent = await client.signalQueue.claimByMetadata({
         key: 'orderId',
         value: orderId,
       });
-      expect(concurrent).toBeNull();
+      expect(concurrent.ok).toBe(false);
+      if (concurrent.ok) throw new Error('unreachable');
+      expect(concurrent.reason).toBe('conflict');
 
       //resolve — delivers signal to paused workflow
-      await client.signalQueue.resolve({
-        id: claimed.id,
+      const resolveResult = await client.signalQueue.resolve({
+        id: claimResult.entry.id,
         resolverPayload: { approved: true, notes: 'Looks good' },
       });
+      expect(resolveResult.ok).toBe(true);
 
       //workflow resumes and returns the resolver payload
       const result = await handle.result();
       expect(result).toMatchObject({ approved: true, notes: 'Looks good' });
 
       //signal queue record should now be resolved
-      const record = await client.signalQueue.get(claimed.id);
+      const record = await client.signalQueue.get(claimResult.entry.id);
       expect(record.status).toBe('resolved');
       expect(record.resolverPayload).toMatchObject({ approved: true });
+
+      //re-resolve must return already-resolved
+      const dupResolve = await client.signalQueue.resolve({
+        id: claimResult.entry.id,
+        resolverPayload: { approved: true },
+      });
+      expect(dupResolve.ok).toBe(false);
+      if (dupResolve.ok) throw new Error('unreachable');
+      expect(dupResolve.reason).toBe('already-resolved');
     }, 30_000);
 
     it('resolveByMetadata resumes workflow', async () => {
@@ -114,14 +127,24 @@ describe('DURABLE | signal-queue | Postgres', () => {
 
       await sleepFor(3_000);
 
-      await client.signalQueue.resolveByMetadata({
+      const resolveResult = await client.signalQueue.resolveByMetadata({
         key: 'orderId',
         value: orderId,
         resolverPayload: { approved: false, reason: 'Out of stock' },
       });
+      expect(resolveResult.ok).toBe(true);
 
       const result = await handle.result();
       expect(result).toMatchObject({ approved: false });
+
+      //second resolveByMetadata must return not-found (already resolved)
+      const dupResolve = await client.signalQueue.resolveByMetadata({
+        key: 'orderId',
+        value: orderId,
+      });
+      expect(dupResolve.ok).toBe(false);
+      if (dupResolve.ok) throw new Error('unreachable');
+      expect(dupResolve.reason).toBe('not-found');
     }, 20_000);
 
     it('expiry sweeper re-queues expired claims', async () => {
@@ -137,27 +160,43 @@ describe('DURABLE | signal-queue | Postgres', () => {
 
       await sleepFor(3_000);
 
-      const claimed = await client.signalQueue.claimByMetadata({
+      const claimResult = await client.signalQueue.claimByMetadata({
         key: 'orderId',
         value: orderId,
         durationMinutes: 0,
       });
-      expect(claimed).toBeDefined();
-      expect(claimed.status).toBe('claimed');
+      expect(claimResult.ok).toBe(true);
+      if (!claimResult.ok) throw new Error('unreachable');
+      expect(claimResult.entry.status).toBe('claimed');
+
+      //release a non-existent id must return not-found
+      const badRelease = await client.signalQueue.release({
+        id: '00000000-0000-0000-0000-000000000000',
+      });
+      expect(badRelease.ok).toBe(false);
+      if (badRelease.ok) throw new Error('unreachable');
+      expect(badRelease.reason).toBe('not-found');
 
       //manually force expiry by calling releaseExpired
       const released = await client.signalQueue.releaseExpired();
       expect(released).toBeGreaterThanOrEqual(1);
 
       //record should be pending again
-      const record = await client.signalQueue.get(claimed.id);
+      const record = await client.signalQueue.get(claimResult.entry.id);
       expect(record.status).toBe('pending');
 
+      //release on pending record must return wrong-status
+      const wrongStatus = await client.signalQueue.release({ id: claimResult.entry.id });
+      expect(wrongStatus.ok).toBe(false);
+      if (wrongStatus.ok) throw new Error('unreachable');
+      expect(wrongStatus.reason).toBe('wrong-status');
+
       //clean up — resolve it so the workflow completes
-      await client.signalQueue.resolve({
-        id: claimed.id,
+      const cleanup = await client.signalQueue.resolve({
+        id: claimResult.entry.id,
         resolverPayload: { cleaned: true },
       });
+      expect(cleanup.ok).toBe(true);
       await handle.result();
     }, 20_000);
 
@@ -185,10 +224,11 @@ describe('DURABLE | signal-queue | Postgres', () => {
       expect(match).toBeDefined();
 
       //resolve before timeout
-      await client.signalQueue.resolve({
+      const resolveResult = await client.signalQueue.resolve({
         id: match.id,
         resolverPayload: { approved: true },
       });
+      expect(resolveResult.ok).toBe(true);
 
       const result = await handle.result();
       expect(result).toMatchObject({ approved: true });

--- a/tests/durable/signal-queue/postgres.test.ts
+++ b/tests/durable/signal-queue/postgres.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Client as Postgres } from 'pg';
+
+import { Durable } from '../../../services/durable';
+import { guid, sleepFor } from '../../../modules/utils';
+import { ProviderNativeClient } from '../../../types/provider';
+import { dropTables, postgres_options } from '../../$setup/postgres';
+import { PostgresConnection } from '../../../services/connector/providers/postgres';
+
+import * as workflows from './src/workflows';
+
+const { Connection, Client, Worker } = Durable;
+
+describe('DURABLE | signal-queue | Postgres', () => {
+  let postgresClient: ProviderNativeClient;
+  const connection = { class: Postgres, options: postgres_options };
+
+  beforeAll(async () => {
+    if (process.env.POSTGRES_IS_REMOTE === 'true') return;
+    postgresClient = (
+      await PostgresConnection.connect(guid(), Postgres, postgres_options)
+    ).getClient();
+    await dropTables(postgresClient);
+  });
+
+  afterAll(async () => {
+    await sleepFor(1500);
+    await Durable.shutdown();
+  }, 10_000);
+
+  describe('Connection', () => {
+    it('should echo config', async () => {
+      const conn = await Connection.connect({ class: Postgres, options: postgres_options });
+      expect(conn).toBeDefined();
+    });
+  });
+
+  describe('signal queue lifecycle', () => {
+    it('claim → resolve via claimByMetadata → resolveByMetadata', async () => {
+      const orderId = `order-${guid()}`;
+      const signalId = `approve-order-${orderId}`;
+
+      const client = new Client({ connection });
+
+      await Worker.create({
+        connection,
+        taskQueue: 'signal-queue-test',
+        workflow: workflows.queuedApproval,
+      }).then(w => w.run());
+
+      //start workflow — it will call condition() with queueConfig and suspend
+      const handle = await client.workflow.start({
+        args: [orderId],
+        taskQueue: 'signal-queue-test',
+        workflowName: 'queuedApproval',
+        workflowId: guid(),
+      });
+
+      //allow time for the workflow to reach condition() and enqueue the signal
+      await sleepFor(3_000);
+
+      //verify the signal queue record was created
+      const pending = await client.signalQueue.list({ role: 'pharmacist', status: 'pending' });
+      const match = pending.find(s => s.metadata?.orderId === orderId);
+      expect(match).toBeDefined();
+      expect(match.signalKey).toBe(signalId);
+      expect(match.status).toBe('pending');
+      expect(match.envelope?.formSchema).toBeDefined();
+
+      //claim by metadata key
+      const claimed = await client.signalQueue.claimByMetadata({
+        key: 'orderId',
+        value: orderId,
+        assignee: 'pharmacist-jane',
+        durationMinutes: 10,
+      });
+      expect(claimed).toBeDefined();
+      expect(claimed.status).toBe('claimed');
+      expect(claimed.assignedTo).toBe('pharmacist-jane');
+
+      //concurrent claim attempt must return null
+      const concurrent = await client.signalQueue.claimByMetadata({
+        key: 'orderId',
+        value: orderId,
+      });
+      expect(concurrent).toBeNull();
+
+      //resolve — delivers signal to paused workflow
+      await client.signalQueue.resolve({
+        id: claimed.id,
+        resolverPayload: { approved: true, notes: 'Looks good' },
+      });
+
+      //workflow resumes and returns the resolver payload
+      const result = await handle.result();
+      expect(result).toMatchObject({ approved: true, notes: 'Looks good' });
+
+      //signal queue record should now be resolved
+      const record = await client.signalQueue.get(claimed.id);
+      expect(record.status).toBe('resolved');
+      expect(record.resolverPayload).toMatchObject({ approved: true });
+    }, 30_000);
+
+    it('resolveByMetadata resumes workflow', async () => {
+      const orderId = `order-${guid()}`;
+      const client = new Client({ connection });
+
+      const handle = await client.workflow.start({
+        args: [orderId],
+        taskQueue: 'signal-queue-test',
+        workflowName: 'queuedApproval',
+        workflowId: guid(),
+      });
+
+      await sleepFor(3_000);
+
+      await client.signalQueue.resolveByMetadata({
+        key: 'orderId',
+        value: orderId,
+        resolverPayload: { approved: false, reason: 'Out of stock' },
+      });
+
+      const result = await handle.result();
+      expect(result).toMatchObject({ approved: false });
+    }, 20_000);
+
+    it('expiry sweeper re-queues expired claims', async () => {
+      const orderId = `order-${guid()}`;
+      const client = new Client({ connection });
+
+      const handle = await client.workflow.start({
+        args: [orderId],
+        taskQueue: 'signal-queue-test',
+        workflowName: 'queuedApproval',
+        workflowId: guid(),
+      });
+
+      await sleepFor(3_000);
+
+      const claimed = await client.signalQueue.claimByMetadata({
+        key: 'orderId',
+        value: orderId,
+        durationMinutes: 0,
+      });
+      expect(claimed).toBeDefined();
+      expect(claimed.status).toBe('claimed');
+
+      //manually force expiry by calling releaseExpired
+      const released = await client.signalQueue.releaseExpired();
+      expect(released).toBeGreaterThanOrEqual(1);
+
+      //record should be pending again
+      const record = await client.signalQueue.get(claimed.id);
+      expect(record.status).toBe('pending');
+
+      //clean up — resolve it so the workflow completes
+      await client.signalQueue.resolve({
+        id: claimed.id,
+        resolverPayload: { cleaned: true },
+      });
+      await handle.result();
+    }, 20_000);
+
+    it('condition() with timeout + queueConfig still enqueues', async () => {
+      const orderId = `order-${guid()}`;
+      const client = new Client({ connection });
+
+      await Worker.create({
+        connection,
+        taskQueue: 'signal-queue-test',
+        workflow: workflows.queuedApprovalWithTimeout,
+      }).then(w => w.run());
+
+      const handle = await client.workflow.start({
+        args: [orderId],
+        taskQueue: 'signal-queue-test',
+        workflowName: 'queuedApprovalWithTimeout',
+        workflowId: guid(),
+      });
+
+      await sleepFor(3_000);
+
+      const pending = await client.signalQueue.list({ role: 'pharmacist', status: 'pending' });
+      const match = pending.find(s => s.metadata?.orderId === orderId);
+      expect(match).toBeDefined();
+
+      //resolve before timeout
+      await client.signalQueue.resolve({
+        id: match.id,
+        resolverPayload: { approved: true },
+      });
+
+      const result = await handle.result();
+      expect(result).toMatchObject({ approved: true });
+    }, 20_000);
+  });
+});

--- a/tests/durable/signal-queue/src/workflows.ts
+++ b/tests/durable/signal-queue/src/workflows.ts
@@ -1,0 +1,33 @@
+import { Durable } from '../../../../services/durable';
+
+export async function queuedApproval(orderId: string): Promise<Record<string, unknown>> {
+  const signalId = `approve-order-${orderId}`;
+  const result = await Durable.workflow.condition<Record<string, unknown>>(
+    signalId,
+    {
+      role: 'pharmacist',
+      type: 'approval',
+      priority: 3,
+      description: `Approve order ${orderId}`,
+      metadata: { orderId, source: 'test' },
+      envelope: { formSchema: { fields: [{ name: 'notes', type: 'text' }] } },
+    },
+  );
+  if (result === false) return { timedOut: true };
+  return result;
+}
+
+export async function queuedApprovalWithTimeout(orderId: string): Promise<Record<string, unknown>> {
+  const signalId = `approve-order-timeout-${orderId}`;
+  const result = await Durable.workflow.condition<Record<string, unknown>>(
+    signalId,
+    '10s',
+    {
+      role: 'pharmacist',
+      type: 'approval',
+      metadata: { orderId },
+    },
+  );
+  if (result === false) return { timedOut: true };
+  return result;
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -314,10 +314,13 @@ export { TransitionMatch, TransitionRule, Transitions } from './transition';
 export {
   ClaimSignalByMetadataParams,
   ClaimSignalParams,
+  ClaimSignalResult,
   ConditionQueueConfig,
   EnqueueSignalParams,
   ListSignalsParams,
+  ReleaseSignalResult,
   ResolveSignalByMetadataParams,
   ResolveSignalParams,
+  ResolveSignalResult,
   SignalQueueEntry,
 } from './signal';

--- a/types/index.ts
+++ b/types/index.ts
@@ -311,3 +311,13 @@ export {
 } from './telemetry';
 export { WorkListTaskType } from './task';
 export { TransitionMatch, TransitionRule, Transitions } from './transition';
+export {
+  ClaimSignalByMetadataParams,
+  ClaimSignalParams,
+  ConditionQueueConfig,
+  EnqueueSignalParams,
+  ListSignalsParams,
+  ResolveSignalByMetadataParams,
+  ResolveSignalParams,
+  SignalQueueEntry,
+} from './signal';

--- a/types/signal.ts
+++ b/types/signal.ts
@@ -1,0 +1,105 @@
+/**
+ * Represents a queued signal record in the hotmesh_signals table.
+ * Created atomically with workflow suspension when condition() is called
+ * with a queue configuration.
+ */
+export interface SignalQueueEntry {
+  id: string;
+  namespace: string;
+  appId: string;
+  signalKey: string;
+  workflowId: string;
+  jobId?: string;
+  topic?: string;
+  status: 'pending' | 'claimed' | 'resolved' | 'expired' | 'released';
+  role?: string;
+  type?: string;
+  subtype?: string;
+  priority: number;
+  description?: string;
+  taskQueue?: string;
+  workflowType?: string;
+  assignedTo?: string;
+  claimedAt?: Date;
+  claimExpiresAt?: Date;
+  resolvedAt?: Date;
+  resolverPayload?: Record<string, unknown>;
+  envelope?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  expiresAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Optional queue configuration passed to condition() to create a
+ * richly-typed, indexed, claimable signal record alongside workflow suspension.
+ *
+ * metadata is GIN-indexed and used for claimByMetadata / resolveByMetadata queries.
+ * envelope is unindexed and intended for display context (form schemas, etc.).
+ */
+export interface ConditionQueueConfig {
+  role?: string;
+  type?: string;
+  subtype?: string;
+  priority?: number;
+  description?: string;
+  taskQueue?: string;
+  workflowType?: string;
+  assignedTo?: string;
+  metadata?: Record<string, unknown>;
+  envelope?: Record<string, unknown>;
+  durationMinutes?: number;
+}
+
+export interface EnqueueSignalParams {
+  namespace: string;
+  appId: string;
+  signalKey: string;
+  workflowId: string;
+  jobId?: string;
+  topic?: string;
+  role?: string;
+  type?: string;
+  subtype?: string;
+  priority?: number;
+  description?: string;
+  taskQueue?: string;
+  workflowType?: string;
+  assignedTo?: string;
+  metadata?: Record<string, unknown>;
+  envelope?: Record<string, unknown>;
+  expiresAt?: Date;
+}
+
+export interface ClaimSignalParams {
+  id: string;
+  assignee?: string;
+  durationMinutes?: number;
+}
+
+export interface ClaimSignalByMetadataParams {
+  key: string;
+  value: unknown;
+  assignee?: string;
+  durationMinutes?: number;
+}
+
+export interface ResolveSignalParams {
+  id: string;
+  resolverPayload?: Record<string, unknown>;
+}
+
+export interface ResolveSignalByMetadataParams {
+  key: string;
+  value: unknown;
+  resolverPayload?: Record<string, unknown>;
+}
+
+export interface ListSignalsParams {
+  status?: 'pending' | 'claimed' | 'resolved' | 'expired' | 'released';
+  role?: string;
+  taskQueue?: string;
+  limit?: number;
+  offset?: number;
+}

--- a/types/signal.ts
+++ b/types/signal.ts
@@ -103,3 +103,40 @@ export interface ListSignalsParams {
   limit?: number;
   offset?: number;
 }
+
+/**
+ * Result of a claim operation (by ID or by metadata).
+ *
+ * - ok: true  → signal was claimed; entry contains the full record
+ * - ok: false, reason: 'not-found'  → no signal exists for the given id/metadata
+ * - ok: false, reason: 'conflict'   → signal exists but was already claimed concurrently
+ */
+export type ClaimSignalResult =
+  | { ok: true; entry: SignalQueueEntry }
+  | { ok: false; reason: 'not-found' | 'conflict' };
+
+/**
+ * Result of a resolve operation (by ID or by metadata).
+ *
+ * - ok: true  → signal marked resolved and workflow signal delivered
+ * - ok: false, reason: 'not-found'       → no pending/claimed signal found
+ * - ok: false, reason: 'already-resolved' → signal exists but was already resolved (id-based only)
+ * - ok: false, reason: 'signal-failed'    → DB record updated but workflow signal delivery failed;
+ *                                            signalKey is provided so callers can retry delivery
+ */
+export type ResolveSignalResult =
+  | { ok: true }
+  | { ok: false; reason: 'not-found' }
+  | { ok: false; reason: 'already-resolved' }
+  | { ok: false; reason: 'signal-failed'; signalKey: string };
+
+/**
+ * Result of a release operation.
+ *
+ * - ok: true  → signal returned to pending
+ * - ok: false, reason: 'not-found'    → no signal exists for this id
+ * - ok: false, reason: 'wrong-status' → signal exists but is not in 'claimed' status
+ */
+export type ReleaseSignalResult =
+  | { ok: true }
+  | { ok: false; reason: 'not-found' | 'wrong-status' };


### PR DESCRIPTION
## Summary

- Adds `hotmesh_signals` Postgres table with GIN index on `metadata` and btree indexes on `(role, status)`, `(task_queue, status)`, `signal_key`, and `claim_expires_at`
- Extends `condition(signalId, queueConfig?)` to atomically create a claimable `hotmesh_signals` row inside the same Postgres transaction that suspends the workflow — eliminating the two-step write pattern used by downstream projects
- Adds `client.signalQueue.*` namespace: `list`, `get`, `claim`, `claimByMetadata`, `release`, `resolve`, `resolveByMetadata`, `releaseExpired`
- All mutating methods return discriminated union result types (`ClaimSignalResult`, `ReleaseSignalResult`, `ResolveSignalResult`) with explicit reason codes (`not-found`, `conflict`, `already-resolved`, `signal-failed`) — no silent nulls
- Store methods use CTE-based atomic queries to prevent TOCTOU races between concurrent workers; `signal-failed` carries `signalKey` so callers can retry signal delivery independently
- Signal delivery in `resolve`/`resolveByMetadata` goes through `hotMeshClient.signal()` — the low-level HotMesh signal activity — not a durable-layer shortcut; confirmed by `task-signal-race-pending-stored` log entries in test output
- New table added via migration path only (not `getTableNames()`), so existing deployments with all tables present do not re-run `createTables` or trigger the `CREATE TRIGGER` conflict
- Redis provider unaffected; feature is Postgres-only, duck-typed behind `typeof store.enqueueSignal === 'function'`
- Exports `SignalQueueEntry`, `ConditionQueueConfig`, `ClaimSignalResult`, `ReleaseSignalResult`, `ResolveSignalResult` from both `types/index.ts` and `services/durable/index.ts`
- README updated with full signal queue section, method table, result type shapes, and Postgres-only callout

## Test plan

- [ ] `docker compose exec hotmesh npx vitest run tests/durable/signal-queue/postgres.test.ts` — 5 tests pass: connection echo, claim→resolve lifecycle (including `already-resolved` and `conflict` assertions), resolveByMetadata (including duplicate `not-found`), expiry sweeper (including `wrong-status` and `not-found` assertions), `condition()` with timeout + queueConfig
- [ ] `docker compose exec hotmesh npx vitest run tests/durable/condition-timeout/postgres.test.ts` — 3 tests pass; no regression on existing condition/timeout behavior
- [ ] All other durable test suites unaffected (signal-queue is Postgres-only, additive)