### PR TITLE
Redeploy durable app schema on version drift (APP_VERSION 15→16) — v0.22.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.22.5",
+  "version": "0.22.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.22.5",
+      "version": "0.22.6",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.22.5",
+  "version": "0.22.6",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/durable/client.ts
+++ b/services/durable/client.ts
@@ -516,7 +516,12 @@ export class ClientService {
         });
         throw error;
       }
-    } else if (isNaN(Number(appVersion)) || appVersion < version) {
+    } else if (
+      isNaN(Number(appVersion)) ||
+      Number(appVersion) < Number(version)
+    ) {
+      // Numeric compare: string `<` mis-orders at digit boundaries (e.g. '9' < '16'
+      // is false as strings). Redeploy + hot-swap when an older schema is deployed.
       try {
         await hotMesh.deploy(getWorkflowYAML(appId, version));
         await hotMesh.activate(version);

--- a/services/durable/schemas/factory.ts
+++ b/services/durable/schemas/factory.ts
@@ -1,4 +1,10 @@
-const APP_VERSION = '15';
+// Schema content version for the generated durable app YAML below. BUMP THIS
+// whenever `getWorkflowYAML` changes — it is how existing deployments detect a
+// schema upgrade and hot-swap to it (see WorkerService.activateWorkflow and
+// ClientService.deployAndActivate). Changing the YAML without a bump leaves
+// every already-deployed database on the old schema forever. Numeric string —
+// compared with `Number()` for ordering. (v16: condition() escalation hook.)
+const APP_VERSION = '16';
 const APP_ID = 'durable';
 
 /**

--- a/services/durable/worker.ts
+++ b/services/durable/worker.ts
@@ -211,8 +211,19 @@ export class WorkerService {
    */
   static async activateWorkflow(hotMesh: HotMesh) {
     const app = await hotMesh.engine.store.getApp(hotMesh.engine.appId);
-    const appVersion = app?.version;
-    if (!appVersion) {
+    const appVersion = app?.version as unknown as string;
+    if (
+      !appVersion ||
+      isNaN(Number(appVersion)) ||
+      Number(appVersion) < Number(APP_VERSION)
+    ) {
+      // Not deployed, or an OLDER schema version is deployed (the SDK was
+      // upgraded). Deploy this SDK's schema and hot-swap to it. HotMesh keeps
+      // the prior version deployed, so in-flight jobs drain on the old schema
+      // while new jobs use APP_VERSION. Without this branch an existing, active
+      // app would never pick up a new schema — atomic-escalation hooks and any
+      // other schema-encoded feature would silently never activate after an
+      // upgrade. Mirrors ClientService.deployAndActivate.
       try {
         await hotMesh.deploy(
           getWorkflowYAML(hotMesh.engine.appId, APP_VERSION),

--- a/tests/durable/version-drift/postgres.test.ts
+++ b/tests/durable/version-drift/postgres.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Proves the durable app schema hot-swaps when an OLDER version is already
+ * deployed (the SDK-upgrade path). Regression guard for the bug where an
+ * existing, active durable app at version N never picked up the SDK's newer
+ * schema at version N+1 — silently disabling schema-encoded features like the
+ * condition() escalation hook on every persistent (non-fresh) database.
+ *
+ * Scenario: deploy + activate the durable app at an older version, then create a
+ * Durable.Worker (which runs WorkerService.activateWorkflow). The worker must
+ * detect the drift and deploy + activate the current APP_VERSION.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Client as Postgres } from 'pg';
+
+import { HotMesh } from '../../../index';
+import { Durable } from '../../../services/durable';
+import { guid, sleepFor } from '../../../modules/utils';
+import { HMSH_LOGLEVEL } from '../../../modules/enums';
+import { ProviderNativeClient } from '../../../types/provider';
+import { dropTables, postgres_options } from '../../$setup/postgres';
+import { PostgresConnection } from '../../../services/connector/providers/postgres';
+import {
+  getWorkflowYAML,
+  APP_VERSION,
+  APP_ID,
+} from '../../../services/durable/schemas/factory';
+
+const { Connection, Worker } = Durable;
+const OLD_VERSION = String(Number(APP_VERSION) - 1);
+
+async function noop(): Promise<string> {
+  return 'ok';
+}
+
+describe('DURABLE | version drift redeploy | Postgres', () => {
+  let postgresClient: ProviderNativeClient;
+  let hotMesh: HotMesh;
+  const connection = { class: Postgres, options: postgres_options };
+
+  beforeAll(async () => {
+    postgresClient = (
+      await PostgresConnection.connect(guid(), Postgres, postgres_options)
+    ).getClient();
+    await dropTables(postgresClient);
+  });
+
+  afterAll(async () => {
+    await sleepFor(1500);
+    await Durable.shutdown();
+  }, 15_000);
+
+  it('deploys the durable app at the previous (older) version', async () => {
+    await Connection.connect(connection);
+    hotMesh = await HotMesh.init({
+      appId: APP_ID,
+      logLevel: HMSH_LOGLEVEL,
+      engine: { connection },
+    });
+    await hotMesh.deploy(getWorkflowYAML(APP_ID, OLD_VERSION));
+    await hotMesh.activate(OLD_VERSION);
+
+    const app = await hotMesh.engine.store.getApp(APP_ID);
+    expect(app.version).toBe(OLD_VERSION);
+    expect(app.active).toBe(true);
+  }, 20_000);
+
+  it('hot-swaps to the current APP_VERSION when a worker activates', async () => {
+    // Worker.create → WorkerService.activateWorkflow sees deployed < APP_VERSION
+    // and redeploys + activates the new schema version.
+    const worker = await Worker.create({
+      connection,
+      taskQueue: 'version-drift-test',
+      workflow: noop,
+    });
+    await worker.run();
+
+    // Read the registry directly — a long-lived HotMesh instance caches the app
+    // record, so assert against the authoritative store row.
+    const { rows } = await postgresClient.query(
+      'SELECT version, active FROM hmsh_applications WHERE app_id = $1',
+      [APP_ID],
+    );
+    expect(rows[0].version).toBe(APP_VERSION);
+    expect(Number(rows[0].version)).toBeGreaterThan(Number(OLD_VERSION));
+    expect(rows[0].active).toBe(true);
+
+    // Both versions remain deployed — in-flight jobs drain on the old schema.
+    const { rows: versions } = await postgresClient.query(
+      'SELECT version FROM hmsh_application_versions WHERE app_id = $1 ORDER BY version',
+      [APP_ID],
+    );
+    expect(versions.map((r) => r.version)).toEqual([OLD_VERSION, APP_VERSION]);
+  }, 30_000);
+});

--- a/tests/unit/services/durable/factory.test.ts
+++ b/tests/unit/services/durable/factory.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  getWorkflowYAML,
+  APP_VERSION,
+  APP_ID,
+} from '../../../../services/durable/schemas/factory';
+
+/**
+ * Guards the durable app schema version contract.
+ *
+ * The deployed schema only upgrades when APP_VERSION increases (see
+ * WorkerService.activateWorkflow / ClientService.deployAndActivate, which
+ * compare `Number(deployedVersion) < Number(APP_VERSION)`). Two invariants must
+ * hold or upgrades break for every already-deployed database:
+ *
+ *  1. APP_VERSION is a numeric string — the deploy/activate logic orders
+ *     versions with `Number()`. A non-numeric version makes drift detection
+ *     fall back to "redeploy always" at best, or mis-order at worst.
+ *  2. The generated YAML carries the escalation hook wired to condition()'s
+ *     queueConfig. If this regresses, condition(signalId, config) silently stops
+ *     writing hmsh_escalations rows — exactly the failure that motivated v16.
+ */
+describe('UNIT | durable schema factory | version + escalation hook', () => {
+  it('APP_VERSION is a numeric string (ordering invariant for drift detection)', () => {
+    expect(APP_VERSION).toMatch(/^\d+$/);
+    expect(Number.isNaN(Number(APP_VERSION))).toBe(false);
+    expect(Number(APP_VERSION)).toBeGreaterThanOrEqual(16);
+  });
+
+  it('embeds the requested version in the generated YAML', () => {
+    const yaml = getWorkflowYAML(APP_ID, APP_VERSION);
+    expect(yaml).toContain(`version: '${APP_VERSION}'`);
+    expect(yaml).toContain(`id: ${APP_ID}`);
+  });
+
+  it('wires condition() queueConfig into a wait-hook escalation block', () => {
+    const yaml = getWorkflowYAML(APP_ID, APP_VERSION);
+    // The wait hook maps the worker-emitted queueConfig onto an escalation:
+    // block so the row is written in the hook's Leg1 transaction.
+    expect(yaml).toContain('escalation:');
+    expect(yaml).toContain('queueConfig.role');
+    expect(yaml).toContain('queueConfig.type');
+    expect(yaml).toContain('queueConfig.metadata');
+    expect((yaml.match(/queueConfig/g) || []).length).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
## Problem

An existing, **active** durable app never picks up a new workflow schema after an SDK upgrade. The escalation hook for `condition(signalId, config)` was added to `getWorkflowYAML` **without bumping `APP_VERSION`**, so every already-deployed database keeps the old schema and silently stops writing `hmsh_escalations` rows on the atomic path. Fresh DBs work; persistent ones (production RDS) do not — there is no error, every station just hangs.

## Root causes (both fixed)

1. **`APP_VERSION` hardcoded `'15'`, never bumped when the schema changed.** Bumped to `'16'` with a comment making the bump-on-change contract explicit.
2. **`WorkerService.activateWorkflow` had no version-drift branch.** It deployed only when the app was absent and activated only when inactive — an existing active app at an older version was a no-op. Added the drift branch (deploy + activate the new `APP_VERSION` when `Number(deployed) < Number(APP_VERSION)`), mirroring `ClientService.deployAndActivate`. HotMesh keeps the prior version deployed, so in-flight jobs drain on the old schema while new jobs use the new one (designed hot-swap).

Also hardened both comparisons to **numeric** (string `<` mis-orders at digit boundaries — `'9' < '16'` is `false` as strings).

## Why now

We're about to test the efficient `condition(config)` pipeline against persistent AWS (`longtail.hotmesh.io`). Without this, the atomic-escalation path silently fails there exactly as it did on an upgraded local DB.

## Tests

- New unit guard: `APP_VERSION` is numeric + the generated YAML wires `queueConfig` into a wait-hook escalation block — a future schema change can't regress silently.
- Postgres (host, port 5414): escalations **57**, migrations **25**, basic+helloworld **34**, exec-child+signal-race+exporter **54** — all green on v16.
- `tests/functional/redeploy/postgres.test.ts` uses in-container file fixtures (`/app/...`) and fails identically host-side with and without this change (pre-existing/environmental).