### PR TITLE
Reservation heartbeat keeps slow activities leased; lease loss aborts execution (v0.25.4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.25.3",
+      "version": "0.25.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/router/consumption/index.ts
+++ b/services/router/consumption/index.ts
@@ -62,6 +62,9 @@ export class ConsumptionManager<
   private duressManager?: DuressManager;
   private onDuressChange?: (snapshot: DuressSnapshot) => void;
   private messagesSinceLastEval = 0;
+  // Lazily resolved once: whether the provider supports reservation
+  // heartbeats (extendReservation + feature flag).
+  private canExtendReservations: boolean | undefined;
 
   // Adaptive consumption pressure — scales reservation timeout AND batch
   // size based on stream depth. Under load: timeout grows (prevents
@@ -317,6 +320,7 @@ export class ConsumptionManager<
             message.id,
             message.data,
             callback,
+            consumer,
           );
         });
 
@@ -341,6 +345,7 @@ export class ConsumptionManager<
             message.id,
             message.data,
             callback,
+            consumer,
           );
         }
       }
@@ -370,6 +375,7 @@ export class ConsumptionManager<
               message.id,
               message.data,
               callback,
+              consumer,
             );
           });
           await Promise.allSettled(reclaimPromises);
@@ -384,6 +390,7 @@ export class ConsumptionManager<
               message.id,
               message.data,
               callback,
+              consumer,
             );
           }
         }
@@ -530,6 +537,7 @@ export class ConsumptionManager<
                 message.id,
                 message.data,
                 callback,
+                consumer,
               );
             });
 
@@ -557,6 +565,7 @@ export class ConsumptionManager<
                 message.id,
                 message.data,
                 callback,
+                consumer,
               );
             }
           }
@@ -590,6 +599,7 @@ export class ConsumptionManager<
                   message.id,
                   message.data,
                   callback,
+                  consumer,
                 );
               });
               await Promise.allSettled(reclaimPromises);
@@ -604,6 +614,7 @@ export class ConsumptionManager<
                   message.id,
                   message.data,
                   callback,
+                  consumer,
                 );
               }
             }
@@ -650,12 +661,27 @@ export class ConsumptionManager<
     consume.call(this);
   }
 
+  /**
+   * Whether reservation heartbeats are available: the provider must
+   * implement extendReservation and advertise the capability.
+   */
+  private supportsHeartbeat(): boolean {
+    if (this.canExtendReservations === undefined) {
+      this.canExtendReservations =
+        typeof this.stream.extendReservation === 'function' &&
+        this.stream.getProviderSpecificFeatures()
+          .supportsReservationExtension === true;
+    }
+    return this.canExtendReservations;
+  }
+
   async consumeOne(
     stream: string,
     group: string,
     id: string,
     input: StreamData,
     callback: (streamData: StreamData) => Promise<StreamDataResponse | void>,
+    consumer?: string,
   ): Promise<void> {
     this.logger.debug(`stream-read-one`, { group, stream, id });
 
@@ -726,11 +752,20 @@ export class ConsumptionManager<
       return;
     }
 
-    // Lease deadline: the full configured reservation timeout (N).
-    // The reclaim interval is N+5s, so the deadline always fires
-    // before a reclaimant can pick up the message. This preserves
-    // the user's contract — if they set 30s, the function gets 30s.
-    const deadlineMs = this.adaptiveReservationTimeout * 1000;
+    // Lease strategy. With heartbeat support (provider capability +
+    // consumer identity), the reservation is refreshed at half the base
+    // window while the callback runs, so an activity that outlives the
+    // window stays leased and executes exactly once; the deadline then
+    // acts as a runaway cap (HMSH_RESERVATION_TIMEOUT_MAX_S). A crashed
+    // consumer stops heartbeating and its message is rescued within one
+    // window through the normal claim path. Providers without extension
+    // keep the hard deadline at the reservation timeout (N), with
+    // reclaim at N+5s.
+    const canHeartbeat = Boolean(consumer) && this.supportsHeartbeat();
+    const deadlineS = canHeartbeat
+      ? HMSH_RESERVATION_TIMEOUT_MAX_S
+      : this.adaptiveReservationTimeout;
+    const deadlineMs = deadlineS * 1000;
 
     let output: StreamDataResponse | void;
     const telemetry = new RouterTelemetry(this.appId);
@@ -739,15 +774,54 @@ export class ConsumptionManager<
       telemetry.startStreamSpan(input, this.role);
 
       let deadlineTimer: ReturnType<typeof setTimeout>;
+      let rejectLease: (err: Error) => void;
       const deadlinePromise = new Promise<never>((_, reject) => {
+        rejectLease = reject;
         deadlineTimer = setTimeout(
-          () =>
-            reject(
-              new LeaseExpiredError(deadlineMs, this.adaptiveReservationTimeout),
-            ),
+          () => reject(new LeaseExpiredError(deadlineMs, deadlineS)),
           deadlineMs,
         );
       });
+
+      // Heartbeat at half the BASE window (adaptive scaling only grows
+      // the claim window, so the base cadence always outpaces reclaim
+      // eligibility). A beat that reports 0 means the lease is gone —
+      // reclaimed by another consumer, acked, or the job was
+      // interrupted — so this execution abandons without acking. A beat
+      // that errors is transient and retries on the next tick. Fast
+      // callbacks settle before the first beat ever fires.
+      let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+      if (canHeartbeat) {
+        const intervalMs = Math.max(
+          1_000,
+          Math.floor((HMSH_RESERVATION_TIMEOUT_S * 1000) / 2),
+        );
+        heartbeatTimer = setInterval(() => {
+          this.stream
+            .extendReservation(stream, id, consumer)
+            .then((extended) => {
+              if (extended === 0) {
+                this.logger.warn('stream-lease-lost', {
+                  group,
+                  stream,
+                  id,
+                  consumer,
+                  topic: input.metadata?.topic,
+                  jobId: input.metadata?.jid,
+                });
+                rejectLease(new LeaseExpiredError(deadlineMs, deadlineS));
+              }
+            })
+            .catch((error) => {
+              this.logger.warn('stream-lease-extend-error', {
+                group,
+                stream,
+                id,
+                error,
+              });
+            });
+        }, intervalMs);
+      }
 
       try {
         output = await Promise.race([
@@ -756,6 +830,9 @@ export class ConsumptionManager<
         ]);
       } finally {
         clearTimeout(deadlineTimer);
+        if (heartbeatTimer) {
+          clearInterval(heartbeatTimer);
+        }
       }
 
       telemetry.setStreamErrorFromOutput(output);
@@ -773,7 +850,7 @@ export class ConsumptionManager<
           stream,
           id,
           deadlineMs,
-          reservationTimeoutS: this.adaptiveReservationTimeout,
+          reservationTimeoutS: deadlineS,
           topic: input.metadata?.topic,
           activityId: input.metadata?.aid,
           jobId: input.metadata?.jid,

--- a/services/stream/index.ts
+++ b/services/stream/index.ts
@@ -151,6 +151,7 @@ export abstract class StreamService<
     supportsRetry: boolean;
     supportsNotifications?: boolean; // New optional feature flag
     supportsParallelProcessing?: boolean;
+    supportsReservationExtension?: boolean; // heartbeat lease extension
     maxMessageSize: number;
     maxBatchSize: number;
   };
@@ -166,6 +167,16 @@ export abstract class StreamService<
   // Soft-deletes every live stream message belonging to a job so that an
   // interrupted job's queued/reserved/retry messages are never delivered.
   expireJobMessages?(jid: string): Promise<number>;
+
+  // Optional reservation heartbeat (implemented by providers that support
+  // it; advertised via supportsReservationExtension). Refreshes an owned
+  // reservation while the activity callback is still running; returns 0
+  // when the lease is no longer held (reclaimed, acked, or expired).
+  extendReservation?(
+    streamName: string,
+    messageId: string,
+    consumerName: string,
+  ): Promise<number>;
 
   // Optional notification management methods (implemented by providers that support them)
   stopNotificationConsumer?(

--- a/services/stream/providers/postgres/messages.ts
+++ b/services/stream/providers/postgres/messages.ts
@@ -303,6 +303,38 @@ export async function expireJobMessages(
 }
 
 /**
+ * Refresh an owned reservation (heartbeat). Scoped to the owning
+ * consumer and to live rows: a message that was reclaimed by another
+ * consumer, acked, or expired (job interrupted) reports 0 so the
+ * stale consumer can abandon its execution.
+ */
+export async function extendReservation(
+  client: PostgresClientType & ProviderClient,
+  tableName: string,
+  streamName: string,
+  messageId: string,
+  consumerName: string,
+  logger: ILogger,
+): Promise<number> {
+  try {
+    const res = await client.query(
+      `UPDATE ${tableName}
+       SET reserved_at = NOW()
+       WHERE stream_name = $1 AND id = $2
+         AND reserved_by = $3 AND expired_at IS NULL`,
+      [streamName, parseInt(messageId), consumerName],
+    );
+    return res.rowCount ?? 0;
+  } catch (error) {
+    logger.error(`postgres-stream-extend-error-${streamName}`, {
+      messageId,
+      error,
+    });
+    throw error;
+  }
+}
+
+/**
  * Delivery liveness guard. Scoped to messages that are REDELIVERIES
  * (a prior reservation lapsed) or RETRIES (retry_attempt > 0) — zombie
  * messages of interrupted jobs only resurface through those paths, so

--- a/services/stream/providers/postgres/postgres.ts
+++ b/services/stream/providers/postgres/postgres.ts
@@ -508,6 +508,31 @@ class PostgresStreamService extends StreamService<
   }
 
   /**
+   * Refreshes an owned reservation (heartbeat). Called by the consumer
+   * while an activity callback is still running so the message stays
+   * leased past the base reservation window. Returns 0 when the lease
+   * is no longer this consumer's to hold (reclaimed, acked, or expired).
+   */
+  async extendReservation(
+    streamName: string,
+    messageId: string,
+    consumerName: string,
+  ): Promise<number> {
+    if (this.securedMode) {
+      return 0;
+    }
+    const target = this.resolveStreamTarget(streamName);
+    return Messages.extendReservation(
+      this.streamClient,
+      target.tableName,
+      target.streamName,
+      messageId,
+      consumerName,
+      this.logger,
+    );
+  }
+
+  /**
    * Soft-deletes every live stream row that belongs to a job, across the
    * worker and engine stream tables. Called by the engine when a job is
    * interrupted or scrubbed so its queued, reserved, and scheduled-retry
@@ -701,7 +726,12 @@ class PostgresStreamService extends StreamService<
   }
 
   getProviderSpecificFeatures() {
-    return Stats.getProviderSpecificFeatures(this.config);
+    return {
+      ...Stats.getProviderSpecificFeatures(this.config),
+      //heartbeat lease extension uses direct table access; secured
+      //workers use stored procedures and keep hard-deadline leases
+      supportsReservationExtension: !this.securedMode,
+    };
   }
 
   async cleanup(): Promise<void> {

--- a/tests/durable/heartbeat/postgres.test.ts
+++ b/tests/durable/heartbeat/postgres.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Client as Postgres } from 'pg';
+
+import { Durable } from '../../../services/durable';
+import { WorkflowHandleService } from '../../../services/durable/handle';
+import { guid, sleepFor } from '../../../modules/utils';
+import { HMSH_LOGLEVEL } from '../../../modules/enums';
+import { ProviderNativeClient } from '../../../types/provider';
+import { dropTables, postgres_options } from '../../$setup/postgres';
+import { PostgresConnection } from '../../../services/connector/providers/postgres';
+
+import * as workflows from './src/workflows';
+import * as activities from './src/activities';
+
+const { Connection, Client, Worker } = Durable;
+
+/**
+ * An activity that runs longer than the base reservation window (30s)
+ * must execute exactly once and deliver its result. The consumer
+ * heartbeats the reservation (reserved_at refresh) while the activity
+ * callback runs, so the message never becomes claimable mid-execution.
+ * A crashed consumer stops heartbeating and its message is rescued
+ * within one window (proven at the provider layer in
+ * tests/functional/stream/providers/postgres/extension.test.ts).
+ */
+describe('DURABLE | heartbeat | Postgres', () => {
+  let handle: WorkflowHandleService;
+  let postgresClient: ProviderNativeClient;
+  const connection = { class: Postgres, options: postgres_options };
+  const taskQueue = 'heartbeat-world';
+  const workflowId = guid();
+
+  beforeAll(async () => {
+    if (process.env.POSTGRES_IS_REMOTE === 'true') return;
+
+    postgresClient = (
+      await PostgresConnection.connect(guid(), Postgres, postgres_options)
+    ).getClient();
+    await dropTables(postgresClient);
+  });
+
+  afterAll(async () => {
+    await sleepFor(1500);
+    await Durable.shutdown();
+  }, 15_000);
+
+  describe('Worker and Client', () => {
+    it('should run the worker and start the workflow', async () => {
+      const worker = await Worker.create({
+        connection,
+        taskQueue,
+        workflow: workflows.heartbeatExample,
+        options: {
+          logLevel: HMSH_LOGLEVEL,
+        },
+      });
+      await worker.run();
+
+      activities.resetExecutionCount();
+      const client = new Client({ connection });
+      handle = await client.workflow.start({
+        args: ['run-1'],
+        taskQueue,
+        workflowName: 'heartbeatExample',
+        workflowId,
+        expire: 600,
+      });
+      expect(handle.workflowId).toBe(workflowId);
+    }, 15_000);
+  });
+
+  describe('Slow activity', () => {
+    it('should execute the activity exactly once and deliver its result', async () => {
+      //the activity sleeps 45s — past the 30s reservation window; the
+      //heartbeat holds the lease so the single execution's result lands
+      const result = await handle.result();
+      expect(result).toBe('leased:run-1');
+      expect(activities.getExecutionCount()).toBe(1);
+
+      //the message was acked by its one and only execution
+      const res = await postgresClient.query(
+        `SELECT COUNT(*)::int AS count FROM durable.worker_streams
+         WHERE jid = $1 AND expired_at IS NULL AND dead_lettered_at IS NULL`,
+        [workflowId],
+      );
+      expect(res.rows[0].count).toBe(0);
+    }, 110_000);
+  });
+});

--- a/tests/durable/heartbeat/src/activities.ts
+++ b/tests/durable/heartbeat/src/activities.ts
@@ -1,0 +1,20 @@
+let executionCount = 0;
+
+export function getExecutionCount(): number {
+  return executionCount;
+}
+
+export function resetExecutionCount(): void {
+  executionCount = 0;
+}
+
+/**
+ * An activity that outlives the base reservation window (30s default).
+ * The reservation heartbeat keeps the message leased while it runs, so
+ * it executes exactly once and its result is delivered.
+ */
+export async function outliveTheLease(runId: string): Promise<string> {
+  executionCount++;
+  await new Promise((resolve) => setTimeout(resolve, 45_000));
+  return `leased:${runId}`;
+}

--- a/tests/durable/heartbeat/src/workflows.ts
+++ b/tests/durable/heartbeat/src/workflows.ts
@@ -1,0 +1,11 @@
+import { Durable } from '../../../../services/durable';
+
+import * as activities from './activities';
+
+const { outliveTheLease } = Durable.workflow.proxyActivities<typeof activities>({
+  activities,
+});
+
+export async function heartbeatExample(runId: string): Promise<string> {
+  return await outliveTheLease(runId);
+}

--- a/tests/functional/stream/providers/postgres/extension.test.ts
+++ b/tests/functional/stream/providers/postgres/extension.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { Client } from 'pg';
+
+import { HMNS } from '../../../../../modules/key';
+import { PostgresConnection } from '../../../../../services/connector/providers/postgres';
+import { LoggerService } from '../../../../../services/logger';
+import { PostgresStreamService } from '../../../../../services/stream/providers/postgres/postgres';
+import { PostgresClientType } from '../../../../../types/postgres';
+import {
+  ProviderNativeClient,
+  ProviderClient,
+} from '../../../../../types/provider';
+import { dropTables } from '../../../../$setup/postgres';
+
+/**
+ * Reservation extension (heartbeat support). While an activity callback
+ * runs, the consumer periodically refreshes reserved_at so the message
+ * stays leased past the base reservation window. The refresh is scoped
+ * to the owning consumer and to live rows, so a reclaimed or expired
+ * message reports 0 and the stale consumer abandons. A consumer that
+ * stops heartbeating (crash) leaves reserved_at to age out, and the
+ * message is rescued through the normal claim path.
+ */
+describe('FUNCTIONAL | PostgresStreamService | reservation extension', () => {
+  let postgresClient: ProviderNativeClient;
+  let service: PostgresStreamService;
+  const APP_ID = 'mytestapp';
+  const SCHEMA = APP_ID;
+  const STREAM = 'extensionStream';
+  const GROUP = 'WORKER';
+  const CONSUMER = 'extConsumer';
+
+  const msg = (idx: number): string =>
+    JSON.stringify({
+      type: 'worker',
+      metadata: { jid: `jid${idx}`, topic: STREAM },
+      data: { idx },
+    });
+
+  const backdateReservations = async (seconds: number): Promise<void> => {
+    await postgresClient.query(
+      `UPDATE ${SCHEMA}.worker_streams
+       SET reserved_at = NOW() - INTERVAL '${seconds} seconds'
+       WHERE stream_name = $1 AND expired_at IS NULL AND reserved_at IS NOT NULL`,
+      [STREAM],
+    );
+  };
+
+  beforeAll(async () => {
+    postgresClient = (
+      await PostgresConnection.connect('test', Client, {
+        user: 'postgres',
+        host: 'postgres',
+        database: 'hotmesh',
+        password: 'password',
+        port: 5432,
+      })
+    ).getClient();
+
+    await dropTables(postgresClient);
+  });
+
+  beforeEach(async () => {
+    if (service) {
+      try {
+        await service.cleanup();
+      } catch (error) {
+        // Ignore cleanup errors
+      }
+    }
+
+    service = new PostgresStreamService(
+      postgresClient as PostgresClientType & ProviderClient,
+      {} as ProviderClient,
+    );
+    await service.init(HMNS, APP_ID, new LoggerService());
+
+    try {
+      await service.deleteStream('*');
+    } catch (error) {
+      // Stream might not exist; ignore error
+    }
+  });
+
+  afterEach(async () => {
+    if (service) {
+      try {
+        await service.cleanup();
+      } catch (error) {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  afterAll(async () => {
+    await postgresClient.end();
+  });
+
+  it('should advertise reservation extension support', () => {
+    const features = service.getProviderSpecificFeatures();
+    expect(features.supportsReservationExtension).toBe(true);
+  });
+
+  it('should extend an owned reservation so the message stays leased', async () => {
+    await service.publishMessages(STREAM, [msg(1)]);
+    const claimed = await service.consumeMessages(STREAM, GROUP, CONSUMER);
+    expect(claimed).toHaveLength(1);
+
+    //the lease has nearly lapsed; a heartbeat refreshes it
+    await backdateReservations(60);
+    const extended = await service.extendReservation(
+      STREAM,
+      claimed[0].id,
+      CONSUMER,
+    );
+    expect(extended).toBe(1);
+
+    //the refreshed reservation is honored: the message is claimed, not reclaimable
+    const reclaimed = await service.consumeMessages(STREAM, GROUP, 'rival');
+    expect(reclaimed).toHaveLength(0);
+  });
+
+  it('should report 0 when a different consumer holds the reservation', async () => {
+    await service.publishMessages(STREAM, [msg(2)]);
+    const claimed = await service.consumeMessages(STREAM, GROUP, CONSUMER);
+    expect(claimed).toHaveLength(1);
+
+    const extended = await service.extendReservation(
+      STREAM,
+      claimed[0].id,
+      'someoneElse',
+    );
+    expect(extended).toBe(0);
+  });
+
+  it('should report 0 once the message is expired', async () => {
+    await service.publishMessages(STREAM, [msg(3)]);
+    const claimed = await service.consumeMessages(STREAM, GROUP, CONSUMER);
+    expect(claimed).toHaveLength(1);
+
+    await service.ackAndDelete(STREAM, GROUP, [claimed[0].id]);
+    const extended = await service.extendReservation(
+      STREAM,
+      claimed[0].id,
+      CONSUMER,
+    );
+    expect(extended).toBe(0);
+  });
+
+  it('should rescue a message whose consumer stopped heartbeating', async () => {
+    await service.publishMessages(STREAM, [msg(4)]);
+    const claimed = await service.consumeMessages(STREAM, GROUP, CONSUMER);
+    expect(claimed).toHaveLength(1);
+
+    //the consumer crashes: heartbeats stop and the reservation ages out
+    await backdateReservations(600);
+    const rescued = await service.consumeMessages(STREAM, GROUP, 'rescuer');
+    expect(rescued).toHaveLength(1);
+    expect(rescued[0].id).toBe(claimed[0].id);
+  });
+});

--- a/tests/functional/stream/providers/postgres/postgres.test.ts
+++ b/tests/functional/stream/providers/postgres/postgres.test.ts
@@ -423,6 +423,7 @@ describe('FUNCTIONAL | PostgresStreamService', () => {
         supportsOrdering: true,
         supportsTrimming: true,
         supportsRetry: false,
+        supportsReservationExtension: true,
         maxMessageSize: 1024 * 1024,
         maxBatchSize: 256,
       });


### PR DESCRIPTION
## Summary

An activity that ran longer than the base reservation window (`HMSH_RESERVATION_TIMEOUT_S`, 30s default) was abandoned at the deadline — its result discarded, its message left unacked — then redelivered at window+5s and **re-executed from the start**, duplicating its side effects on every lap. Deterministically slow activities (e.g. 20–60s batch loops on quiet queues, where adaptive scaling never engages) looped this way indefinitely. This is the "related" knob from the zombie-batch field report (#211): the mechanism that resurfaces messages after slow batches and worker restarts.

## Fix: heartbeat lease extension

While the activity callback runs, the consumer refreshes its reservation (`reserved_at = NOW()`, scoped to the owning `reserved_by` and live rows) every **half base window** (15s default). The lease now means "the worker is alive and still working", so:

- A slow activity stays leased for as long as it genuinely runs, executes **exactly once**, and delivers its result. Capped by `HMSH_RESERVATION_TIMEOUT_MAX_S` (1800s default) so a hung callback is eventually abandoned and reclaimed.
- A **crashed** consumer stops heartbeating; its message ages out and is rescued within one window through the normal claim path — crash recovery is preserved.
- A beat that reports 0 rows means the lease is gone (message reclaimed by another consumer, acked, or its job interrupted by #211's purge): the stale execution **abandons without acking**, so it never publishes a competing result. Beat errors are transient and retry next tick.

The cadence is pinned to the base window (not the adaptive one) because adaptive scaling only grows the claim window — the base cadence always outpaces reclaim eligibility.

### Performance at scale

Fast callbacks settle before the first beat fires — the steady-state hot path issues **zero** extension queries. Only activities still running at 15s pay one point-UPDATE per 15s, keyed on the (stream_name, id) primary key. The claim query is unchanged.

### Scope

Exposed as an optional `StreamService` capability advertised via `getProviderSpecificFeatures().supportsReservationExtension`. The Postgres provider implements it; NATS and secured workers (stored-procedure access) keep the previous hard-deadline lease behavior.

## Tests

- `tests/durable/heartbeat/postgres.test.ts` — 45s activity (past the 30s window) executes exactly once and delivers its result. **Fails on main**: two `stream-lease-expired` abandonments in 110s and the workflow never completes.
- `tests/functional/stream/providers/postgres/extension.test.ts` — 5 provider tests: owned extension holds the lease against a rival claim, non-owner and expired rows report 0, a silent (crashed) consumer's message is rescued, capability flag advertised.
- Zombie regression (#211) still green — terminate expires the row, the in-flight activity's next beat detects the lost lease and abandons.
- Full functional (255) and durable (414) suites green; `tsc --noEmit` clean.

## Semantics change (deliberate)

A runaway (hung) callback is now abandoned at the max cap (30min default) rather than 30s. A genuinely crashed process is still recovered within ~one window, since heartbeats stop at death. Previously a "recovered" hung activity just meant a duplicate execution started while the hung one kept running.