### PR TITLE
Thread events into Worker.create and Durable.Client engines; 0.22.5

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -19,6 +19,7 @@ This guide demonstrates how to build sophisticated workflows using HotMesh, prog
 - [The Simplest Sequential Data Flow](#the-simplest-sequential-data-flow)
 - [The Simplest Compositional Executable Flow](#the-simplest-compositional-executable-flow)
 - [The Simplest Conditional Executable Flow](#the-simplest-conditional-executable-flow)
+- [The Simplest Escalation Flow](#the-simplest-escalation-flow)
 
 ## Setup
 ### Install Packages
@@ -868,3 +869,139 @@ const response9c = await hotMesh.pubsub('abc.test', { a : 'hello' });
 console.log(response9c.data.b); // hello world
 console.log(response9c.data.c); // hello world world
 ```
+
+## The Simplest Escalation Flow
+
+When a workflow must pause and wait for an external actor — a human reviewer, an AI agent, a manufacturing cell — add an `escalation:` block to a `hook` activity. At suspension time, HotMesh atomically writes one row to `public.hmsh_escalations` with full routing context: who should act (`role`), what kind of work it is (`type`/`subtype`), how urgent it is (`priority`), and any application-specific keys (`metadata`) needed to display or route it.
+
+The `signal_key` in the row is the job ID. Resuming the workflow is always `hotMesh.signal(hookTopic, { id: jobId, ...resolverData })`.
+
+```yaml
+# abc.10.yaml
+app:
+  id: abc
+  version: '10'
+  graphs:
+    - subscribes: abc.test
+      publishes: abc.tested
+      expire: 300
+
+      input:
+        schema:
+          type: object
+          properties:
+            orderId:
+              type: string
+            region:
+              type: string
+
+      output:
+        schema:
+          type: object
+          properties:
+            approved:
+              type: boolean
+            approvedBy:
+              type: string
+
+      activities:
+        t1:
+          type: trigger
+        a1:
+          type: hook
+          escalation:
+            role: approver
+            type: order-approval
+            subtype: regional
+            priority: 2
+            description: Approve order for dispatch
+            metadata:
+              orderId: '{t1.output.data.orderId}'
+              region: '{t1.output.data.region}'
+            envelope:
+              instructions: 'Review and approve or reject the order'
+          job:
+            maps:
+              approved: '{a1.hook.data.approved}'
+              approvedBy: '{a1.hook.data.approvedBy}'
+
+      transitions:
+        t1:
+          - to: a1
+
+      hooks:
+        abc.approve:
+          - to: a1
+            conditions:
+              match:
+                - expected: '{$job.metadata.jid}'
+                  actual: '{$self.hook.data.id}'
+```
+
+The `metadata` fields support `@pipe` expressions — they are resolved against the live job context at suspension time, so the row carries the actual input values, not template strings.
+
+The `hooks` section declares the signal topic (`abc.approve`) and routes it to activity `a1`. The condition `{$job.metadata.jid} == {$self.hook.data.id}` ensures the signal is only delivered to the correct workflow instance.
+
+Deploy, start the workflow, then query and claim the waiting escalation:
+
+```javascript
+// continued from prior example
+
+await hotMesh.deploy('./abc.10.yaml');
+await hotMesh.activate('10');
+
+// Start the workflow — returns immediately, workflow suspends at the hook
+const jobId = await hotMesh.pub('abc.test', { orderId: 'ORD-123', region: 'us-west' });
+
+// Wait briefly for the hook activity to write its escalation row
+await new Promise(r => setTimeout(r, 1000));
+
+// Query the pending escalation by signal_key (= jobId)
+const store = hotMesh.engine.store;
+const row = await store.getEscalationBySignalKey(jobId, 'hmsh');
+console.log(row.role);     // approver
+console.log(row.type);     // order-approval
+console.log(row.status);   // pending
+console.log(row.metadata); // { orderId: 'ORD-123', region: 'us-west' }
+
+// Claim it — marks it in-progress and sets the assignee
+await store.claimEscalation({
+  id: row.id,
+  namespace: 'hmsh',
+  assignee: 'alice',
+  durationMinutes: 60,
+});
+
+// Subscribe to the completion event before signaling
+let result;
+await hotMesh.sub(`abc.tested.${jobId}`, (_topic, msg) => { result = msg; });
+
+// Deliver the approval — resumes the suspended workflow
+await hotMesh.signal('abc.approve', {
+  id: jobId,          // routes to the correct workflow instance
+  approved: true,
+  approvedBy: 'alice',
+});
+
+// Wait for the workflow to complete
+await new Promise(r => setTimeout(r, 1000));
+await hotMesh.unsub(`abc.tested.${jobId}`);
+
+console.log(result.data.approved);   // true
+console.log(result.data.approvedBy); // alice
+```
+
+Escalation rows persist after signal delivery — they are audit records. Resolve the row to attach the reviewer's decision and advance its status:
+
+```javascript
+await store.resolveEscalation({
+  id: row.id,
+  namespace: 'hmsh',
+  resolverPayload: { verdict: 'approved' },
+});
+
+const resolved = await store.getEscalationBySignalKey(jobId, 'hmsh');
+console.log(resolved.status); // resolved
+```
+
+The escalation table (`public.hmsh_escalations`) is global — all apps share it. Rows from different apps are distinguished by `namespace` and `app_id`. The `Durable.workflow.condition(signalId, queueConfig)` primitive on the Durable layer provides the same suspension behavior without writing YAML, and `Escalations.Client` / `Durable.Client.escalations` expose the full claim-and-resolve API with TypeScript types.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.22.4",
+      "version": "0.22.5",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/durable/client.ts
+++ b/services/durable/client.ts
@@ -19,6 +19,7 @@ import { JobState } from '../../types/job';
 import { KeyType } from '../../modules/key';
 import { StreamStatus, StringAnyType } from '../../types';
 import { EscalationClientService } from '../escalations/client';
+import { EventsConfig } from '../../types/system_events';
 
 import { Search } from './search';
 import { Entity } from './entity';
@@ -80,6 +81,10 @@ export class ClientService {
   /**
    * @private
    */
+  events?: EventsConfig;
+  /**
+   * @private
+   */
   static topics: string[] = [];
   /**
    * @private
@@ -99,6 +104,7 @@ export class ClientService {
    */
   constructor(config: ClientConfig) {
     this.connection = config.connection;
+    this.events = config.events;
     this.escalations = new EscalationClientService({
       getHotMeshClient: this.getHotMeshClient.bind(this),
       events: config.events,
@@ -132,6 +138,7 @@ export class ClientService {
         readonly,
         connection: this.connection,
       },
+      events: this.events,
     });
 
     //synchronously cache the promise (before awaiting)

--- a/services/durable/worker.ts
+++ b/services/durable/worker.ts
@@ -409,6 +409,7 @@ export class WorkerService {
       appId: targetNamespace,
       engine: { connection: config.connection },
       workers: [workerEntry],
+      events: config.events,
     });
 
     WorkerService.instances.set(targetTopic, hotMeshWorker);
@@ -714,6 +715,7 @@ export class WorkerService {
       appId: targetNamespace,
       engine: { connection: providerConfig },
       workers: [workerEntry],
+      events: config.events,
     });
     WorkerService.instances.set(targetTopic, hotMeshWorker);
     return hotMeshWorker;
@@ -883,6 +885,7 @@ export class WorkerService {
       appId: config.namespace ?? APP_ID,
       engine: { connection: providerConfig },
       workers: [workerEntry],
+      events: config.events,
     });
     WorkerService.instances.set(targetTopic, hotMeshWorker);
     return hotMeshWorker;

--- a/tests/durable/events/postgres.test.ts
+++ b/tests/durable/events/postgres.test.ts
@@ -1,5 +1,5 @@
 /**
- * Proves the system-event emission surface introduced in 0.22.4.
+ * Proves the system-event emission surface introduced in 0.22.4/0.22.5.
  *
  * The event hook must fire exactly once per durable transition, post-commit,
  * with the full committed row as `data` and a collision-proof `event_id`.
@@ -11,6 +11,7 @@
  *   C — claimMany / resolveMany: per-row emit, counts match
  *   D — engine start fires system.engine.{appId}.started
  *   E — deploy fires system.engine.{appId}.deployed
+ *   F — Worker.create with events: condition(config) hook Leg1 fires created
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { Client as Postgres } from 'pg';
@@ -18,7 +19,7 @@ import { Client as Postgres } from 'pg';
 import { Durable } from '../../../services/durable';
 import { EscalationClientService } from '../../../services/escalations/client';
 import { HotMesh } from '../../../services/hotmesh';
-import { guid } from '../../../modules/utils';
+import { guid, sleepFor } from '../../../modules/utils';
 import { HMSH_LOGLEVEL } from '../../../modules/enums';
 import { dropTables, postgres_options } from '../../$setup/postgres';
 import { PostgresConnection } from '../../../services/connector/providers/postgres';
@@ -155,8 +156,6 @@ describe('DURABLE | system-event emission | Postgres', () => {
     it('event_id format is {id}:{verb}:{updated_at}', () => {
       const evt = collected.find(e => e.type.endsWith('.created'));
       expect(evt).toBeTruthy();
-      const parts = evt!.event_id.split(':');
-      // UUID has 5 parts, total: uuid(5 parts via hyphen) + verb + iso → check starts with escalationId
       expect(evt!.event_id.startsWith(escalationId + ':created:')).toBe(true);
     });
   });
@@ -240,7 +239,7 @@ describe('DURABLE | system-event emission | Postgres', () => {
     const collected: SystemEvent[] = [];
 
     it('HotMesh.init with events fires engine.started', async () => {
-      const appId = `evt-engine-${guid().slice(0, 8)}`;
+      const appId = `evt-engine-${guid().slice(0, 8).replace(/[^A-Za-z0-9]/g, '-')}`;
       const hm = await HotMesh.init({
         appId,
         logLevel: HMSH_LOGLEVEL,
@@ -262,7 +261,7 @@ describe('DURABLE | system-event emission | Postgres', () => {
     const collected: SystemEvent[] = [];
 
     it('deploy fires system.engine.{appId}.deployed', async () => {
-      const appId = `evt-deploy-${guid().slice(0, 8)}`;
+      const appId = `evt-deploy-${guid().slice(0, 8).replace(/[^A-Za-z0-9]/g, '-')}`;
       const hm = await HotMesh.init({
         appId,
         logLevel: HMSH_LOGLEVEL,
@@ -277,6 +276,70 @@ describe('DURABLE | system-event emission | Postgres', () => {
       const deployed = collected.find(e => e.type === `system.engine.${appId}.deployed`);
       expect(deployed).toBeTruthy();
       expect(deployed!.app_id).toBe(appId);
+    }, 20_000);
+  });
+
+  // ─── Scenario F: Worker.create with events threads hook Leg1 ───────────────
+
+  describe('Scenario F — Worker.create events wires hook Leg1 created emit', () => {
+    const collected: SystemEvent[] = [];
+    const taskQueue = `evt-worker-${guid().slice(0, 8).replace(/[^A-Za-z0-9]/g, '-')}`;
+
+    // Minimal workflow that suspends via condition(signalId, config),
+    // writing one hmsh_escalations row in the hook Leg1 transaction.
+    async function conditionWorkflow(orderId: string): Promise<unknown> {
+      const signalId = `cond-${Durable.guid()}`;
+      return Durable.workflow.condition(signalId, {
+        role: 'reviewer',
+        type: 'event-test-approval',
+        priority: 1,
+        metadata: { orderId },
+      });
+    }
+
+    it('Worker.create with events fires system.escalation.{id}.created on condition()', async () => {
+      const orderId = guid();
+      // In a real multi-engine fleet, every process registers the same events hook.
+      // Here both the client and worker share one publisher so exactly one engine
+      // fires the created event regardless of which one wins the dispatch race.
+      const sharedPublish = (e: SystemEvent) => { collected.push(e); };
+
+      // Start the workflow first (queues it). Pass events so this engine also
+      // has eventsPublish set — whichever engine processes the hook will emit.
+      const client = new Durable.Client({
+        connection,
+        events: { publish: sharedPublish },
+      });
+      const handle = await client.workflow.start({
+        args: [orderId],
+        taskQueue,
+        workflowName: 'conditionWorkflow',
+        workflowId: guid(),
+      });
+      expect(handle.workflowId).toBeDefined();
+
+      // Create worker with the same events publisher — this is the fix being proved
+      const worker = await Durable.Worker.create({
+        connection,
+        taskQueue,
+        workflow: conditionWorkflow,
+        events: { publish: sharedPublish },
+      });
+      await worker.run();
+
+      // Allow the workflow to reach condition() and write the escalation row
+      await sleepFor(4000);
+
+      const createdEvt = collected.find(e =>
+        e.type.endsWith('.created') && (e.data as any)?.metadata?.orderId === orderId
+      );
+      expect(createdEvt).toBeTruthy();
+      expect(createdEvt!.type).toMatch(/^system\.escalation\..+\.created$/);
+      expect((createdEvt!.data as any).role).toBe('reviewer');
+      expect((createdEvt!.data as any).type).toBe('event-test-approval');
+      expect((createdEvt!.data as any).signal_key).not.toBeNull();
+      expect((createdEvt!.data as any).workflow_id).toBeDefined();
+      expect(createdEvt!.event_id).toMatch(/^[^:]+:created:/);
     }, 20_000);
   });
 });


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `Worker.create` and `Durable.Client` both create internal `HotMesh.init` instances that lacked `events` wiring. When a `condition(signalId, queueConfig)` workflow suspends, the hook Leg1 `created` event was silently dropped because the engine that won the dispatch race had no `eventsPublish` set.
- **Fix in `worker.ts`**: `events: config.events` added to all three `HotMesh.init` call sites (`registerActivityWorker`, `initActivityWorker`, `initWorkflowWorker`).
- **Fix in `client.ts`**: `events` stored on `ClientService` and passed to its internal `HotMesh.init`. In a multi-engine fleet, exactly one engine processes each hook activity — whichever wins emits via its own `eventsPublish`. Both client and worker engines now carry the hook so the event fires regardless of which wins.
- **Scenario F test**: proves `Worker.create({ events })` fires `system.escalation.{id}.created` when a workflow calls `condition(signalId, queueConfig)`. Both client and worker share a single publisher so exactly one `created` event lands in `collected`.
- **Docs**: `docs/quickstart.md` gains "The Simplest Escalation Flow" — full YAML DAG `hook` + `escalation:` block pattern with query / claim / signal / resolve lifecycle code.

## Test plan

- [x] `npm run prove:events` — 18/18 pass (Scenarios A–F all green)
- [x] `npm run prove` — 377/377 pass, 31 test files
- [x] `npx tsc --noEmit` — zero errors
- [x] Version bumped to 0.22.5 in `package.json` + `package-lock.json`