### PR TITLE
Interrupt purges job stream messages; delivery guard drops dead-job redeliveries (v0.25.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.25.2",
+      "version": "0.25.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/engine/completion.ts
+++ b/services/engine/completion.ts
@@ -127,6 +127,7 @@ export async function interrupt(
   options: JobInterruptOptions = {},
 ): Promise<string> {
   await instance.store.interrupt(topic, jobId, options);
+  await expireStreamMessages(instance, jobId);
   const context = (await instance.getState(topic, jobId)) as JobState;
   const completionOpts: JobCompletionOptions = {
     interrupt: options.descend,
@@ -143,7 +144,35 @@ export async function scrub(
   instance: CompletionContext,
   jobId: string,
 ) {
+  await expireStreamMessages(instance, jobId);
   await instance.store.scrub(jobId);
+}
+
+/**
+ * Soft-deletes the job's stream messages (queued, reserved, and
+ * scheduled retries) so no message belonging to a dead job is ever
+ * delivered again. Interrupting the job wins or throws before this
+ * runs; failures here are logged and absorbed because the delivery
+ * liveness guard drops any surviving message at claim time.
+ */
+async function expireStreamMessages(
+  instance: CompletionContext,
+  jobId: string,
+): Promise<void> {
+  try {
+    const expired = await instance.stream.expireJobMessages?.(jobId);
+    if (expired) {
+      instance.logger.info('engine-job-stream-messages-expired', {
+        jobId,
+        expired,
+      });
+    }
+  } catch (error) {
+    instance.logger.error('engine-job-stream-expire-error', {
+      jobId,
+      error,
+    });
+  }
 }
 
 /**

--- a/services/stream/index.ts
+++ b/services/stream/index.ts
@@ -162,6 +162,11 @@ export abstract class StreamService<
     messageIds: string[],
   ): Promise<number>;
 
+  // Optional job-scoped expiry (implemented by providers that support it).
+  // Soft-deletes every live stream message belonging to a job so that an
+  // interrupted job's queued/reserved/retry messages are never delivered.
+  expireJobMessages?(jid: string): Promise<number>;
+
   // Optional notification management methods (implemented by providers that support them)
   stopNotificationConsumer?(
     streamName: string,

--- a/services/stream/providers/postgres/messages.ts
+++ b/services/stream/providers/postgres/messages.ts
@@ -256,6 +256,123 @@ export function buildPublishSQL(
 }
 
 /**
+ * Job-liveness context for the delivery guard. `keyPrefix` is the minted
+ * job-key prefix (`hmsh:<app>:j:`) so `keyPrefix || jid` addresses the
+ * jobs row. `enabled` is mutated to false (self-disable) when the jobs
+ * table is not visible from the stream connection.
+ */
+export interface JobLivenessContext {
+  jobsTable: string;
+  keyPrefix: string;
+  enabled: boolean;
+}
+
+/**
+ * Soft-delete every live stream row that belongs to a job. Called when a
+ * job is interrupted so its queued, reserved, and scheduled-retry
+ * messages are never delivered again. Uses the partial jid indexes
+ * (idx_*_streams_jid_created); runs once per interrupt.
+ */
+export async function expireJobMessages(
+  client: PostgresClientType & ProviderClient,
+  tableNames: string[],
+  jid: string,
+  logger: ILogger,
+): Promise<number> {
+  if (!jid) return 0;
+  let total = 0;
+  for (const tableName of tableNames) {
+    try {
+      const res = await client.query(
+        `UPDATE ${tableName}
+         SET expired_at = NOW()
+         WHERE jid = $1 AND expired_at IS NULL`,
+        [jid],
+      );
+      total += res.rowCount ?? 0;
+    } catch (error) {
+      logger.error(`postgres-stream-expire-job-error`, {
+        tableName,
+        jid,
+        error,
+      });
+      throw error;
+    }
+  }
+  return total;
+}
+
+/**
+ * Delivery liveness guard. Scoped to messages that are REDELIVERIES
+ * (a prior reservation lapsed) or RETRIES (retry_attempt > 0) — zombie
+ * messages of interrupted jobs only resurface through those paths, so
+ * first deliveries (the steady-state hot path) pay zero extra cost.
+ * A suspect whose job exists, is live, and has status <= 0 is expired
+ * in place and dropped from the batch. A missing job row still delivers
+ * (job-creating messages precede the row). Fails open on any error;
+ * self-disables when the jobs table is not visible (42P01).
+ */
+async function dropDeadJobMessages(
+  client: PostgresClientType & ProviderClient,
+  tableName: string,
+  streamName: string,
+  rows: any[],
+  liveness: JobLivenessContext,
+  logger: ILogger,
+): Promise<Set<string>> {
+  const deadIds = new Set<string>();
+  const suspects = rows.filter(
+    (row) => row.jid && (row.redelivered || row.retry_attempt > 0),
+  );
+  if (suspects.length === 0) {
+    return deadIds;
+  }
+  try {
+    const res = await client.query(
+      `UPDATE ${tableName} t
+       SET expired_at = NOW()
+       FROM ${liveness.jobsTable} j
+       WHERE t.stream_name = $1
+         AND t.id = ANY($2::bigint[])
+         AND j.key = $3 || t.jid
+         AND j.is_live
+         AND j.status <= 0
+       RETURNING t.id`,
+      [streamName, suspects.map((row) => row.id), liveness.keyPrefix],
+    );
+    for (const row of res.rows) {
+      deadIds.add(row.id.toString());
+    }
+    if (deadIds.size > 0) {
+      logger.warn(`postgres-stream-zombie-dropped-${streamName}`, {
+        count: deadIds.size,
+        jids: [
+          ...new Set(
+            suspects
+              .filter((row) => deadIds.has(row.id.toString()))
+              .map((row) => row.jid),
+          ),
+        ],
+      });
+    }
+  } catch (error) {
+    if (error?.code === '42P01') {
+      //jobs table is not visible from this connection; the guard cannot
+      //run here — interrupt-time purging (expireJobMessages) still applies
+      liveness.enabled = false;
+      logger.info('postgres-stream-liveness-guard-disabled', {
+        jobsTable: liveness.jobsTable,
+      });
+    } else {
+      logger.error(`postgres-stream-liveness-guard-error-${streamName}`, {
+        error,
+      });
+    }
+  }
+  return deadIds;
+}
+
+/**
  * Fetch messages from the stream with optional exponential backoff.
  * Uses SKIP LOCKED for high-concurrency consumption.
  * No group_name filter needed - the table itself determines engine vs worker.
@@ -277,6 +394,7 @@ export async function fetchMessages(
     maxRetries?: number;
   } = {},
   logger: ILogger,
+  liveness?: JobLivenessContext,
 ): Promise<StreamMessage[]> {
   const enableBackoff = options?.enableBackoff ?? false;
   const initialBackoff = options?.initialBackoff ?? 100;
@@ -288,10 +406,11 @@ export async function fetchMessages(
 
   // Include workflow_name in RETURNING for worker streams. Columns are
   // qualified with the update target's alias because the claim UPDATE
-  // joins a CTE that also exposes an id column.
+  // joins a CTE that also exposes an id column. Worker streams also
+  // return jid and the pre-claim redelivery flag for the liveness guard.
   const returningClause = isEngine
     ? 't.id, t.message, t.max_retry_attempts, t.backoff_coefficient, t.maximum_interval_seconds, t.retry_attempt'
-    : 't.id, t.message, t.workflow_name, t.max_retry_attempts, t.backoff_coefficient, t.maximum_interval_seconds, t.retry_attempt';
+    : 't.id, t.message, t.workflow_name, t.max_retry_attempts, t.backoff_coefficient, t.maximum_interval_seconds, t.retry_attempt, t.jid, candidates.redelivered';
 
   try {
     while (retries < maxRetries) {
@@ -305,9 +424,12 @@ export async function fetchMessages(
       // reserves MORE rows than LIMIT. The UPDATE repeats stream_name so
       // the planner prunes to a single hash partition and joins on the
       // (stream_name, id) primary key.
+      // candidates exposes the PRE-claim reservation state: a non-null
+      // reserved_at at claim time means a prior reservation lapsed
+      // (redelivery) — the trigger condition for the liveness guard.
       const res = await client.query(
         `WITH candidates AS MATERIALIZED (
-           SELECT id FROM ${tableName}
+           SELECT id, (reserved_at IS NOT NULL) AS redelivered FROM ${tableName}
            WHERE stream_name = $1
              AND (reserved_at IS NULL OR reserved_at < NOW() - INTERVAL '${reservationTimeout} seconds')
              AND expired_at IS NULL
@@ -324,7 +446,22 @@ export async function fetchMessages(
         [streamName, batchSize, consumerName],
       );
 
-      const messages: StreamMessage[] = res.rows.map((row: any) => {
+      let rows = res.rows;
+      if (!isEngine && liveness?.enabled && rows.length > 0) {
+        const deadIds = await dropDeadJobMessages(
+          client,
+          tableName,
+          streamName,
+          rows,
+          liveness,
+          logger,
+        );
+        if (deadIds.size > 0) {
+          rows = rows.filter((row: any) => !deadIds.has(row.id.toString()));
+        }
+      }
+
+      const messages: StreamMessage[] = rows.map((row: any) => {
         const data = parseStreamMessage(row.message);
 
         const hasDefaultRetryPolicy =

--- a/services/stream/providers/postgres/postgres.ts
+++ b/services/stream/providers/postgres/postgres.ts
@@ -57,6 +57,11 @@ class PostgresStreamService extends StreamService<
   // Scout manager
   private scoutManager: ScoutManager;
 
+  // Job-liveness context for the delivery guard (worker streams).
+  // Shared by reference with fetchMessages so the guard can
+  // self-disable when the jobs table is not visible (42P01).
+  private liveness: Messages.JobLivenessContext | undefined;
+
   // Notification manager
   private notificationManager: NotificationManager<PostgresStreamService>;
 
@@ -81,6 +86,14 @@ class PostgresStreamService extends StreamService<
     // and never need direct table access.
     if (!this.securedMode) {
       await deploySchema(this.streamClient, this.appId, this.logger);
+      //delivery liveness guard: drops redelivered/retried worker messages
+      //whose job is dead. Secured workers cannot read the jobs table —
+      //interrupt-time purging (expireJobMessages) covers them instead.
+      this.liveness = {
+        jobsTable: `${this.safeName(this.appId)}.jobs`,
+        keyPrefix: this.mintKey(KeyType.JOB_STATE, { jobId: '' }),
+        enabled: true,
+      };
     }
 
     // Initialize scout manager (skipped in secured mode — roles table inaccessible)
@@ -489,6 +502,25 @@ class PostgresStreamService extends StreamService<
       target.isEngine,
       consumerName,
       options || {},
+      this.logger,
+      this.liveness,
+    );
+  }
+
+  /**
+   * Soft-deletes every live stream row that belongs to a job, across the
+   * worker and engine stream tables. Called by the engine when a job is
+   * interrupted or scrubbed so its queued, reserved, and scheduled-retry
+   * messages are never delivered again.
+   */
+  async expireJobMessages(jid: string): Promise<number> {
+    if (this.securedMode) {
+      return 0;
+    }
+    return Messages.expireJobMessages(
+      this.streamClient,
+      [this.getEngineTableName(), this.getWorkerTableName()],
+      jid,
       this.logger,
     );
   }

--- a/tests/durable/zombie/postgres.test.ts
+++ b/tests/durable/zombie/postgres.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Client as Postgres } from 'pg';
+
+import { Durable } from '../../../services/durable';
+import { WorkflowHandleService } from '../../../services/durable/handle';
+import { guid, sleepFor } from '../../../modules/utils';
+import { HMSH_LOGLEVEL } from '../../../modules/enums';
+import { ProviderNativeClient } from '../../../types/provider';
+import { dropTables, postgres_options } from '../../$setup/postgres';
+import { PostgresConnection } from '../../../services/connector/providers/postgres';
+
+import * as workflows from './src/workflows';
+import * as activities from './src/activities';
+
+const { Connection, Client, Worker } = Durable;
+
+/**
+ * Terminating a workflow must purge its queued/reserved stream messages.
+ * A terminated workflow's activity message left live in worker_streams is
+ * redelivered when its reservation lapses (or a worker restarts) and the
+ * activity's side effects re-execute against live state ("zombie batches").
+ */
+describe('DURABLE | zombie | Postgres', () => {
+  let handle: WorkflowHandleService;
+  let postgresClient: ProviderNativeClient;
+  const connection = { class: Postgres, options: postgres_options };
+  const taskQueue = 'zombie-world';
+  const workflowId = guid();
+
+  const liveRowsForJid = async (jid: string): Promise<number> => {
+    const res = await postgresClient.query(
+      `SELECT COUNT(*)::int AS count FROM durable.worker_streams
+       WHERE jid = $1 AND expired_at IS NULL AND dead_lettered_at IS NULL`,
+      [jid],
+    );
+    return res.rows[0].count;
+  };
+
+  const until = async (
+    predicate: () => boolean,
+    timeoutMs: number,
+    label: string,
+  ): Promise<void> => {
+    const start = Date.now();
+    while (!predicate()) {
+      if (Date.now() - start > timeoutMs) {
+        throw new Error(`timed out waiting for: ${label}`);
+      }
+      await sleepFor(100);
+    }
+  };
+
+  beforeAll(async () => {
+    if (process.env.POSTGRES_IS_REMOTE === 'true') return;
+
+    postgresClient = (
+      await PostgresConnection.connect(guid(), Postgres, postgres_options)
+    ).getClient();
+    await dropTables(postgresClient);
+  });
+
+  afterAll(async () => {
+    await sleepFor(1500);
+    await Durable.shutdown();
+  }, 15_000);
+
+  describe('Worker and Client', () => {
+    it('should run the worker and start the workflow', async () => {
+      const workerConnection = (await Connection.connect(connection)) as any;
+      expect(workerConnection).toBeDefined();
+
+      const worker = await Worker.create({
+        connection,
+        taskQueue,
+        workflow: workflows.zombieExample,
+        options: {
+          logLevel: HMSH_LOGLEVEL,
+        },
+      });
+      await worker.run();
+
+      activities.resetSideEffectCount();
+      const client = new Client({ connection });
+      handle = await client.workflow.start({
+        args: ['zombie-run-1'],
+        taskQueue,
+        workflowName: 'zombieExample',
+        workflowId,
+        expire: 600,
+      });
+      expect(handle.workflowId).toBe(workflowId);
+
+      //wait until the slow activity is executing (its message is reserved)
+      await until(
+        () => activities.getSideEffectCount() === 1,
+        10_000,
+        'activity to start executing',
+      );
+    }, 20_000);
+  });
+
+  describe('Terminate', () => {
+    it('should purge the terminated workflow`s stream messages', async () => {
+      //the activity message is reserved and mid-execution; terminate now
+      await handle.terminate();
+      const status = await handle.status();
+      expect(status).toBeLessThan(0);
+
+      //no message belonging to the terminated jid may remain deliverable
+      expect(await liveRowsForJid(workflowId)).toBe(0);
+    }, 10_000);
+
+    it('should never re-execute the terminated workflow`s activity', async () => {
+      //simulate a lapsed reservation (the mechanism by which zombie
+      //messages resurface after slow activities or worker restarts):
+      //backdate any live reservation for the jid past the claim window
+      await postgresClient.query(
+        `UPDATE durable.worker_streams
+         SET reserved_at = NOW() - INTERVAL '600 seconds', visible_at = NOW()
+         WHERE jid = $1 AND expired_at IS NULL AND dead_lettered_at IS NULL`,
+        [workflowId],
+      );
+
+      //wake every worker-stream consumer that has rows for this jid
+      //(expired rows included: soft-deleted rows still record the topic)
+      const topics = await postgresClient.query(
+        `SELECT DISTINCT stream_name FROM durable.worker_streams WHERE jid = $1`,
+        [workflowId],
+      );
+      for (const row of topics.rows) {
+        const channel = `wrk_${row.stream_name}`.substring(0, 63);
+        await postgresClient.query(`SELECT pg_notify($1, $2)`, [
+          channel,
+          JSON.stringify({
+            stream_name: row.stream_name,
+            table_type: 'worker',
+          }),
+        ]);
+      }
+
+      //allow time for a zombie redelivery to claim and execute; the
+      //original execution (5s sleep) also settles within this window
+      await sleepFor(7_500);
+
+      //the side effect fired exactly once — on the original execution
+      expect(activities.getSideEffectCount()).toBe(1);
+      expect(await liveRowsForJid(workflowId)).toBe(0);
+    }, 20_000);
+  });
+});

--- a/tests/durable/zombie/src/activities.ts
+++ b/tests/durable/zombie/src/activities.ts
@@ -1,0 +1,20 @@
+let sideEffectCount = 0;
+
+export function getSideEffectCount(): number {
+  return sideEffectCount;
+}
+
+export function resetSideEffectCount(): void {
+  sideEffectCount = 0;
+}
+
+/**
+ * A slow activity with an observable side effect. The side effect
+ * (counter increment) happens FIRST, so every execution — including
+ * a zombie re-execution after the workflow was terminated — is counted.
+ */
+export async function slowSideEffect(runId: string): Promise<string> {
+  sideEffectCount++;
+  await new Promise((resolve) => setTimeout(resolve, 5_000));
+  return runId;
+}

--- a/tests/durable/zombie/src/workflows.ts
+++ b/tests/durable/zombie/src/workflows.ts
@@ -1,0 +1,12 @@
+import { Durable } from '../../../../services/durable';
+
+import * as activities from './activities';
+
+const { slowSideEffect } = Durable.workflow.proxyActivities<typeof activities>({
+  activities,
+});
+
+export async function zombieExample(runId: string): Promise<string> {
+  await slowSideEffect(runId);
+  return 'done';
+}

--- a/tests/functional/stream/providers/postgres/liveness.test.ts
+++ b/tests/functional/stream/providers/postgres/liveness.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { Client } from 'pg';
+
+import { HMNS } from '../../../../../modules/key';
+import { PostgresConnection } from '../../../../../services/connector/providers/postgres';
+import { LoggerService } from '../../../../../services/logger';
+import { PostgresStreamService } from '../../../../../services/stream/providers/postgres/postgres';
+import { PostgresClientType } from '../../../../../types/postgres';
+import {
+  ProviderNativeClient,
+  ProviderClient,
+} from '../../../../../types/provider';
+import { dropTables } from '../../../../$setup/postgres';
+
+/**
+ * Job-liveness protections for the Postgres stream provider:
+ *
+ * 1. expireJobMessages(jid) — soft-deletes every live stream row that
+ *    belongs to a job, across worker and engine streams. Called by the
+ *    engine when a job is interrupted so its queued/reserved/retry
+ *    messages are never delivered again.
+ * 2. Delivery liveness guard — a claimed worker-stream message that is a
+ *    REDELIVERY (prior reservation lapsed) or a RETRY (retry_attempt > 0)
+ *    is checked against the jobs table; when its job exists and is dead
+ *    (status <= 0), the message is expired and dropped instead of
+ *    executed. First deliveries skip the check (zero hot-path cost) —
+ *    rows that exist at interrupt time are handled by expireJobMessages.
+ */
+describe('FUNCTIONAL | PostgresStreamService | job liveness', () => {
+  let postgresClient: ProviderNativeClient;
+  let service: PostgresStreamService;
+  const APP_ID = 'mytestapp';
+  const SCHEMA = APP_ID;
+  const JOB_KEY_PREFIX = `${HMNS}:${APP_ID}:j:`;
+  const WORKER_STREAM = 'livenessStream';
+  const ENGINE_STREAM_KEY = `${HMNS}:${APP_ID}:x:`; //trailing ':' = engine
+  const GROUP = 'WORKER';
+  const CONSUMER = 'livenessConsumer';
+  const DEAD_STATUS = -1_000_000_000;
+
+  const workerMsg = (jid: string, idx: number, extra = {}): string =>
+    JSON.stringify({
+      type: 'worker',
+      metadata: { jid, topic: WORKER_STREAM },
+      data: { idx },
+      ...extra,
+    });
+
+  const insertJob = async (jid: string, status: number): Promise<void> => {
+    await postgresClient.query(
+      `INSERT INTO ${SCHEMA}.jobs (key, status, is_live) VALUES ($1, $2, TRUE)`,
+      [`${JOB_KEY_PREFIX}${jid}`, status],
+    );
+  };
+
+  const lapseReservations = async (tableName: string): Promise<void> => {
+    await postgresClient.query(
+      `UPDATE ${SCHEMA}.${tableName}
+       SET reserved_at = NOW() - INTERVAL '600 seconds', visible_at = NOW()
+       WHERE expired_at IS NULL`,
+    );
+  };
+
+  const liveRows = async (
+    tableName: string,
+    jid: string,
+  ): Promise<number> => {
+    const res = await postgresClient.query(
+      `SELECT COUNT(*)::int AS count FROM ${SCHEMA}.${tableName}
+       WHERE jid = $1 AND expired_at IS NULL AND dead_lettered_at IS NULL`,
+      [jid],
+    );
+    return res.rows[0].count;
+  };
+
+  beforeAll(async () => {
+    postgresClient = (
+      await PostgresConnection.connect('test', Client, {
+        user: 'postgres',
+        host: 'postgres',
+        database: 'hotmesh',
+        password: 'password',
+        port: 5432,
+      })
+    ).getClient();
+
+    await dropTables(postgresClient);
+  });
+
+  beforeEach(async () => {
+    if (service) {
+      try {
+        await service.cleanup();
+      } catch (error) {
+        // Ignore cleanup errors
+      }
+    }
+
+    service = new PostgresStreamService(
+      postgresClient as PostgresClientType & ProviderClient,
+      {} as ProviderClient,
+    );
+    await service.init(HMNS, APP_ID, new LoggerService());
+
+    try {
+      await service.deleteStream('*');
+    } catch (error) {
+      // Stream might not exist; ignore error
+    }
+
+    //a minimal jobs table (the store provider owns the real one); the
+    //guard only reads (key, status, is_live)
+    await postgresClient.query(
+      `CREATE TABLE IF NOT EXISTS ${SCHEMA}.jobs (
+        key TEXT NOT NULL,
+        status INTEGER NOT NULL,
+        is_live BOOLEAN DEFAULT TRUE
+      )`,
+    );
+    await postgresClient.query(`TRUNCATE ${SCHEMA}.jobs`);
+  });
+
+  afterEach(async () => {
+    if (service) {
+      try {
+        await service.cleanup();
+      } catch (error) {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  afterAll(async () => {
+    await postgresClient.end();
+  });
+
+  describe('expireJobMessages', () => {
+    it('should expire every live row for a jid across worker and engine streams', async () => {
+      //jidA: one queued, one scheduled retry (future visible_at), one engine row
+      await service.publishMessages(WORKER_STREAM, [
+        workerMsg('jidA', 1),
+        workerMsg('jidA', 2, { _visibilityDelayMs: 60_000 }),
+        workerMsg('jidB', 3),
+      ]);
+      await service.publishMessages(ENGINE_STREAM_KEY, [workerMsg('jidA', 4)]);
+
+      //reserve jidA's queued message (in-flight, as during an interrupt)
+      const claimed = await service.consumeMessages(
+        WORKER_STREAM,
+        GROUP,
+        CONSUMER,
+        { batchSize: 1 },
+      );
+      expect(claimed).toHaveLength(1);
+
+      const expired = await service.expireJobMessages('jidA');
+      expect(expired).toBe(3);
+
+      expect(await liveRows('worker_streams', 'jidA')).toBe(0);
+      expect(await liveRows('engine_streams', 'jidA')).toBe(0);
+      expect(await liveRows('worker_streams', 'jidB')).toBe(1);
+
+      //idempotent: everything is already expired
+      expect(await service.expireJobMessages('jidA')).toBe(0);
+    });
+  });
+
+  describe('delivery liveness guard', () => {
+    it('should expire and drop a redelivered message whose job is dead', async () => {
+      await insertJob('jidA', DEAD_STATUS);
+      await service.publishMessages(WORKER_STREAM, [workerMsg('jidA', 1)]);
+
+      //first delivery skips the guard (interrupt-time purge owns rows
+      //that already exist when a job dies)
+      const first = await service.consumeMessages(WORKER_STREAM, GROUP, CONSUMER);
+      expect(first).toHaveLength(1);
+
+      //the reservation lapses (slow activity, worker restart) — the
+      //redelivery is checked and the zombie is dropped, not executed
+      await lapseReservations('worker_streams');
+      const second = await service.consumeMessages(WORKER_STREAM, GROUP, CONSUMER);
+      expect(second).toHaveLength(0);
+      expect(await liveRows('worker_streams', 'jidA')).toBe(0);
+    });
+
+    it('should expire and drop a scheduled retry row for a dead job', async () => {
+      await insertJob('jidB', DEAD_STATUS);
+      await service.publishMessages(WORKER_STREAM, [workerMsg('jidB', 1)]);
+      await postgresClient.query(
+        `UPDATE ${SCHEMA}.worker_streams SET retry_attempt = 1
+         WHERE stream_name = $1 AND expired_at IS NULL`,
+        [WORKER_STREAM],
+      );
+
+      const consumed = await service.consumeMessages(WORKER_STREAM, GROUP, CONSUMER);
+      expect(consumed).toHaveLength(0);
+      expect(await liveRows('worker_streams', 'jidB')).toBe(0);
+    });
+
+    it('should deliver redelivered messages for a live job', async () => {
+      await insertJob('jidC', 5);
+      await service.publishMessages(WORKER_STREAM, [workerMsg('jidC', 1)]);
+
+      const first = await service.consumeMessages(WORKER_STREAM, GROUP, CONSUMER);
+      expect(first).toHaveLength(1);
+
+      await lapseReservations('worker_streams');
+      const second = await service.consumeMessages(WORKER_STREAM, GROUP, CONSUMER);
+      expect(second).toHaveLength(1);
+      expect(await liveRows('worker_streams', 'jidC')).toBe(1);
+    });
+
+    it('should deliver redelivered messages when the job row is missing', async () => {
+      //a missing row means the job may still be mid-creation; only a row
+      //that exists AND is dead marks a message as a zombie
+      await service.publishMessages(WORKER_STREAM, [workerMsg('ghost', 1)]);
+
+      const first = await service.consumeMessages(WORKER_STREAM, GROUP, CONSUMER);
+      expect(first).toHaveLength(1);
+
+      await lapseReservations('worker_streams');
+      const second = await service.consumeMessages(WORKER_STREAM, GROUP, CONSUMER);
+      expect(second).toHaveLength(1);
+    });
+
+    it('should deliver engine-stream messages regardless of job status', async () => {
+      //the guard is scoped to worker streams (activity side effects);
+      //engine messages are state transitions the engine itself validates
+      await insertJob('jidE', DEAD_STATUS);
+      await service.publishMessages(ENGINE_STREAM_KEY, [workerMsg('jidE', 1)]);
+
+      const first = await service.consumeMessages(ENGINE_STREAM_KEY, 'ENGINE', CONSUMER);
+      expect(first).toHaveLength(1);
+
+      await lapseReservations('engine_streams');
+      const second = await service.consumeMessages(ENGINE_STREAM_KEY, 'ENGINE', CONSUMER);
+      expect(second).toHaveLength(1);
+    });
+
+    it('should keep delivering when the jobs table is unavailable', async () => {
+      await postgresClient.query(`DROP TABLE ${SCHEMA}.jobs`);
+
+      await service.publishMessages(WORKER_STREAM, [workerMsg('jidF', 1)]);
+      await postgresClient.query(
+        `UPDATE ${SCHEMA}.worker_streams SET retry_attempt = 1
+         WHERE stream_name = $1 AND expired_at IS NULL`,
+        [WORKER_STREAM],
+      );
+
+      //guard self-disables (fail open); delivery continues unharmed
+      const first = await service.consumeMessages(WORKER_STREAM, GROUP, CONSUMER);
+      expect(first).toHaveLength(1);
+
+      await lapseReservations('worker_streams');
+      const second = await service.consumeMessages(WORKER_STREAM, GROUP, CONSUMER);
+      expect(second).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Terminating a durable workflow left its queued, reserved, and scheduled-retry stream messages live in `worker_streams`/`engine_streams`. When a reservation lapsed (activity slower than the reservation window, or a worker restart), a worker claimed the dead workflow's activity message and **re-executed its side effects in full** against live state — the "zombie batch" failure mode reported from the long-tail factory-simulation topology (8 simultaneous API calls from 1 live + 7 terminated crews; stale-input completers winning races against live actors).

## Fix (two independent layers)

**1. Purge on interrupt** — `interrupt()` and `scrub()` now call `expireJobMessages(jid)`, which soft-deletes (`expired_at = NOW()`) every live stream row belonging to the job across both stream tables. Uses the existing partial jid indexes (`idx_*_streams_jid_created`); runs once per interrupt. Exposed as an optional `StreamService` capability (Postgres implements it; the engine calls it via optional chaining).

**2. Delivery liveness guard** — when the Postgres provider claims worker-stream messages, any claimed row that is a **redelivery** (its prior reservation lapsed — detected from pre-claim `reserved_at` in the claim CTE) or a **retry** (`retry_attempt > 0`) is checked against the jobs table in a single `UPDATE … FROM` statement. A suspect whose job exists, is live, and has `status <= 0` is expired in place and dropped from the batch. This also makes worker restarts self-cleaning for zombie backlogs created before this fix.

### Performance at scale

The guard engages **only for redelivered/retried messages** — zombies can only resurface through those paths, since rows that exist at interrupt time are purged by layer 1. First deliveries (the steady-state hot path) gain zero queries; the claim query is unchanged except for one computed column in the CTE it already materializes. The guard fails open on error and self-disables (logged once) when the jobs table is not visible from the stream connection (mixed-provider or secured-worker deployments, where layer 1 still applies).

### Semantics

- `jid = ''` or **no jobs row** → deliver (job-creating messages precede the row; re-used workflow IDs stay safe).
- Jobs row exists, `is_live`, `status <= 0` → expire and drop, with a `postgres-stream-zombie-dropped` warn log.
- Engine streams are out of the guard's scope (state transitions the engine itself validates); they are still purged by layer 1.

## Tests

- `tests/durable/zombie/postgres.test.ts` — end-to-end field scenario: terminate a workflow mid-activity, assert zero live rows for the jid, force a reservation lapse + NOTIFY, assert the side effect fired exactly once. **Fails on main** (1 live zombie row; side-effect count 2), passes here.
- `tests/functional/stream/providers/postgres/liveness.test.ts` — 7 provider tests: purge across worker+engine/reserved/future-`visible_at` rows with other jids untouched, idempotency; guard drops dead-job redeliveries and retries, delivers live-job/missing-row/engine cases, self-disables without the jobs table.
- Full functional suite (250) and durable suite (412) green; `tsc --noEmit` clean.

## Field guidance

After upgrading, restarting workers drains pre-existing zombie backlogs automatically (reclaimed messages flow through the guard). The regression query from the report returns 0 for terminated jids.