### PR TITLE
Bump to 0.22.1: TOCTOU fix, migration support, uuid util, prove scripts

### DIFF
--- a/modules/utils.ts
+++ b/modules/utils.ts
@@ -1,5 +1,5 @@
 import os from 'os';
-import { createHash } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 
 import { parseExpression } from 'cron-parser';
 import { nanoid } from 'nanoid';
@@ -58,6 +58,11 @@ export function deterministicRandom(seed: number): number {
 
 export function guid(size: number = HMSH_GUID_SIZE): string {
   return `H` + nanoid(size);
+}
+
+/** Returns a standard RFC 4122 v4 UUID (e.g. for use as a DB primary key). */
+export function uuid(): string {
+  return randomUUID();
 }
 
 export async function sleepFor(ms: number): Promise<void> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
@@ -50,7 +50,7 @@
     "test:durable:signal": "vitest run tests/durable/signal/postgres.test.ts",
     "test:durable:readonly": "docker compose --profile readonly up -d --build && docker compose exec hotmesh-readonly npx vitest run --config tests/durable/readonly/vitest.config.mts",
     "test:durable:unknown": "vitest run tests/durable/unknown/postgres.test.ts",
-    "test:durable:esclations": "HMSH_LOGLEVEL=info vitest run tests/durable/escalations",
+    "test:durable:escalations": "HMSH_LOGLEVEL=info vitest run tests/durable/escalations",
     "test:durable:exporter": "HMSH_LOGLEVEL=info vitest run tests/durable/exporter",
     "test:durable:exporter:debug": "EXPORT_DEBUG=1 HMSH_LOGLEVEL=error vitest run tests/durable/basic/postgres.test.ts",
     "test:durable:codec": "vitest run tests/durable/codec/postgres.test.ts",
@@ -85,7 +85,13 @@
     "test:sub:nats": "vitest run tests/functional/sub/providers/nats/nats.test.ts",
     "test:trigger": "vitest run tests/unit/services/activities/trigger.test.ts",
     "test:virtual": "vitest run tests/virtual",
-    "test:unit": "vitest run tests/unit"
+    "test:unit": "vitest run tests/unit",
+
+    "prove": "docker compose exec hotmesh npx vitest run tests/durable 2>&1 | tee /tmp/hmsh-durable.txt && grep -E 'FAIL|Tests |Files ' /tmp/hmsh-durable.txt | tail -5",
+    "prove:escalations": "docker compose exec hotmesh npx vitest run tests/durable/escalations/postgres.test.ts 2>&1 | tee /tmp/hmsh-escalations.txt && grep -E 'FAIL|Tests |Files ' /tmp/hmsh-escalations.txt | tail -5",
+    "prove:functional": "docker compose exec hotmesh npx vitest run tests/functional 2>&1 | tee /tmp/hmsh-functional.txt && grep -E 'FAIL|Tests |Files ' /tmp/hmsh-functional.txt | tail -5",
+    "prove:all": "docker compose exec hotmesh npx vitest run tests/ 2>&1 | tee /tmp/hmsh-all.txt && grep -E 'FAIL|Tests |Files ' /tmp/hmsh-all.txt | tail -5",
+    "prove:file": "f() { docker compose exec hotmesh npx vitest run \"$@\" 2>&1 | tee /tmp/hmsh-file.txt && grep -E 'FAIL|Tests |Files ' /tmp/hmsh-file.txt | tail -5; }; f"
   },
   "keywords": [
     "Invisible Infrastructure",

--- a/services/durable/client.ts
+++ b/services/durable/client.ts
@@ -35,6 +35,7 @@ import {
   ResolveEscalationParams,
   ResolveByMetadataParams,
   EscalateToRoleParams,
+  MigrateEscalationParams,
 } from '../../types/hmsh_escalations';
 
 import { Search } from './search';
@@ -774,35 +775,25 @@ export class ClientService {
       const hotMeshClient = await this.getHotMeshClient(null, ns);
       const store = hotMeshClient.engine.store as any;
 
-      // UUID primary-key lookup — no namespace filter needed; use existing.namespace for the UPDATE.
-      const existing = await store.getEscalation(params.id);
-      if (!existing) return { ok: false, reason: 'not-found' };
-      if (existing.status === 'resolved') return { ok: false, reason: 'already-resolved' };
-      if (existing.status === 'cancelled') return { ok: false, reason: 'already-cancelled' };
+      // store.resolveEscalation() uses FOR UPDATE inside its CTE, serializing concurrent
+      // callers at the DB level. The second caller blocks on the row lock, reads
+      // 'already-resolved' after the first commits, and returns — no signal is queued.
+      // This eliminates the double-signal race that the previous KVTransaction approach
+      // had: two concurrent callers could both pass the unlocked getEscalation() read,
+      // both queue signal INSERTs, and both commit them — even though only one UPDATE won.
+      const dbResult = await store.resolveEscalation({
+        id: params.id,
+        resolverPayload: params.resolverPayload,
+        // namespace intentionally omitted — UUID lookup; passing ns would miss rows
+        // stored under namespace 'hmsh' (the engine default) when ns = APP_ID = 'durable'.
+      });
+      if (!dbResult.ok) return dbResult;
 
-      // Build a single atomic transaction: signal stream INSERTs + escalation UPDATE in one BEGIN/COMMIT.
-      // engine.signal() with a transaction queues an INSERT into the stream table without executing;
-      // queueResolveEscalation() queues the status UPDATE; txn.exec() commits all in one round-trip.
-      const txn = store.transact();
-
-      if (existing.signal_key && existing.topic) {
-        const signalPayload = { id: existing.signal_key, data: params.resolverPayload ?? {} };
-        try {
-          const sc = await this.getHotMeshClient(`${ns}.wfs.signal`, ns);
-          await sc.engine.signal(`${ns}.wfs.signal`, signalPayload, StreamStatus.SUCCESS, 200, txn);
-        } catch { /* no collator hook rule — skip */ }
-        try {
-          const wc = await this.getHotMeshClient(`${ns}.wfs.wait`, ns);
-          await wc.engine.signal(`${ns}.wfs.wait`, signalPayload, StreamStatus.SUCCESS, 200, txn);
-        } catch { /* no waiter hook rule — skip */ }
+      if (dbResult.signalKey) {
+        const signalPayload = { id: dbResult.signalKey, data: params.resolverPayload ?? {} };
+        const delivered = await this._deliverEscalationSignal(ns, dbResult.topic, signalPayload);
+        if (!delivered) return { ok: false, reason: 'signal-failed' };
       }
-
-      store.queueResolveEscalation(
-        { id: params.id, namespace: existing.namespace ?? ns, resolverPayload: params.resolverPayload },
-        txn,
-      );
-
-      await txn.exec();
       return { ok: true };
     },
 
@@ -828,34 +819,51 @@ export class ClientService {
       const hotMeshClient = await this.getHotMeshClient(null, ns);
       const store = hotMeshClient.engine.store as any;
 
-      // Metadata lookup: filter by namespace to scope correctly, but use existing.namespace for the UPDATE.
-      const existing = await store.findEscalationByMetadata(params.key, params.value, params.roles ?? null);
-      if (!existing) return { ok: false, reason: 'not-found' };
-      if (existing.status === 'resolved') return { ok: false, reason: 'already-resolved' };
-      if (existing.status === 'cancelled') return { ok: false, reason: 'already-cancelled' };
+      // Same FOR UPDATE CTE serialization as resolve(). Metadata filter selects
+      // the highest-priority matching row; the lock prevents concurrent callers
+      // from both resolving it.
+      const dbResult = await store.resolveEscalationByMetadata({
+        key: params.key,
+        value: params.value,
+        resolverPayload: params.resolverPayload,
+        roles: params.roles,
+      });
+      if (!dbResult.ok) return dbResult;
 
-      // Same atomic pattern as resolve(): signal INSERTs + UPDATE in one transaction.
-      const txn = store.transact();
-
-      if (existing.signal_key && existing.topic) {
-        const signalPayload = { id: existing.signal_key, data: params.resolverPayload ?? {} };
-        try {
-          const sc = await this.getHotMeshClient(`${ns}.wfs.signal`, ns);
-          await sc.engine.signal(`${ns}.wfs.signal`, signalPayload, StreamStatus.SUCCESS, 200, txn);
-        } catch { /* no collator hook rule — skip */ }
-        try {
-          const wc = await this.getHotMeshClient(`${ns}.wfs.wait`, ns);
-          await wc.engine.signal(`${ns}.wfs.wait`, signalPayload, StreamStatus.SUCCESS, 200, txn);
-        } catch { /* no waiter hook rule — skip */ }
+      if (dbResult.signalKey) {
+        const signalPayload = { id: dbResult.signalKey, data: params.resolverPayload ?? {} };
+        const delivered = await this._deliverEscalationSignal(ns, dbResult.topic, signalPayload);
+        if (!delivered) return { ok: false, reason: 'signal-failed' };
       }
-
-      store.queueResolveEscalation(
-        { id: existing.id, namespace: existing.namespace ?? ns, resolverPayload: params.resolverPayload },
-        txn,
-      );
-
-      await txn.exec();
       return { ok: true };
+    },
+
+    /**
+     * Full-fidelity migration: inserts an escalation row preserving the original
+     * UUID and all lifecycle state. Returns the inserted row, or `null` if the
+     * UUID already exists (idempotent — safe to call multiple times with the same
+     * `params.id`). Use this to migrate rows from a legacy escalation table to
+     * `hmsh_escalations` without losing original IDs or state.
+     *
+     * @example
+     * ```typescript
+     * const entry = await client.escalations.migrate({
+     *   id: 'original-uuid',
+     *   status: 'resolved',
+     *   resolvedAt: new Date('2025-01-01'),
+     *   type: 'order-approval',
+     *   role: 'approver',
+     * });
+     * // null on subsequent calls with the same id — idempotent
+     * ```
+     */
+    migrate: async (
+      params: MigrateEscalationParams,
+      namespace?: string,
+    ): Promise<EscalationEntry | null> => {
+      const ns = (params.namespace ?? namespace) ?? APP_ID;
+      const hotMeshClient = await this.getHotMeshClient(null, ns);
+      return (hotMeshClient.engine.store as any).createEscalationForMigration(params);
     },
 
     /**
@@ -875,6 +883,49 @@ export class ClientService {
       return (hotMeshClient.engine.store as any).releaseExpiredEscalations(namespace);
     },
   };
+
+  /**
+   * Delivers a signal to the registered escalation topic.
+   *
+   * When the topic is known (stored at condition() time), we deliver only to that
+   * topic. This avoids writing a stale pending entry to the alternate stream, which
+   * would interfere with concurrent consumers in other workflows or tests.
+   *
+   * When topic is null (legacy/standalone rows with no registered topic), we try
+   * both wfs.signal and wfs.wait unconditionally — engine.signal() on the wrong
+   * topic stores pending without throwing, so a sequential fallback would skip
+   * the second topic and leave single-condition workflows permanently suspended.
+   *
+   * @private
+   */
+  private async _deliverEscalationSignal(
+    ns: string,
+    topic: string | null | undefined,
+    signalPayload: { id: string; data: Record<string, unknown> },
+  ): Promise<boolean> {
+    if (topic) {
+      // Registered topic known — deliver precisely, no stream pollution.
+      try {
+        const tc = await this.getHotMeshClient(topic, ns);
+        await tc.engine.signal(topic, signalPayload, StreamStatus.SUCCESS, 200);
+        return true;
+      } catch { /* topic not currently registered — fall through */ }
+    }
+
+    // Topic unknown or primary delivery failed — try both topics unconditionally.
+    let delivered = false;
+    try {
+      const sc = await this.getHotMeshClient(`${ns}.wfs.signal`, ns);
+      await sc.engine.signal(`${ns}.wfs.signal`, signalPayload, StreamStatus.SUCCESS, 200);
+      delivered = true;
+    } catch { /* no collator hook rule for this workflow */ }
+    try {
+      const wc = await this.getHotMeshClient(`${ns}.wfs.wait`, ns);
+      await wc.engine.signal(`${ns}.wfs.wait`, signalPayload, StreamStatus.SUCCESS, 200);
+      delivered = true;
+    } catch { /* no waiter hook rule for this workflow */ }
+    return delivered;
+  }
 
   /**
    * @private

--- a/services/durable/index.ts
+++ b/services/durable/index.ts
@@ -1,6 +1,6 @@
 import { HotMesh } from '../hotmesh';
 import { ContextType, WorkflowInboundCallsInterceptor, WorkflowOutboundCallsInterceptor, ActivityInboundCallsInterceptor } from '../../types/durable';
-import { guid } from '../../modules/utils';
+import { guid, uuid } from '../../modules/utils';
 
 import { ClientService } from './client';
 import { ConnectionService } from './connection';
@@ -317,6 +317,13 @@ class DurableClass {
    * Generate a unique identifier for workflow IDs
    */
   static guid = guid;
+
+  /**
+   * Generate a standard RFC 4122 v4 UUID — use for DB primary keys and
+   * any context that requires a hyphenated UUID format rather than the
+   * compact HotMesh guid format.
+   */
+  static uuid = uuid;
 
   /**
    * Provision a scoped Postgres role for a worker. The role can only

--- a/services/store/providers/postgres/postgres.ts
+++ b/services/store/providers/postgres/postgres.ts
@@ -1926,6 +1926,79 @@ class PostgresStoreService extends StoreService<
     );
   }
 
+  /**
+   * Full-fidelity INSERT for data migration. Preserves the original `id` (UUID),
+   * lifecycle state, and timestamps from the source table. Uses
+   * `ON CONFLICT (id) DO NOTHING` so re-running a migration batch is safe —
+   * rows that already exist are skipped and `null` is returned for them.
+   */
+  async createEscalationForMigration(
+    params: import('../../../../types/hmsh_escalations').MigrateEscalationParams,
+  ): Promise<import('../../../../types/hmsh_escalations').EscalationEntry | null> {
+    const {
+      id,
+      namespace, appId, signalKey, topic, workflowId, taskQueue, workflowType,
+      type, subtype, entity, description, role, priority,
+      originId, parentId, initiatedBy, createdBy, traceId, spanId,
+      escalationPayload, metadata, envelope, expiresAt,
+      status, assignedTo, claimExpiresAt, claimedAt, resolvedAt,
+      resolverPayload, milestones, createdAt, updatedAt,
+    } = params;
+    const result = await this.pgClient.query(`
+      INSERT INTO public.hmsh_escalations
+        (id, namespace, app_id, signal_key, topic, workflow_id, task_queue, workflow_type,
+         type, subtype, entity, description, role, priority,
+         origin_id, parent_id, initiated_by, created_by, trace_id, span_id,
+         escalation_payload, metadata, envelope, expires_at,
+         status, assigned_to, claim_expires_at, claimed_at, resolved_at,
+         resolver_payload, milestones, created_at, updated_at)
+      VALUES
+        ($1,  $2,  $3,  $4,  $5,  $6,  $7,  $8,
+         $9,  $10, $11, $12, $13, $14,
+         $15, $16, $17, $18, $19, $20,
+         $21, $22, $23, $24,
+         $25, $26, $27, $28, $29,
+         $30, $31, $32, $33)
+      ON CONFLICT (id) DO NOTHING
+      RETURNING *
+    `, [
+      id,
+      namespace ?? 'hmsh',
+      appId ?? 'hmsh',
+      signalKey ?? null,
+      topic ?? null,
+      workflowId ?? null,
+      taskQueue ?? null,
+      workflowType ?? null,
+      type ?? null,
+      subtype ?? null,
+      entity ?? null,
+      description ?? null,
+      role ?? null,
+      priority ?? 5,
+      originId ?? null,
+      parentId ?? null,
+      initiatedBy ?? null,
+      createdBy ?? null,
+      traceId ?? null,
+      spanId ?? null,
+      escalationPayload ? JSON.stringify(escalationPayload) : null,
+      metadata ? JSON.stringify(metadata) : null,
+      envelope ? JSON.stringify(envelope) : null,
+      expiresAt ?? null,
+      status ?? 'pending',
+      assignedTo ?? null,
+      claimExpiresAt ?? null,
+      claimedAt ?? null,
+      resolvedAt ?? null,
+      resolverPayload ? JSON.stringify(resolverPayload) : null,
+      milestones ? JSON.stringify(milestones) : '[]',
+      createdAt ?? new Date(),
+      updatedAt ?? new Date(),
+    ]);
+    return result.rows[0] ?? null;
+  }
+
   async getEscalation(id: string, namespace?: string): Promise<import('../../../../types/hmsh_escalations').EscalationEntry | null> {
     const result = await this.pgClient.query(
       `SELECT * FROM public.hmsh_escalations WHERE id = $1${namespace ? ' AND namespace = $2' : ''}`,

--- a/tests/durable/escalations/postgres.test.ts
+++ b/tests/durable/escalations/postgres.test.ts
@@ -11,7 +11,7 @@ import { Client as Postgres } from 'pg';
 
 import { Durable } from '../../../services/durable';
 import { WorkflowHandleService } from '../../../services/durable/handle';
-import { guid, sleepFor } from '../../../modules/utils';
+import { guid, sleepFor, uuid } from '../../../modules/utils';
 import { ProviderNativeClient } from '../../../types/provider';
 import { dropTables, postgres_options } from '../../$setup/postgres';
 import { PostgresConnection } from '../../../services/connector/providers/postgres';
@@ -281,6 +281,98 @@ describe('DURABLE | escalations | Postgres', () => {
       expect(esc.signal_key).toBeNull();
       expect(esc.type).toBe('support');
       expect(esc.status).toBe('pending');
+    }, 5_000);
+  });
+
+  describe('concurrent resolve (TOCTOU safety)', () => {
+    /**
+     * Two callers fire resolve() simultaneously on the same row.
+     * store.resolveEscalation() uses FOR UPDATE inside its CTE, serializing
+     * concurrent callers at the DB level. The second caller blocks on the
+     * row lock, reads 'already-resolved' after the first commits, and
+     * returns { ok: false, reason: 'already-resolved' } — exactly one
+     * signal is delivered, never two.
+     */
+    it('should resolve exactly once when two callers race', async () => {
+      const esc = await client.escalations.create({
+        type: 'support',
+        role: 'agent',
+        description: 'Concurrent resolve test',
+        metadata: { ticketId: `T-concurrent-${guid()}` },
+      });
+
+      // Fire both resolves simultaneously — no await between them.
+      const [r1, r2] = await Promise.all([
+        client.escalations.resolve({ id: esc.id, resolverPayload: { winner: 1 } }),
+        client.escalations.resolve({ id: esc.id, resolverPayload: { winner: 2 } }),
+      ]);
+
+      const successes = [r1, r2].filter((r) => r.ok).length;
+      const alreadyResolved = [r1, r2].filter((r) => !r.ok && (r as any).reason === 'already-resolved').length;
+
+      // Exactly one caller wins; the other sees already-resolved.
+      expect(successes).toBe(1);
+      expect(alreadyResolved).toBe(1);
+
+      // Row is definitively resolved — not stuck in pending.
+      const final = await client.escalations.get(esc.id);
+      expect(final?.status).toBe('resolved');
+    }, 10_000);
+  });
+
+  describe('migration (full-fidelity UUID + state preservation)', () => {
+    it('should insert a row preserving the original UUID and all lifecycle state', async () => {
+      // Migration requires standard UUIDs — the id column is PostgreSQL UUID type.
+      const originalId = uuid();
+      const createdAt = new Date('2024-06-01T10:00:00Z');
+      const resolvedAt = new Date('2024-06-01T11:30:00Z');
+
+      const entry = await client.escalations.migrate({
+        id: originalId,
+        status: 'resolved',
+        type: 'order-approval',
+        role: 'approver',
+        description: 'Migrated from lt_escalations',
+        priority: 3,
+        resolvedAt,
+        resolverPayload: { approved: true },
+        createdAt,
+        metadata: { legacy: true, orderId: 'ORD-001' },
+      });
+
+      expect(entry).not.toBeNull();
+      expect(entry!.id).toBe(originalId);
+      expect(entry!.status).toBe('resolved');
+      expect(entry!.type).toBe('order-approval');
+      expect(entry!.role).toBe('approver');
+      expect(entry!.priority).toBe(3);
+      expect(entry!.resolver_payload).toMatchObject({ approved: true });
+      // Timestamps are preserved — not overwritten with NOW()
+      expect(new Date(entry!.created_at).toISOString()).toBe(createdAt.toISOString());
+      expect(new Date(entry!.resolved_at!).toISOString()).toBe(resolvedAt.toISOString());
+    }, 5_000);
+
+    it('should return null on a second call with the same id (idempotent)', async () => {
+      const originalId = uuid();
+      await client.escalations.migrate({
+        id: originalId,
+        type: 'support',
+        role: 'agent',
+      });
+
+      // Second call — same id — must not throw, must return null.
+      const duplicate = await client.escalations.migrate({
+        id: originalId,
+        type: 'support',
+        role: 'agent',
+        description: 'This should not overwrite the original',
+      });
+
+      expect(duplicate).toBeNull();
+
+      // Original row is untouched — description still null from first insert.
+      const row = await client.escalations.get(originalId);
+      expect(row?.description).toBeNull();
     }, 5_000);
   });
 });

--- a/types/hmsh_escalations.ts
+++ b/types/hmsh_escalations.ts
@@ -203,3 +203,28 @@ export interface EscalateToRoleParams {
   targetRole: string;
   namespace?: string;
 }
+
+/**
+ * Full-fidelity migration params. Extends `CreateEscalationParams` with:
+ * - `id` (required) — preserves the original UUID; no auto-generation
+ * - lifecycle state fields (`status`, `assignedTo`, `claimExpiresAt`, …) — carry over
+ *   the exact state of the migrated row so in-flight escalations land correctly
+ * - `createdAt` / `updatedAt` — preserve original timestamps
+ *
+ * The underlying INSERT uses `ON CONFLICT (id) DO NOTHING`, so calling
+ * `migrate()` multiple times with the same ID is safe — subsequent calls
+ * return `null` without touching the existing row.
+ */
+export interface MigrateEscalationParams extends CreateEscalationParams {
+  /** Required — preserve the original UUID from the source table. */
+  id: string;
+  status?: 'pending' | 'claimed' | 'resolved' | 'cancelled' | 'expired';
+  assignedTo?: string;
+  claimExpiresAt?: Date;
+  claimedAt?: Date;
+  resolvedAt?: Date;
+  resolverPayload?: Record<string, unknown>;
+  milestones?: Array<{ name: string; value: unknown; [key: string]: unknown }>;
+  createdAt?: Date;
+  updatedAt?: Date;
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -329,4 +329,5 @@ export {
   ResolveEscalationParams,
   ResolveByMetadataParams,
   EscalateToRoleParams,
+  MigrateEscalationParams,
 } from './hmsh_escalations';


### PR DESCRIPTION
## Summary

- **TOCTOU fix** (`resolve()` / `resolveByMetadata()`): replaces the unlocked-read + KVTransaction pattern with `store.resolveEscalation()` (FOR UPDATE CTE). Concurrent callers are serialized at the DB level — the second caller blocks on the row lock, reads `already-resolved`, and returns without queuing a signal. Double-signal race eliminated.
- **Topic-aware signal delivery** via new `_deliverEscalationSignal()`: delivers to the registered topic stored at `condition()` time, avoiding stale pending entries in the alternate stream that caused cross-test concurrency failures in the full suite.
- **`client.escalations.migrate()`**: full-fidelity migration path. Preserves original UUID, lifecycle state, and timestamps. `ON CONFLICT (id) DO NOTHING` makes re-runs idempotent — returns `null` if ID already exists.
- **`MigrateEscalationParams`** type exported from `types/hmsh_escalations.ts` and `types/index.ts`.
- **`uuid()` utility**: `randomUUID` centralized in `modules/utils.ts` and exposed as `Durable.uuid` — follows crypto-centralization principle, avoids inline `crypto.randomUUID()` calls.
- **`prove:*` scripts** in `package.json`: canonical docker + tee + grep test runners. `npm run prove` is the PROVE safe word. `npm run prove:file -- <path>` for single files.
- **Net-new tests**: concurrent resolve race proof (verifies exactly one `ok:true`, one `already-resolved`), migration UUID preservation, migration idempotency.
- Fix `esclations` typo → `escalations` in existing script.

## Test plan

- [x] `npm run prove` — 300 passed, 0 failed, 8 skipped (full durable suite)
- [x] `npm run prove:escalations` — 23 passed, 0 failed
- [x] `npx tsc --noEmit` — zero errors