### PR TITLE
Collator-waiter escalations, Promise.all lineage, opt-in export pointer (v0.23.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.22.8",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.22.8",
+      "version": "0.23.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.22.8",
+  "version": "0.23.0",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/durable/exporter.ts
+++ b/services/durable/exporter.ts
@@ -350,6 +350,15 @@ class ExporterService {
       await this.enrichExecutionInputs(execution, jobId);
     }
 
+    // Opt-in upward lineage pointer — one indexed lookup; surfaces the real
+    // spawning parent (not the collator $C job) and the root ancestor.
+    if (options.include_lineage && this.store.getJobLineage) {
+      const jobKey = `hmsh:${this.appId}:j:${jobId}`;
+      const lineage = await this.store.getJobLineage(jobKey);
+      execution.parent_workflow_id = lineage?.parent_id ?? null;
+      execution.origin_id = lineage?.origin_id ?? null;
+    }
+
     return execution;
   }
 

--- a/services/durable/schemas/factory.ts
+++ b/services/durable/schemas/factory.ts
@@ -3,8 +3,9 @@
 // schema upgrade and hot-swap to it (see WorkerService.activateWorkflow and
 // ClientService.deployAndActivate). Changing the YAML without a bump leaves
 // every already-deployed database on the old schema forever. Numeric string —
-// compared with `Number()` for ordering. (v16: condition() escalation hook.)
-const APP_VERSION = '16';
+// compared with `Number()` for ordering. (v17: collator_waiter escalation block —
+// escalation-bearing condition() inside Promise.all writes its hmsh_escalations row.)
+const APP_VERSION = '17';
 const APP_ID = 'durable';
 
 /**
@@ -1940,6 +1941,49 @@ const getWorkflowYAML = (app: string, version: string): string => {
               - ['{collator_trigger.output.data.items}', '{collator_cycle_hook.output.data.cur_index}']
               - ['{@array.get}', duration]
               - ['{@object.get}']
+          # Flatten the CURRENT item's escalation config into this activity's own
+          # output so the escalation block below can address it with flat symbols.
+          # mapOutputData runs before the escalation INSERT in Leg1, so these are
+          # resolved in time. For a plain (non-escalation) collated condition these
+          # resolve to undefined and the INSERT is skipped, just like the inline waiter.
+          output:
+            maps:
+              queueConfig:
+                '@pipe':
+                  - ['{collator_trigger.output.data.items}', '{collator_cycle_hook.output.data.cur_index}']
+                  - ['{@array.get}', queueConfig]
+                  - ['{@object.get}']
+              taskQueue:
+                '@pipe':
+                  - ['{collator_trigger.output.data.items}', '{collator_cycle_hook.output.data.cur_index}']
+                  - ['{@array.get}', taskQueue]
+                  - ['{@object.get}']
+              workflowName:
+                '@pipe':
+                  - ['{collator_trigger.output.data.items}', '{collator_cycle_hook.output.data.cur_index}']
+                  - ['{@array.get}', workflowName]
+                  - ['{@object.get}']
+          # Identical in principle to the inline waiter escalation block, but sourced
+          # from the collated item. The escalation signal_key is auto-derived from this
+          # activity's reentry hook rule (wfs.signal, matching item.signalId), so resolve()
+          # and signal() — which double-fire wfs.signal + wfs.wait — reach it correctly.
+          escalation:
+            type: '{$self.output.data.queueConfig.type}'
+            subtype: '{$self.output.data.queueConfig.subtype}'
+            entity: '{$self.output.data.queueConfig.entity}'
+            description: '{$self.output.data.queueConfig.description}'
+            role: '{$self.output.data.queueConfig.role}'
+            priority: '{$self.output.data.queueConfig.priority}'
+            metadata: '{$self.output.data.queueConfig.metadata}'
+            envelope: '{$self.output.data.queueConfig.envelope}'
+            originId: '{$self.output.data.queueConfig.originId}'
+            parentId: '{$self.output.data.queueConfig.parentId}'
+            initiatedBy: '{$self.output.data.queueConfig.initiatedBy}'
+            traceId: '{$self.output.data.queueConfig.traceId}'
+            spanId: '{$self.output.data.queueConfig.spanId}'
+            expiresAt: '{$self.output.data.queueConfig.expiresAt}'
+            taskQueue: '{$self.output.data.taskQueue}'
+            workflowType: '{$self.output.data.workflowName}'
           hook:
             type: object
             properties:

--- a/services/durable/workflow/condition.ts
+++ b/services/durable/workflow/condition.ts
@@ -184,7 +184,16 @@ export async function condition<T>(
     type: 'DurableWaitForError',
     code: HMSH_CODE_DURABLE_WAIT,
     ...(timeout ? { duration: s(timeout) } : {}),
-    ...(queueConfig ? { queueConfig } : {}),
+    // taskQueue + workflowName ride along so a collated wait (Promise.all) can
+    // write a faithful hmsh_escalations row from inside the collator flow —
+    // matching the inline waiter, which sources these from its trigger.
+    ...(queueConfig
+      ? {
+          queueConfig,
+          taskQueue: store.get('taskQueue'),
+          workflowName: store.get('workflowName'),
+        }
+      : {}),
   };
   interruptionRegistry.push(interruptionMessage);
 

--- a/services/store/index.ts
+++ b/services/store/index.ts
@@ -321,6 +321,20 @@ abstract class StoreService<
     };
     attributes: Record<string, string>;
   }>;
+
+  /**
+   * Fetch just the lineage columns (`parent_id`, `origin_id`) for a job via a
+   * single indexed lookup on `key`. Powers the exporter's opt-in
+   * `include_lineage` pointer — `parent_id` is the real spawning workflow (never
+   * the synthetic collator `$C` job), `origin_id` is the root ancestor.
+   *
+   * @param jobKey - The job key (e.g., "hmsh:durable:j:workflowId")
+   * @returns parent/origin ids (null when absent — a null `parent_id` marks a root)
+   */
+  getJobLineage?(jobKey: string): Promise<{
+    parent_id: string | null;
+    origin_id: string | null;
+  } | null>;
 }
 
 export { StoreService };

--- a/services/store/providers/postgres/exporter-sql.ts
+++ b/services/store/providers/postgres/exporter-sql.ts
@@ -14,6 +14,17 @@ export const GET_JOB_BY_KEY = `
 `;
 
 /**
+ * Fetch just the lineage columns for a job — a single indexed lookup on `key`.
+ * Backs the exporter's opt-in `include_lineage` pointer.
+ */
+export const GET_JOB_LINEAGE = `
+  SELECT parent_id, origin_id
+  FROM {schema}.jobs
+  WHERE key = $1
+  LIMIT 1
+`;
+
+/**
  * Fetch all attributes for a job.
  */
 export const GET_JOB_ATTRIBUTES = `

--- a/services/store/providers/postgres/postgres.ts
+++ b/services/store/providers/postgres/postgres.ts
@@ -1786,6 +1786,23 @@ class PostgresStoreService extends StoreService<
   }
 
   /**
+   * Single indexed lookup of the lineage columns for a job key. Returns the real
+   * spawning parent (never the synthetic collator `$C` job) and the root ancestor.
+   */
+  async getJobLineage(jobKey: string): Promise<{
+    parent_id: string | null;
+    origin_id: string | null;
+  } | null> {
+    const { GET_JOB_LINEAGE } = await import('./exporter-sql');
+    const schemaName = this.kvsql().safeName(this.appId);
+    const sql = GET_JOB_LINEAGE.replace(/{schema}/g, schemaName);
+    const result = await this.pgClient.query(sql, [jobKey]);
+    if (result.rows.length === 0) return null;
+    const { parent_id, origin_id } = result.rows[0];
+    return { parent_id: parent_id ?? null, origin_id: origin_id ?? null };
+  }
+
+  /**
    * Fetch stream message history for a job from worker_streams.
    * Returns raw activity input/output data from soft-deleted messages.
    */

--- a/tests/durable/basic/postgres.test.ts
+++ b/tests/durable/basic/postgres.test.ts
@@ -54,6 +54,16 @@ describe('DURABLE | baseline | Postgres', () => {
       workflows.testSignalThenStartChild,
       workflows.testParallelChildren,
       workflows.testSignalThenParallelChildren,
+      workflows.childWaitFor,
+      workflows.testParallelConditionChildren,
+      workflows.testParallelConditions,
+      workflows.testConditionPlusProxy,
+      workflows.testConditionPlusChild,
+      workflows.testConditionEscalationPlusProxy,
+      workflows.testLineageChild,
+      workflows.testLineageRoot,
+      workflows.testLineageCollator,
+      workflows.testLineageCollatorNested,
     ];
     for (const wf of workflowFunctions) {
       const worker = await Worker.create({
@@ -319,6 +329,245 @@ describe('DURABLE | baseline | Postgres', () => {
       expect(result).toBeDefined();
       expect((result as any).jobId).toBeDefined();
     }, 25_000);
+  });
+
+  describe('Feature: Promise.all(executeChild) — each child a condition, external signals', () => {
+    it('collects parallel condition-children when each is signaled externally', async () => {
+      const handle = await client.workflow.start({
+        args: ['HotMesh'],
+        taskQueue,
+        workflowName: 'testParallelConditionChildren',
+        workflowId: 'test-par-cond-children-' + guid(),
+        expire: 120,
+      });
+      // Let both child workflows reach their condition(), then signal each directly by its
+      // fixed workflowId. The parent's Promise.all(executeChild) must collect both and return.
+      await sleepFor(3_000);
+      const childA = await client.workflow.getHandle(taskQueue, 'childWaitFor', 'cond-child-a');
+      await childA.signal('child-sig-a', { ok: 'a' });
+      const childB = await client.workflow.getHandle(taskQueue, 'childWaitFor', 'cond-child-b');
+      await childB.signal('child-sig-b', { ok: 'b' });
+      const result = await handle.result();
+      expect((result as any).a).toEqual({ ok: 'a' });
+      expect((result as any).b).toEqual({ ok: 'b' });
+    }, 25_000);
+  });
+
+  describe('Feature: collator_waiter — Promise.all with a direct condition()', () => {
+    it('collects two parallel direct conditions through the collator flow', async () => {
+      const sigA = 'par-cond-a-' + guid();
+      const sigB = 'par-cond-b-' + guid();
+      const handle = await client.workflow.start({
+        args: [sigA, sigB],
+        taskQueue,
+        workflowName: 'testParallelConditions',
+        workflowId: 'test-par-conditions-' + guid(),
+        expire: 120,
+      });
+      // Both conditions register in the collator flow; signal each by its id.
+      await sleepFor(3_000);
+      await handle.signal(sigA, { v: 'a' });
+      await handle.signal(sigB, { v: 'b' });
+      const result = await handle.result();
+      expect((result as any).a).toEqual({ v: 'a' });
+      expect((result as any).b).toEqual({ v: 'b' });
+    }, 25_000);
+
+    it('collects a condition() alongside a proxyActivity() in one Promise.all', async () => {
+      const sig = 'cp-sig-' + guid();
+      const handle = await client.workflow.start({
+        args: ['HotMesh', sig],
+        taskQueue,
+        workflowName: 'testConditionPlusProxy',
+        workflowId: 'test-cond-proxy-' + guid(),
+        expire: 120,
+      });
+      await sleepFor(3_000);
+      await handle.signal(sig, { ok: true });
+      const result = await handle.result();
+      expect((result as any).waited).toEqual({ ok: true });
+      expect((result as any).greeting).toEqual({ complex: 'Basic, HotMesh!' });
+    }, 25_000);
+
+    it('collects a condition() alongside an executeChild() in one Promise.all', async () => {
+      const sig = 'cc-sig-' + guid();
+      const handle = await client.workflow.start({
+        args: ['HotMesh', sig],
+        taskQueue,
+        workflowName: 'testConditionPlusChild',
+        workflowId: 'test-cond-child-' + guid(),
+        expire: 120,
+      });
+      await sleepFor(3_000);
+      await handle.signal(sig, { ok: 'child' });
+      const result = await handle.result();
+      expect((result as any).waited).toEqual({ ok: 'child' });
+      expect((result as any).childDone).toBe(true);
+    }, 25_000);
+  });
+
+  describe('Feature: collator_waiter — Promise.all with an escalation-bearing condition()', () => {
+    it('writes the escalation row for a collated condition and resolves it', async () => {
+      const orderId = 'collator-order-' + guid();
+      const role = 'collator-approver-' + guid();
+      const handle = await client.workflow.start({
+        args: ['HotMesh', orderId, role],
+        taskQueue,
+        workflowName: 'testConditionEscalationPlusProxy',
+        workflowId: 'test-cond-esc-' + guid(),
+        expire: 120,
+      });
+      // Let the collated condition() suspend and write its hmsh_escalations row.
+      await sleepFor(3_000);
+      const list = await client.escalations.list({ role, status: 'pending' });
+      const esc = list.find((e) => (e.metadata as any)?.orderId === orderId);
+      expect(esc).toBeDefined();
+      expect(esc!.type).toBe('collator-escalation');
+      // Resolving the escalation must resume the collated wait (double-fires wfs.signal + wfs.wait).
+      await client.escalations.resolve({ id: esc!.id, resolverPayload: { approved: true } });
+      const result = await handle.result();
+      expect((result as any).decision).toEqual({ approved: true });
+      expect((result as any).greeting).toEqual({ complex: 'Basic, HotMesh!' });
+    }, 30_000);
+  });
+
+  describe('Feature: job lineage — parent_id / origin_id authored into the jobs table', () => {
+    const jobKey = (wfid: string) => `hmsh:durable:j:${wfid}`;
+    const lineageOf = async (wfid: string) => {
+      const { rows } = await postgresClient.query(
+        `SELECT key, parent_id, origin_id FROM durable.jobs WHERE key = $1`,
+        [jobKey(wfid)],
+      );
+      return rows[0];
+    };
+
+    it('records parent_id/origin_id across a 3-level composition (childer path)', async () => {
+      const rootId = 'lineage-root-' + guid();
+      const childId = 'lineage-child-' + guid();
+      const grandchildId = 'lineage-gc-' + guid();
+      const handle = await client.workflow.start({
+        args: [childId, grandchildId],
+        taskQueue,
+        workflowName: 'testLineageRoot',
+        workflowId: rootId,
+        expire: 120,
+      });
+      await handle.result();
+      const root = await lineageOf(rootId);
+      const child = await lineageOf(childId);
+      const grand = await lineageOf(grandchildId);
+      // Root has no parent — anything without a parent_id is a root for lineage reconstruction.
+      expect(root).toBeDefined();
+      expect(root.parent_id ?? null).toBeNull();
+      // Child: direct parent is the root; origin is the root.
+      expect(child.parent_id).toBe(rootId);
+      expect(child.origin_id).toBe(rootId);
+      // Grandchild: direct parent is the child; origin stays pinned to the root.
+      expect(grand.parent_id).toBe(childId);
+      expect(grand.origin_id).toBe(rootId);
+    }, 30_000);
+
+    it('records parent_id/origin_id for a collated child (collator_childer path)', async () => {
+      const rootId = 'lineage-col-root-' + guid();
+      const childId = 'lineage-col-child-' + guid();
+      const sig = 'lineage-col-sig-' + guid();
+      const handle = await client.workflow.start({
+        args: [childId, sig],
+        taskQueue,
+        workflowName: 'testLineageCollator',
+        workflowId: rootId,
+        expire: 120,
+      });
+      await sleepFor(2_000);
+      await handle.signal(sig, { ok: true });
+      await handle.result();
+      const child = await lineageOf(childId);
+      // The spawning workflow is the parent — NOT the synthetic collator ($C) job.
+      expect(child.parent_id).toBe(rootId);
+      expect(child.origin_id).toBe(rootId);
+      expect(child.parent_id).not.toContain('$C');
+    }, 30_000);
+
+    it('nests lineage THROUGH the collator: a collated child spawns its own grandchild', async () => {
+      const rootId = 'lineage-cn-root-' + guid();
+      const childId = 'lineage-cn-child-' + guid();
+      const grandchildId = 'lineage-cn-gc-' + guid();
+      const sig = 'lineage-cn-sig-' + guid();
+      const handle = await client.workflow.start({
+        args: [childId, grandchildId, sig],
+        taskQueue,
+        workflowName: 'testLineageCollatorNested',
+        workflowId: rootId,
+        expire: 120,
+      });
+      await sleepFor(2_000);
+      await handle.signal(sig, { ok: true });
+      await handle.result();
+      const child = await lineageOf(childId);
+      const grand = await lineageOf(grandchildId);
+      // The collated child's parent is the root (it passed through the collator, not absorbed it).
+      expect(child.parent_id).toBe(rootId);
+      expect(child.origin_id).toBe(rootId);
+      expect(child.parent_id).not.toContain('$C');
+      // The grandchild was spawned by the collated child — lineage keeps chaining through the
+      // collator, with origin still pinned to the root.
+      expect(grand.parent_id).toBe(childId);
+      expect(grand.origin_id).toBe(rootId);
+      expect(grand.parent_id).not.toContain('$C');
+    }, 30_000);
+
+    it('exposes the opt-in upward lineage pointer on export (real parent, not the collator)', async () => {
+      const rootId = 'lineage-exp-root-' + guid();
+      const childId = 'lineage-exp-child-' + guid();
+      const grandchildId = 'lineage-exp-gc-' + guid();
+      const rootHandle = await client.workflow.start({
+        args: [childId, grandchildId],
+        taskQueue,
+        workflowName: 'testLineageRoot',
+        workflowId: rootId,
+        expire: 120,
+      });
+      await rootHandle.result();
+
+      // Root: no parent pointer (it IS the root); origin is null for a root.
+      const rootExec = await rootHandle.exportExecution({ include_lineage: true });
+      expect(rootExec.parent_workflow_id ?? null).toBeNull();
+      expect(rootExec.origin_id ?? null).toBeNull();
+
+      // Child: parent points to the root, origin is the root.
+      const childHandle = await client.workflow.getHandle(taskQueue, 'testLineageChild', childId);
+      const childExec = await childHandle.exportExecution({ include_lineage: true });
+      expect(childExec.parent_workflow_id).toBe(rootId);
+      expect(childExec.origin_id).toBe(rootId);
+
+      // Backwards-compatible default: without the opt-in, the pointer is absent.
+      const childExecDefault = await childHandle.exportExecution();
+      expect(childExecDefault.parent_workflow_id).toBeUndefined();
+      expect(childExecDefault.origin_id).toBeUndefined();
+    }, 30_000);
+
+    it('export lineage pointer skips the collator for a collated child', async () => {
+      const rootId = 'lineage-exp-col-root-' + guid();
+      const childId = 'lineage-exp-col-child-' + guid();
+      const sig = 'lineage-exp-col-sig-' + guid();
+      const rootHandle = await client.workflow.start({
+        args: [childId, sig],
+        taskQueue,
+        workflowName: 'testLineageCollator',
+        workflowId: rootId,
+        expire: 120,
+      });
+      await sleepFor(2_000);
+      await rootHandle.signal(sig, { ok: true });
+      await rootHandle.result();
+
+      const childHandle = await client.workflow.getHandle(taskQueue, 'childExample', childId);
+      const childExec = await childHandle.exportExecution({ include_lineage: true });
+      // The pointer is the spawning workflow, never the synthetic collator ($C) job.
+      expect(childExec.parent_workflow_id).toBe(rootId);
+      expect(childExec.parent_workflow_id).not.toContain('$C');
+      expect(childExec.origin_id).toBe(rootId);
+    }, 30_000);
   });
 
   describe('Full workflow (original)', () => {

--- a/tests/durable/basic/src/workflows.ts
+++ b/tests/durable/basic/src/workflows.ts
@@ -271,3 +271,167 @@ export async function testLateRegistration(name: string): Promise<{ complex: str
   });
   return await greet(name);
 }
+
+/** A child whose whole body is a single `condition()` — the unit a fan-in harvest spawns. */
+export async function childWaitFor(signalId: string): Promise<any> {
+  return await Durable.workflow.condition(signalId);
+}
+
+/** Feature 18: Promise.all of `executeChild`, each child a single `condition()` resolved by
+ *  an EXTERNAL signal. This is the supported way to collect N independent durable waits in
+ *  parallel — fan them out as child workflows (each one condition) rather than awaiting
+ *  concurrent conditions in a single execution (which races the wait registration). Each
+ *  child is given a fixed workflowId so the test can signal it directly. */
+export async function testParallelConditionChildren(name: string): Promise<{ a: any; b: any }> {
+  const [a, b] = await Promise.all([
+    Durable.workflow.executeChild<any>({
+      workflowName: 'childWaitFor',
+      args: ['child-sig-a'],
+      taskQueue: 'basic-world',
+      workflowId: 'cond-child-a',
+    }),
+    Durable.workflow.executeChild<any>({
+      workflowName: 'childWaitFor',
+      args: ['child-sig-b'],
+      taskQueue: 'basic-world',
+      workflowId: 'cond-child-b',
+    }),
+  ]);
+  return { a, b };
+}
+
+/** Feature 19: Promise.all of two DIRECT `condition()` calls — the canonical fan-in
+ *  documented on `condition()`. Two wait items (code 595) are collated into the reentrant
+ *  collator flow and BOTH must resolve through `collator_waiter` as each external signal
+ *  arrives. This exercises the collator's waiter branch directly — unlike fanning the waits
+ *  out as child workflows, where each child instead runs a lone inline `waiter`. */
+export async function testParallelConditions(sigA: string, sigB: string): Promise<{ a: any; b: any }> {
+  const [a, b] = await Promise.all([
+    Durable.workflow.condition<any>(sigA),
+    Durable.workflow.condition<any>(sigB),
+  ]);
+  return { a, b };
+}
+
+/** Feature 20: Promise.all mixing a `condition()` with a `proxyActivity()`. The collator
+ *  must collect a wait (595) alongside a proxy (591) and return both in original order; the
+ *  parent does not end until the external signal resolves the wait. */
+export async function testConditionPlusProxy(
+  name: string,
+  sig: string,
+): Promise<{ waited: any; greeting: { complex: string } }> {
+  const [waited, greeting] = await Promise.all([
+    Durable.workflow.condition<any>(sig),
+    greet(name),
+  ]);
+  return { waited, greeting };
+}
+
+/** Feature 21: Promise.all mixing a `condition()` with an `executeChild()`. The collator
+ *  must collect a wait (595) alongside a child (590) and return both in original order. */
+export async function testConditionPlusChild(
+  name: string,
+  sig: string,
+): Promise<{ waited: any; childDone: boolean }> {
+  const [waited, _child] = await Promise.all([
+    Durable.workflow.condition<any>(sig),
+    Durable.workflow.executeChild<void>({
+      workflowName: 'childExample',
+      args: [name],
+      taskQueue: 'basic-world',
+    }),
+  ]);
+  return { waited, childDone: true };
+}
+
+/** Feature 22: Promise.all mixing a `condition()` that carries an ESCALATION queueConfig
+ *  with a `proxyActivity()`. The collated wait must write its `hmsh_escalations` row at
+ *  suspension (so it is listable/claimable/resolvable) and resume when the escalation is
+ *  resolved — proving `collator_waiter` honors the escalation config exactly like the inline
+ *  single-condition `waiter` does. The `signalId` is derived from `orderId` so it is stable
+ *  across replays; the test discovers the row by `role` + `metadata.orderId`. */
+export async function testConditionEscalationPlusProxy(
+  name: string,
+  orderId: string,
+  role: string,
+): Promise<{ decision: any; greeting: { complex: string } }> {
+  const signalId = `collator-esc-${orderId}`;
+  const [decision, greeting] = await Promise.all([
+    Durable.workflow.condition<any>(signalId, {
+      role,
+      type: 'collator-escalation',
+      priority: 3,
+      description: `Approve collated order ${orderId}`,
+      metadata: { orderId },
+    }),
+    greet(name),
+  ]);
+  return { decision, greeting };
+}
+
+/** Lineage: a child that itself spawns a grandchild. Proves `origin_id` stays pinned to the
+ *  root across composition depth while `parent_id` always tracks the direct spawner. */
+export async function testLineageChild(grandchildId: string): Promise<{ done: boolean }> {
+  await Durable.workflow.executeChild<void>({
+    workflowName: 'childExample',
+    args: ['grandchild'],
+    taskQueue: 'basic-world',
+    workflowId: grandchildId,
+  });
+  return { done: true };
+}
+
+/** Lineage root: spawns a child (which spawns a grandchild) through the `childer` path.
+ *  The full root → child → grandchild chain must be reconstructable from the jobs table. */
+export async function testLineageRoot(
+  childId: string,
+  grandchildId: string,
+): Promise<{ done: boolean }> {
+  await Durable.workflow.executeChild<void>({
+    workflowName: 'testLineageChild',
+    args: [grandchildId],
+    taskQueue: 'basic-world',
+    workflowId: childId,
+  });
+  return { done: true };
+}
+
+/** Lineage via the collator: `Promise.all([executeChild, condition])` routes the child through
+ *  `collator_childer`. The child's `parent_id` must be THIS spawning workflow — not the
+ *  synthetic collator (`$C`) job that internally fans the work out. */
+export async function testLineageCollator(
+  childId: string,
+  sig: string,
+): Promise<{ done: boolean }> {
+  await Promise.all([
+    Durable.workflow.executeChild<void>({
+      workflowName: 'childExample',
+      args: ['collated-child'],
+      taskQueue: 'basic-world',
+      workflowId: childId,
+    }),
+    Durable.workflow.condition<any>(sig),
+  ]);
+  return { done: true };
+}
+
+/** Lineage nesting THROUGH the collator: the collated child (spawned via `collator_childer`)
+ *  is itself a composer that spawns a grandchild. Proves `origin_id` stays pinned to the root
+ *  and `parent_id` keeps chaining even when the middle hop is a Promise.all/collator fan-out —
+ *  i.e. lineage travels through the synthetic collator job without absorbing its id. */
+export async function testLineageCollatorNested(
+  childId: string,
+  grandchildId: string,
+  sig: string,
+): Promise<{ done: boolean }> {
+  await Promise.all([
+    Durable.workflow.executeChild<void>({
+      workflowName: 'testLineageChild', // this collated child spawns a grandchild
+      args: [grandchildId],
+      taskQueue: 'basic-world',
+      workflowId: childId,
+    }),
+    Durable.workflow.condition<any>(sig),
+  ]);
+  return { done: true };
+}

--- a/types/exporter.ts
+++ b/types/exporter.ts
@@ -342,6 +342,19 @@ export interface WorkflowExecution {
   summary: WorkflowExecutionSummary;
   children?: WorkflowExecution[];
   stream_history?: StreamHistoryEntry[];
+  /**
+   * Upward lineage pointer to the real spawning workflow — never the synthetic
+   * collator `$C` job. `null` marks a root. Only present when the export was
+   * requested with `include_lineage: true`.
+   */
+  parent_workflow_id?: string | null;
+  /**
+   * Root ancestor of this execution; `null` for a root itself (identify roots
+   * via a null `parent_workflow_id`). Every descendant carries the same
+   * `origin_id`, so a subtree is recoverable in one query. Only present when the
+   * export was requested with `include_lineage: true`.
+   */
+  origin_id?: string | null;
 }
 
 /**
@@ -388,6 +401,17 @@ export interface ExecutionExportOptions {
    * @default false
    */
   allow_direct_query?: boolean;
+  /**
+   * When true, populates the export's `parent_workflow_id` and `origin_id` from
+   * the jobs table via a single indexed lookup. `parent_workflow_id` is the real
+   * spawning workflow (never the synthetic collator `$C` job); `origin_id` is the
+   * root ancestor (a null `parent_workflow_id` marks a root). Opt-in so the extra
+   * query is only paid when a UI needs upward lineage. Requires a provider that
+   * implements `getJobLineage` (e.g., Postgres); a no-op otherwise.
+   *
+   * @default false
+   */
+  include_lineage?: boolean;
   /**
    * When true, fetches the full stream message history for this workflow
    * from the worker_streams table and attaches it as `stream_history`.


### PR DESCRIPTION
## Summary
Durable schema **v16 → v17** (hot-swaps on version drift). Three related improvements, all proven in the durable suite.

### 1. `collator_waiter` escalations
The inline single-condition `waiter` and `signaler_waiter` already had an `escalation:` block; `collator_waiter` did not. So an **escalation-bearing `condition()` inside a `Promise.all`** silently wrote no `hmsh_escalations` row (couldn't be listed/claimed/resolved).

- Added an `escalation:` block to `collator_waiter`, sourced from the collated item via `output.maps` (flattened before the Leg-1 INSERT).
- `condition()` now threads `taskQueue`/`workflowName` onto the wait item so the collated row is faithful.
- The escalation's `signal_key` is auto-derived from `collator_waiter`'s reentry hook (`wfs.signal`), so `escalations.resolve()` / `signal()` — which double-fire `wfs.signal` + `wfs.wait` — reach it.
- Plain (non-escalation) collated conditions remain a no-op INSERT, identical to the inline path.

### 2. Promise.all collator coverage + job lineage
- Tests: parallel `condition()`, `condition()`+proxy, `condition()`+child, and the escalation-bearing collated condition.
- Verified + tested that `parent_id`/`origin_id` are authored into the jobs table across composition (`childer`, `collator_childer`, `signaler_childer`). A collated child's `parent_id` is the **real spawning workflow**, never the synthetic collator (`$C`) job; `origin_id` stays pinned to the root through every hop — including a child spawned from inside a `Promise.all` that itself spawns a grandchild.

### 3. Opt-in export lineage pointer
- `exportExecution({ include_lineage: true })` now surfaces `parent_workflow_id` + `origin_id` via a single indexed lookup (`store.getJobLineage`).
- **Top-level only**, **default-off** (backwards compatible — verified the field is absent without the flag).
- Deliberately **not** folded into the shared jobs `hgetall`: `getJobStats` does `Number(val)` over every field, so injecting UUID columns there would corrupt stats with `NaN`. The opt-in indexed lookup on the (non-hot) observability path is the safe, efficient choice.

## Testing
- Durable suite: **391 passed**, 8 skipped (env-conditional).
- `tsc --noEmit`: clean.
- New basic-suite tests cover every path above, including a fail-first proof that the escalation row was missing before the fix.

## Version
0.22.8 → **0.23.0** (package.json + lock).