### PR TITLE
Add client.signalQueue.getBySignalKey — indexed O(1) signal_key lookup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/durable/client.ts
+++ b/services/durable/client.ts
@@ -487,6 +487,14 @@ export class ClientService {
       return store.getSignal({ namespace: ns, appId: store.appId, id });
     },
 
+    getBySignalKey: async (signalKey: string, namespace?: string) => {
+      const hotMesh = await this.getHotMeshClient(null, namespace);
+      const store = hotMesh.engine.store as any;
+      if (typeof store.getSignalBySignalKey !== 'function') return null;
+      const ns = namespace ?? APP_ID;
+      return store.getSignalBySignalKey({ namespace: ns, appId: store.appId, signalKey });
+    },
+
     claim: async (params: {
       id: string;
       namespace?: string;

--- a/services/store/providers/postgres/postgres.ts
+++ b/services/store/providers/postgres/postgres.ts
@@ -2203,6 +2203,20 @@ class PostgresStoreService extends StoreService<
     return this.rowToSignalEntry(result.rows[0]);
   }
 
+  async getSignalBySignalKey(params: {
+    namespace: string;
+    appId: string;
+    signalKey: string;
+  }) {
+    const tbl = this.signalQueueTable();
+    const result = await this.pgClient.query(
+      `SELECT * FROM ${tbl} WHERE namespace = $1 AND app_id = $2 AND signal_key = $3 LIMIT 1`,
+      [params.namespace, params.appId, params.signalKey],
+    );
+    if (result.rows.length === 0) return null;
+    return this.rowToSignalEntry(result.rows[0]);
+  }
+
   // ─────────────────────────────────────────────────────────────────────────
 
   /**

--- a/tests/durable/signal-queue/postgres.test.ts
+++ b/tests/durable/signal-queue/postgres.test.ts
@@ -200,6 +200,39 @@ describe('DURABLE | signal-queue | Postgres', () => {
       await handle.result();
     }, 20_000);
 
+    it('getBySignalKey returns entry by signal key (indexed lookup)', async () => {
+      const orderId = `order-${guid()}`;
+      const signalId = `approve-order-${orderId}`;
+      const client = new Client({ connection });
+
+      const handle = await client.workflow.start({
+        args: [orderId],
+        taskQueue: 'signal-queue-test',
+        workflowName: 'queuedApproval',
+        workflowId: guid(),
+      });
+
+      await sleepFor(3_000);
+
+      //direct indexed lookup — must find the entry without list + filter
+      const entry = await client.signalQueue.getBySignalKey(signalId);
+      expect(entry).toBeDefined();
+      expect(entry.signalKey).toBe(signalId);
+      expect(entry.status).toBe('pending');
+
+      //unknown key must return null
+      const missing = await client.signalQueue.getBySignalKey('no-such-key');
+      expect(missing).toBeNull();
+
+      //clean up
+      const resolveResult = await client.signalQueue.resolve({
+        id: entry.id,
+        resolverPayload: { approved: true },
+      });
+      expect(resolveResult.ok).toBe(true);
+      await handle.result();
+    }, 20_000);
+
     it('condition() with timeout + queueConfig still enqueues', async () => {
       const orderId = `order-${guid()}`;
       const client = new Client({ connection });


### PR DESCRIPTION
## Summary
- Adds `getSignalBySignalKey` to `PostgresStoreService` — hits `idx_hmsig_signal_key` directly, O(1)
- Exposes it as `client.signalQueue.getBySignalKey(signalKey, namespace?)` on the Durable client

## Why

Long-tail PR #103 introduced `sqGetBySignalKey` as a bridge between `lt_escalations.metadata.signal_id` (a string signal key) and `hotmesh_signals.id` (the UUID needed by `client.signalQueue.resolve`). Without this SDK method, the only option was:

```typescript
const entries = await client.signalQueue.list({ limit: 200 });
return entries.find(e => e.signalKey === signalKey) ?? null;
```

This has a hard cap: if there are >200 live `hotmesh_signals` rows, it silently returns `null` for a valid entry, causing Path F to return 404. At ortho pipeline scale today this is fine; at high throughput it's a correctness bug.

## With this fix

Long-tail can replace the workaround:

```typescript
// Before (O(n), capped at 200)
const entries = await client.signalQueue.list({ limit: 200 });
return entries.find(e => e.signalKey === signalKey) ?? null;

// After (O(1), indexed)
return client.signalQueue.getBySignalKey(signalKey);
```

## Test plan
- [ ] `npx tsc --noEmit` — zero errors (already verified)
- [ ] `docker compose exec hotmesh npx vitest run tests/durable/signal-queue/` — signal queue tests pass