### PR TITLE
Fix startup version race (getVID locks in stale schema)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.22.6",
+  "version": "0.22.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.22.6",
+      "version": "0.22.7",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.22.6",
+  "version": "0.22.7",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/engine/version.ts
+++ b/services/engine/version.ts
@@ -66,10 +66,20 @@ export async function getVID(
       setCacheMode(instance, 'cache', app.version.toString());
     }
     return { id: instance.appId, version: app.version };
-  } else if (!instance.apps && vid) {
-    instance.apps = {};
-    instance.apps[instance.appId] = vid;
-    return vid;
+  } else if (!instance.apps) {
+    // First call — always DB-refresh to avoid locking in a stale version.
+    // The `vid` parameter originates from store.getApp() (which may be
+    // cached from before the last activation).  If a worker missed the
+    // nocache NOTIFY (startup race: LISTEN not yet established when the
+    // NOTIFY fired), it would lock in the pre-activation version for its
+    // entire lifetime, silently loading the old schema on every request.
+    // One extra DB query here, once per engine lifetime, eliminates the
+    // race regardless of NOTIFY delivery.
+    const id = vid?.id ?? instance.appId;
+    const freshApp = await instance.store.getApp(id, true);
+    if (!instance.apps) instance.apps = {};
+    instance.apps[instance.appId] = freshApp;
+    return { id: freshApp.id, version: freshApp.version };
   } else {
     return await fetchAndVerifyVID(instance, {
       id: instance.appId,

--- a/tests/unit/services/engine/version.test.ts
+++ b/tests/unit/services/engine/version.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression guard for the engine startup version race.
+ *
+ * Scenario: a worker starts during (or just before) a schema hot-swap.
+ * The schema is activated and a NOTIFY is broadcast, but the worker misses
+ * it (LISTEN not yet established on the eventClient).  The first call to
+ * getVID() is triggered from getSchema(), which passes the `app` object it
+ * got from store.getApp() — but that object came from the store's own
+ * in-memory cache, which was populated before the activation committed.
+ *
+ * Before the fix: getVID() locked in the stale version from the `vid`
+ * parameter without querying the DB, so the worker loaded the old schema
+ * for its entire lifetime.  In the long-tail incident this meant the v15
+ * schema (no `escalation:` block) was used → `this.config.escalation` was
+ * undefined → PATH 1 silent-return in addEscalationToTransaction → zero
+ * escalation rows written for ~41% of requests (one of two workers stuck).
+ *
+ * After the fix: getVID() always DB-refreshes on first initialization,
+ * ignoring the stale `vid` parameter.  One extra query per engine lifetime.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { getVID } from '../../../../services/engine/version';
+
+const makeInstance = (
+  freshVersion: string,
+  appId = 'test-app',
+): { instance: Parameters<typeof getVID>[0]; mockGetApp: ReturnType<typeof vi.fn> } => {
+  const mockGetApp = vi.fn().mockResolvedValue({
+    id: appId,
+    version: freshVersion,
+    active: true,
+  });
+
+  const instance = {
+    appId,
+    guid: 'test-guid',
+    apps: null as any,
+    cacheMode: 'cache' as const,
+    untilVersion: null as any,
+    store: { getApp: mockGetApp } as any,
+    logger: {
+      info: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+    } as any,
+  };
+
+  return { instance, mockGetApp };
+};
+
+describe('engine/version | getVID | startup race', () => {
+  it('refreshes from DB on first lock-in, ignoring stale vid parameter', async () => {
+    const STALE_VERSION = '15';
+    const FRESH_VERSION = '16';
+    const { instance, mockGetApp } = makeInstance(FRESH_VERSION);
+
+    // Simulate what getSchema() does: it calls store.getApp() (which may be
+    // stale/cached), gets the old version, then passes it to engine.getVID().
+    const staleVid = { id: 'test-app', version: STALE_VERSION };
+    const result = await getVID(instance, staleVid);
+
+    // Must return the fresh DB version, not the stale vid.
+    expect(result.version).toBe(FRESH_VERSION);
+
+    // Must have done a DB read with refresh=true to confirm the version.
+    expect(mockGetApp).toHaveBeenCalledWith('test-app', true);
+  });
+
+  it('does not issue extra DB queries when apps is already initialized', async () => {
+    const CACHED_VERSION = '16';
+    const { instance, mockGetApp } = makeInstance(CACHED_VERSION);
+
+    // Pre-initialize apps (simulates all subsequent calls after first lock-in).
+    instance.apps = {
+      'test-app': { id: 'test-app', version: CACHED_VERSION, active: true } as any,
+    };
+
+    const result = await getVID(instance);
+
+    expect(result.version).toBe(CACHED_VERSION);
+    // No DB query — version already locked in and current.
+    expect(mockGetApp).not.toHaveBeenCalled();
+  });
+
+  it('refreshes on every call in nocache mode until untilVersion is reached', async () => {
+    const FRESH_VERSION = '16';
+    const { instance, mockGetApp } = makeInstance(FRESH_VERSION);
+
+    instance.cacheMode = 'nocache';
+    instance.untilVersion = FRESH_VERSION;
+
+    const result = await getVID(instance);
+
+    expect(result.version).toBe(FRESH_VERSION);
+    expect(mockGetApp).toHaveBeenCalledWith('test-app', true);
+    // Once the target version is confirmed the engine switches back to cache mode.
+    expect(instance.cacheMode).toBe('cache');
+  });
+});


### PR DESCRIPTION
## Summary

- Workers that start during (or just before) a schema hot-swap can miss the quorum `NOTIFY` (their `LISTEN` is not yet established when the `NOTIFY` fires). Before this fix, `getVID()` locked in the stale version passed via the `vid` parameter — which comes from `store.getApp()`, whose in-memory cache was populated before the activation committed — for the engine's entire lifetime.
- In production this caused ~41% of `printerEfficient` workflows to create zero `hmsh_escalations` rows: the worker loaded the v15 schema (no `escalation:` block), `this.config.escalation` was `undefined`, and `addEscalationToTransaction()` took the silent-null PATH 1 return on every request.
- Fix: `getVID()` now always does `store.getApp(id, true)` (DB-refresh, bypass cache) on the first version lock-in, ignoring the stale `vid` parameter. One extra query per engine lifetime.

## Test plan

- [ ] `tests/unit/services/engine/version.test.ts` — 3 new tests; fail-first confirmed (returned `'15'` before fix, `'16'` after)
- [ ] Full durable suite — 379/379 pass
- [ ] `npx tsc --noEmit` — zero errors