### PR TITLE
Condition wakes survive crashes: resolve-side and registration-side windows sealed (v0.25.5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.25.4",
+      "version": "0.25.5",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/escalations/client.ts
+++ b/services/escalations/client.ts
@@ -1,12 +1,15 @@
 import {
   HMSH_LOGLEVEL,
 } from '../../modules/enums';
-import { formatISODate, hashOptions } from '../../modules/utils';
+import { formatISODate, guid, hashOptions } from '../../modules/utils';
+import { KeyType } from '../../modules/key';
 import { HotMesh } from '../hotmesh';
 import { EventsConfig, SystemEvent, EscalationVerb } from '../../types/system_events';
 import { Connection } from '../../types/durable';
 import { StreamStatus } from '../../types';
+import { StreamDataType } from '../../types/stream';
 import {
+  EscalationWakeCommand,
   EscalationEntry,
   ClaimEscalationResult,
   ClaimByMetadataResult,
@@ -199,6 +202,52 @@ export class EscalationClientService {
     return delivered;
   }
 
+  /**
+   * Builds the wake publish as a SQL command so the store can commit it
+   * INSIDE the resolve transaction — the wake becomes durable with the
+   * resolved row, closing the crash window between resolve commit and
+   * post-commit signal delivery. Mirrors `_deliverEscalationSignal`'s
+   * topic fallback chain; returns null when no hook rule is deployed
+   * for any candidate topic (the caller then keeps post-commit
+   * delivery as the only path, preserving prior behavior).
+   */
+  private async _buildWakeCommand(
+    ns: string,
+    topic: string | null | undefined,
+    signalKey: string,
+    data: Record<string, unknown>,
+  ): Promise<EscalationWakeCommand | null> {
+    const hm = await this._engine(null, ns);
+    const engine = hm.engine as any;
+    const candidates = [topic, `${ns}.wfs.signal`, `${ns}.wfs.wait`].filter(
+      Boolean,
+    ) as string[];
+    for (const candidate of candidates) {
+      try {
+        const hookRule = await engine.taskService.getHookRule(candidate);
+        if (!hookRule) continue;
+        const [aid] = await engine.getSchema(`.${hookRule.to}`);
+        const streamData = {
+          type: StreamDataType.WEBHOOK,
+          status: StreamStatus.SUCCESS,
+          code: 200,
+          metadata: { guid: guid(), aid, topic: candidate },
+          data: { id: signalKey, data },
+        };
+        const streamKey = engine.stream.mintKey(KeyType.STREAMS, {
+          topic: null,
+        });
+        const { sql, params } = engine.stream._publishMessages(streamKey, [
+          JSON.stringify(streamData),
+        ]);
+        return { forSignalKey: signalKey, sql, params };
+      } catch {
+        /* candidate not deployed — try the next topic */
+      }
+    }
+    return null;
+  }
+
   // ─── Public API ─────────────────────────────────────────────────────────────
 
   /**
@@ -358,11 +407,28 @@ export class EscalationClientService {
     const ns = (params.namespace ?? namespace) ?? APP_ID;
     const hm = await this._engine(null, ns);
     const store = hm.engine.store as any;
+
+    //pre-build the wake so it commits INSIDE the resolve transaction; the
+    //row's signal routing (signal_key, topic) is immutable after creation
+    let wakeCommand: EscalationWakeCommand | null = null;
+    const preview = await store.getEscalation(params.id, params.namespace);
+    if (preview?.signal_key) {
+      wakeCommand = await this._buildWakeCommand(
+        ns,
+        preview.topic,
+        preview.signal_key,
+        params.resolverPayload ?? {},
+      );
+    }
+
     const dbResult = await store.resolveEscalation(
       { id: params.id, resolverPayload: params.resolverPayload, metadata: params.metadata },
+      wakeCommand ?? undefined,
     );
     if (!dbResult.ok) return dbResult;
-    if (dbResult.signalKey) {
+    if (dbResult.signalKey && !dbResult.wakeEnqueued) {
+      //the wake was not part of the commit (no hook rule found, or the
+      //enqueue was rolled back to its savepoint) — deliver post-commit
       await this._deliverEscalationSignal(ns, dbResult.topic, {
         id: dbResult.signalKey,
         data: params.resolverPayload ?? {},
@@ -387,11 +453,31 @@ export class EscalationClientService {
     const ns = (params.namespace ?? namespace) ?? APP_ID;
     const hm = await this._engine(null, ns);
     const store = hm.engine.store as any;
+
+    //peek the row the resolve is expected to lock and pre-build its wake;
+    //the forSignalKey guard covers the race where a different row wins
+    let wakeCommand: EscalationWakeCommand | null = null;
+    const preview = await store.peekEscalationByMetadata({
+      key: params.key,
+      value: params.value,
+      roles: params.roles,
+      namespace: params.namespace,
+    });
+    if (preview?.signalKey) {
+      wakeCommand = await this._buildWakeCommand(
+        ns,
+        preview.topic,
+        preview.signalKey,
+        params.resolverPayload ?? {},
+      );
+    }
+
     const dbResult = await store.resolveEscalationByMetadata(
       { key: params.key, value: params.value, resolverPayload: params.resolverPayload, roles: params.roles, metadata: params.metadata },
+      wakeCommand ?? undefined,
     );
     if (!dbResult.ok) return dbResult;
-    if (dbResult.signalKey) {
+    if (dbResult.signalKey && !dbResult.wakeEnqueued) {
       await this._deliverEscalationSignal(ns, dbResult.topic, {
         id: dbResult.signalKey,
         data: params.resolverPayload ?? {},

--- a/services/store/index.ts
+++ b/services/store/index.ts
@@ -171,10 +171,17 @@ abstract class StoreService<
    * Leg1: Attempts to set the hook signal. If a pending signal occupies
    * the key (race condition), overwrites it and returns the pending data.
    * When called with a transaction, queues the setnxex (no pending detection).
+   *
+   * When `redelivery` is provided (the webhook routing for this hook),
+   * a consumed pending signal is republished as an engine stream message
+   * in the SAME transaction that overwrites the marker — the wake
+   * survives a crash at any instant. `pendingData` is then not returned,
+   * since the store already owns the redelivery.
    */
   abstract setHookSignal(
     hook: HookSignal,
     transaction?: TransactionProvider,
+    redelivery?: { aid: string; topic: string },
   ): Promise<{ success: boolean; pendingData?: string }>;
   /**
    * Leg2: Atomically gets the hook signal OR inserts a pending signal

--- a/services/store/providers/postgres/postgres.ts
+++ b/services/store/providers/postgres/postgres.ts
@@ -2283,9 +2283,39 @@ class PostgresStoreService extends StoreService<
     return { ok: true, entry: row.entry_json };
   }
 
+  /**
+   * Executes a pre-built wake publish inside the currently open resolve
+   * transaction, guarded by a SAVEPOINT so a wake failure can never roll
+   * back the resolve itself. Returns true when the wake row committed
+   * with the transaction; false means the caller should fall back to
+   * post-commit delivery.
+   */
+  private async enqueueEscalationWake(
+    wakeCommand: import('../../../../types/hmsh_escalations').EscalationWakeCommand | undefined,
+    signalKey: string | null,
+    escalationId: string,
+  ): Promise<boolean> {
+    if (!wakeCommand || !signalKey || wakeCommand.forSignalKey !== signalKey) {
+      return false;
+    }
+    await this.pgClient.query('SAVEPOINT escalation_wake');
+    try {
+      await this.pgClient.query(wakeCommand.sql, wakeCommand.params);
+      return true;
+    } catch (error) {
+      await this.pgClient.query('ROLLBACK TO SAVEPOINT escalation_wake');
+      this.logger.warn('escalation-wake-enqueue-error', {
+        escalationId,
+        error: error.message,
+      });
+      return false;
+    }
+  }
+
   async resolveEscalation(
     params: import('../../../../types/hmsh_escalations').ResolveEscalationParams,
-  ): Promise<import('../../../../types/hmsh_escalations').ResolveEscalationResult & { signalKey?: string | null; topic?: string | null }> {
+    wakeCommand?: import('../../../../types/hmsh_escalations').EscalationWakeCommand,
+  ): Promise<import('../../../../types/hmsh_escalations').ResolveEscalationResult & { signalKey?: string | null; topic?: string | null; wakeEnqueued?: boolean }> {
     const { id, namespace, resolverPayload, metadata } = params;
     const payloadJson = resolverPayload ? JSON.stringify(resolverPayload) : null;
     // metaJson is bound at a fixed index; the CASE no-ops when null so resolution
@@ -2334,17 +2364,49 @@ class PostgresStoreService extends StoreService<
         await this.pgClient.query('ROLLBACK');
         return { ok: false, reason: 'already-resolved' };
       }
+      //the wake commits WITH the resolve: a crash after COMMIT leaves both
+      //the resolved row and its wake message durable; a crash before
+      //leaves neither. The engine_streams INSERT trigger emits the
+      //delivery NOTIFY on commit.
+      const wakeEnqueued = await this.enqueueEscalationWake(wakeCommand, signal_key, id);
       await this.pgClient.query('COMMIT');
-      return { ok: true, entry: updateResult.rows[0], signalKey: signal_key, topic };
+      return { ok: true, entry: updateResult.rows[0], signalKey: signal_key, topic, wakeEnqueued };
     } catch (e) {
       await this.pgClient.query('ROLLBACK');
       throw e;
     }
   }
 
+  /**
+   * Non-locking preview of the row `resolveEscalationByMetadata` would
+   * select — used to pre-build the wake command before the resolve
+   * transaction opens. The `forSignalKey` guard on the wake command
+   * handles the race where a different row wins the lock.
+   */
+  async peekEscalationByMetadata(
+    params: import('../../../../types/hmsh_escalations').ResolveByMetadataParams,
+  ): Promise<{ id: string; signalKey: string | null; topic: string | null } | null> {
+    const { key, value, namespace, roles } = params;
+    const filter = JSON.stringify({ [key]: value });
+    const result = await this.pgClient.query(
+      `SELECT id, signal_key, topic FROM public.hmsh_escalations
+       WHERE ${namespace ? 'namespace = $3 AND' : ''}
+             metadata @> $1::jsonb
+         AND ($2::text[] IS NULL OR role = ANY($2::text[]))
+         AND status IN ('pending', 'cancelled')
+       ORDER BY priority ASC, created_at ASC
+       LIMIT 1`,
+      namespace ? [filter, roles ?? null, namespace] : [filter, roles ?? null],
+    );
+    const row = result.rows[0];
+    if (!row) return null;
+    return { id: row.id, signalKey: row.signal_key, topic: row.topic };
+  }
+
   async resolveEscalationByMetadata(
     params: import('../../../../types/hmsh_escalations').ResolveByMetadataParams,
-  ): Promise<import('../../../../types/hmsh_escalations').ResolveEscalationResult & { signalKey?: string | null; topic?: string | null }> {
+    wakeCommand?: import('../../../../types/hmsh_escalations').EscalationWakeCommand,
+  ): Promise<import('../../../../types/hmsh_escalations').ResolveEscalationResult & { signalKey?: string | null; topic?: string | null; wakeEnqueued?: boolean }> {
     const { key, value, namespace, resolverPayload, roles, metadata } = params;
     const filter = JSON.stringify({ [key]: value });
     const payloadJson = resolverPayload ? JSON.stringify(resolverPayload) : null;
@@ -2385,8 +2447,9 @@ class PostgresStoreService extends StoreService<
         await this.pgClient.query('ROLLBACK');
         return { ok: false, reason: 'already-resolved' };
       }
+      const wakeEnqueued = await this.enqueueEscalationWake(wakeCommand, signal_key, id);
       await this.pgClient.query('COMMIT');
-      return { ok: true, entry: updateResult.rows[0], signalKey: signal_key, topic };
+      return { ok: true, entry: updateResult.rows[0], signalKey: signal_key, topic, wakeEnqueued };
     } catch (e) {
       await this.pgClient.query('ROLLBACK');
       throw e;

--- a/services/store/providers/postgres/postgres.ts
+++ b/services/store/providers/postgres/postgres.ts
@@ -1056,6 +1056,7 @@ class PostgresStoreService extends StoreService<
   async setHookSignal(
     hook: HookSignal,
     transaction?: ProviderTransaction,
+    redelivery?: { aid: string; topic: string },
   ): Promise<{ success: boolean; pendingData?: string }> {
     const key = this.mintKey(KeyType.SIGNALS, { appId: this.appId });
     const { topic, resolved, jobId } = hook;
@@ -1102,6 +1103,51 @@ class PostgresStoreService extends StoreService<
       const captured = lockResult.rows[0]?.value;
       const wasInsert = lockResult.rows[0]?.inserted;
       const isPending = captured?.startsWith('$pending::');
+
+      if (isPending && redelivery) {
+        //consume the marker and commit its redelivery as ONE unit: the
+        //pending wake becomes a durable engine stream message in the
+        //same transaction that destroys the marker, so the wake
+        //survives a crash at any instant. A crash before COMMIT leaves
+        //the marker intact for the resume path to consume again.
+        const pendingData = captured.slice('$pending::'.length);
+        const message = JSON.stringify({
+          type: 'webhook',
+          status: 'success',
+          code: 200,
+          metadata: {
+            guid: guid(),
+            aid: redelivery.aid,
+            topic: redelivery.topic,
+          },
+          data: JSON.parse(pendingData),
+        });
+        const schemaName = this.kvsql().safeName(this.appId);
+        await this.pgClient.query('BEGIN');
+        try {
+          await this.pgClient.query(
+            `UPDATE ${tableName}
+             SET value = $1, expiry = NOW() + INTERVAL '${delay} seconds'
+             WHERE key = $2`,
+            [jobId, storedKey],
+          );
+          await this.pgClient.query(
+            `INSERT INTO ${schemaName}.engine_streams
+             (stream_name, message, priority)
+             VALUES ($1, $2, 5)`,
+            [this.appId, message],
+          );
+          await this.pgClient.query('COMMIT');
+        } catch (redeliveryError) {
+          await this.pgClient.query('ROLLBACK');
+          throw redeliveryError;
+        }
+        this.logger.warn('hook-signal-pending-redelivered', {
+          key: signalKey,
+          topic: redelivery.topic,
+        });
+        return { success: true };
+      }
 
       if (!wasInsert) {
         //step 2: row existed — overwrite with hook value

--- a/services/task/index.ts
+++ b/services/task/index.ts
@@ -137,8 +137,13 @@ class TaskService {
         expire,
       };
       //called standalone (no transaction) so the single CTE query can
-      //atomically detect and return pending signal data on collision
-      const result = await this.store.setHookSignal(hook);
+      //atomically detect and return pending signal data on collision.
+      //the redelivery routing lets the store republish a consumed
+      //pending signal durably, in the same transaction that consumes it
+      const result = await this.store.setHookSignal(hook, undefined, {
+        aid: hookRule.to,
+        topic,
+      });
       if (result.pendingData) {
         this.logger.warn('task-signal-race-pending-consumed', {
           topic,

--- a/tests/durable/wake-atomicity/postgres.test.ts
+++ b/tests/durable/wake-atomicity/postgres.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { Client as Postgres } from 'pg';
+
+import { Durable } from '../../../services/durable';
+import { WorkflowHandleService } from '../../../services/durable/handle';
+import { EscalationClientService } from '../../../services/escalations/client';
+import { guid, sleepFor } from '../../../modules/utils';
+import { ProviderNativeClient } from '../../../types/provider';
+import { dropTables, postgres_options } from '../../$setup/postgres';
+import { PostgresConnection } from '../../../services/connector/providers/postgres';
+
+import * as workflows from './src/workflows';
+
+const { Connection, Client, Worker } = Durable;
+
+/**
+ * The wake of a condition() awaiter must be atomic with the escalation
+ * resolve commit. The historical window: resolveEscalation committed
+ * `status='resolved'` (+resolver_payload), then the wake signal was
+ * published as a separate post-commit step — a process death between
+ * the two left the row resolved and the awaiting workflow asleep
+ * forever, with no error and no retry.
+ *
+ * This test simulates that death faithfully by suppressing the
+ * post-commit delivery step entirely: the workflow must still wake,
+ * because the wake message commits WITH the resolve transaction.
+ */
+describe('DURABLE | wake-atomicity | Postgres', () => {
+  let handle: WorkflowHandleService;
+  let postgresClient: ProviderNativeClient;
+  let client: InstanceType<typeof Client>;
+  const connection = { class: Postgres, options: postgres_options };
+  const runId = guid();
+
+  beforeAll(async () => {
+    if (process.env.POSTGRES_IS_REMOTE === 'true') return;
+
+    postgresClient = (
+      await PostgresConnection.connect(guid(), Postgres, postgres_options)
+    ).getClient();
+    await dropTables(postgresClient);
+  });
+
+  afterAll(async () => {
+    vi.restoreAllMocks();
+    await sleepFor(1500);
+    await Durable.shutdown();
+  }, 15_000);
+
+  describe('Worker and Client', () => {
+    it('should park a workflow on condition()', async () => {
+      client = new Client({ connection });
+      handle = await client.workflow.start({
+        args: [runId],
+        taskQueue: 'wake-world',
+        workflowName: 'crashWindowWorkflow',
+        workflowId: guid(),
+        expire: 600,
+      });
+
+      const worker = await Worker.create({
+        connection,
+        taskQueue: 'wake-world',
+        workflow: workflows.crashWindowWorkflow,
+      });
+      await worker.run();
+
+      //wait for the condition() suspension to write the escalation row
+      let escalation: { id: string } | undefined;
+      const start = Date.now();
+      while (!escalation) {
+        const list = await client.escalations.list({
+          role: 'crash-approver',
+          status: 'pending',
+        });
+        escalation = list.find((e) => (e.metadata as any)?.runId === runId);
+        if (!escalation && Date.now() - start > 15_000) {
+          throw new Error('timed out waiting for escalation row');
+        }
+        if (!escalation) await sleepFor(250);
+      }
+      expect(escalation).toBeDefined();
+    }, 20_000);
+  });
+
+  describe('Resolve with the post-commit delivery step suppressed', () => {
+    it('should wake the awaiting workflow from the resolve transaction alone', async () => {
+      const list = await client.escalations.list({
+        role: 'crash-approver',
+        status: 'pending',
+      });
+      const escalation = list.find((e) => (e.metadata as any)?.runId === runId);
+      expect(escalation).toBeDefined();
+
+      //simulate death between the resolve commit and the post-commit
+      //wake publish: the delivery step never runs
+      const spy = vi
+        .spyOn(
+          EscalationClientService.prototype as any,
+          '_deliverEscalationSignal',
+        )
+        .mockResolvedValue(false);
+
+      try {
+        const result = await client.escalations.resolve({
+          id: escalation!.id,
+          resolverPayload: { approved: true, via: 'atomic-wake' },
+        });
+        expect(result.ok).toBe(true);
+
+        //the durable proof is committed (the crash-window precondition)
+        const row = await postgresClient.query(
+          `SELECT status FROM public.hmsh_escalations WHERE id = $1`,
+          [escalation!.id],
+        );
+        expect(row.rows[0].status).toBe('resolved');
+
+        //the workflow must wake and return the resolver payload — the
+        //wake rides the resolve transaction, not the suppressed step
+        const output = (await Promise.race([
+          handle.result(),
+          sleepFor(25_000).then(() => {
+            throw new Error(
+              'workflow never woke: wake was lost with the suppressed post-commit delivery',
+            );
+          }),
+        ])) as { approved: boolean; via: string };
+        expect(output.approved).toBe(true);
+        expect(output.via).toBe('atomic-wake');
+      } finally {
+        spy.mockRestore();
+      }
+    }, 40_000);
+  });
+});

--- a/tests/durable/wake-atomicity/race.postgres.test.ts
+++ b/tests/durable/wake-atomicity/race.postgres.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { Client as Postgres } from 'pg';
+
+import { Durable } from '../../../services/durable';
+import { WorkflowHandleService } from '../../../services/durable/handle';
+import { Hook } from '../../../services/activities/hook';
+import { guid, sleepFor } from '../../../modules/utils';
+import { ProviderNativeClient } from '../../../types/provider';
+import { dropTables, postgres_options } from '../../$setup/postgres';
+import { PostgresConnection } from '../../../services/connector/providers/postgres';
+
+import * as workflows from './src/workflows';
+
+const { Client, Worker } = Durable;
+
+/**
+ * Registration-window race (field addendum): the escalation row commits
+ * with the waiter's Leg1 transaction and is immediately visible to hot
+ * consumers, but the waiter's hook-signal registration runs post-commit.
+ * A resolve that lands INSIDE that window must still wake the workflow:
+ * the wake's webhook finds no registration, parks as a $pending marker,
+ * and the completing registration must detect and redeliver it.
+ *
+ * The window is widened deterministically (registration delayed 1500ms)
+ * so the resolve always lands inside it — no timing luck involved.
+ */
+describe('DURABLE | wake-atomicity | registration-window race', () => {
+  let handle: WorkflowHandleService;
+  let postgresClient: ProviderNativeClient;
+  let client: InstanceType<typeof Client>;
+  const connection = { class: Postgres, options: postgres_options };
+  const runId = guid();
+
+  beforeAll(async () => {
+    if (process.env.POSTGRES_IS_REMOTE === 'true') return;
+
+    postgresClient = (
+      await PostgresConnection.connect(guid(), Postgres, postgres_options)
+    ).getClient();
+    await dropTables(postgresClient);
+  });
+
+  afterAll(async () => {
+    vi.restoreAllMocks();
+    await sleepFor(1500);
+    await Durable.shutdown();
+  }, 15_000);
+
+  it('should wake the workflow when the resolve lands inside the registration window', async () => {
+    //hold the waiter's post-commit registration open: the escalation row
+    //is visible while the hook signal is not yet registered
+    const original = Hook.prototype.registerWebHookSignal;
+    const spy = vi
+      .spyOn(Hook.prototype, 'registerWebHookSignal')
+      .mockImplementation(async function (this: unknown) {
+        await sleepFor(1_500);
+        return original.call(this);
+      });
+
+    try {
+      client = new Client({ connection });
+      handle = await client.workflow.start({
+        args: [runId],
+        taskQueue: 'wake-race',
+        workflowName: 'crashWindowWorkflow',
+        workflowId: guid(),
+        expire: 600,
+      });
+      const worker = await Worker.create({
+        connection,
+        taskQueue: 'wake-race',
+        workflow: workflows.crashWindowWorkflow,
+      });
+      await worker.run();
+
+      //hot consumer: resolve the row the instant it becomes visible
+      let resolved = false;
+      const start = Date.now();
+      while (!resolved) {
+        const list = await client.escalations.list({
+          role: 'crash-approver',
+          status: 'pending',
+        });
+        const escalation = list.find(
+          (e) => (e.metadata as any)?.runId === runId,
+        );
+        if (escalation) {
+          const result = await client.escalations.resolve({
+            id: escalation.id,
+            resolverPayload: { approved: true, via: 'in-window' },
+          });
+          expect(result.ok).toBe(true);
+          resolved = true;
+        } else {
+          if (Date.now() - start > 20_000) {
+            throw new Error('timed out waiting for escalation row');
+          }
+          await sleepFor(25);
+        }
+      }
+
+      //registration completes ~1.5s later; the parked wake must be
+      //detected and redelivered — the workflow wakes with the payload
+      const output = (await Promise.race([
+        handle.result(),
+        sleepFor(25_000).then(() => {
+          throw new Error(
+            'workflow never woke: in-window resolve was delivered to nobody',
+          );
+        }),
+      ])) as { approved: boolean; via: string };
+      expect(output.approved).toBe(true);
+      expect(output.via).toBe('in-window');
+    } finally {
+      spy.mockRestore();
+    }
+  }, 60_000);
+
+  it('should wake the workflow when the pending handoff dies after consuming the marker', async () => {
+    //same in-window resolve, but the process "dies" the instant the
+    //registration consumes the $pending marker — before the in-memory
+    //redelivery publish. The redelivery must be durable (committed with
+    //the marker consumption), or the wake is destroyed with the marker.
+    const raceRunId = guid();
+    const original = Hook.prototype.registerWebHookSignal;
+    const delaySpy = vi
+      .spyOn(Hook.prototype, 'registerWebHookSignal')
+      .mockImplementation(async function (this: unknown) {
+        await sleepFor(1_500);
+        return original.call(this);
+      });
+    const deathSpy = vi
+      .spyOn(Hook.prototype as any, 'redeliverPendingSignal')
+      .mockResolvedValue(undefined);
+
+    try {
+      const raceHandle = await client.workflow.start({
+        args: [raceRunId],
+        taskQueue: 'wake-race',
+        workflowName: 'crashWindowWorkflow',
+        workflowId: guid(),
+        expire: 600,
+      });
+
+      let resolved = false;
+      const start = Date.now();
+      while (!resolved) {
+        const list = await client.escalations.list({
+          role: 'crash-approver',
+          status: 'pending',
+        });
+        const escalation = list.find(
+          (e) => (e.metadata as any)?.runId === raceRunId,
+        );
+        if (escalation) {
+          const result = await client.escalations.resolve({
+            id: escalation.id,
+            resolverPayload: { approved: true, via: 'durable-handoff' },
+          });
+          expect(result.ok).toBe(true);
+          resolved = true;
+        } else {
+          if (Date.now() - start > 20_000) {
+            throw new Error('timed out waiting for escalation row');
+          }
+          await sleepFor(25);
+        }
+      }
+
+      const output = (await Promise.race([
+        raceHandle.result(),
+        sleepFor(25_000).then(() => {
+          throw new Error(
+            'workflow never woke: the pending marker was consumed but its redelivery died in memory',
+          );
+        }),
+      ])) as { approved: boolean; via: string };
+      expect(output.approved).toBe(true);
+      expect(output.via).toBe('durable-handoff');
+    } finally {
+      delaySpy.mockRestore();
+      deathSpy.mockRestore();
+    }
+  }, 60_000);
+});

--- a/tests/durable/wake-atomicity/src/workflows.ts
+++ b/tests/durable/wake-atomicity/src/workflows.ts
@@ -1,0 +1,21 @@
+import { Durable } from '../../../../services/durable';
+
+// Parks on condition(), writing one hmsh_escalations row at suspension.
+// Resolving that row must wake this workflow even if the resolver process
+// dies immediately after the resolve transaction commits.
+export async function crashWindowWorkflow(
+  runId: string,
+): Promise<{ approved: boolean; via: string }> {
+  const signalId = `wake-${Durable.guid()}`;
+  const result = await Durable.workflow.condition<{ approved: boolean; via: string }>(
+    signalId,
+    {
+      role: 'crash-approver',
+      type: 'wake-atomicity',
+      priority: 1,
+      description: `crash-window wake for ${runId}`,
+      metadata: { runId },
+    },
+  );
+  return result as { approved: boolean; via: string };
+}

--- a/types/hmsh_escalations.ts
+++ b/types/hmsh_escalations.ts
@@ -94,6 +94,20 @@ export type ResolveEscalationResult =
   | { ok: true; entry: EscalationEntry }
   | { ok: false; reason: 'not-found' | 'already-resolved' | 'already-cancelled' | 'already-expired' };
 
+/**
+ * A pre-built wake publish, executed INSIDE the resolve transaction so the
+ * awaiting workflow's wake commits atomically with `status='resolved'`. The
+ * SQL is a stream INSERT produced by the stream provider; `forSignalKey`
+ * pins the command to the row it was built for — the store executes it only
+ * when the locked row's `signal_key` matches (a mismatched row falls back
+ * to post-commit delivery).
+ */
+export interface EscalationWakeCommand {
+  forSignalKey: string;
+  sql: string;
+  params: unknown[];
+}
+
 export type ReleaseEscalationResult =
   | { ok: true; entry: EscalationEntry }
   | { ok: false; reason: 'not-found' | 'wrong-assignee' };


### PR DESCRIPTION
Workflows awaiting `condition()` could wedge forever when a crash landed between an escalation state change and its wake signal. What is better:

- Resolving an escalation now commits the awaiter's wake **in the same transaction** as the `status='resolved'` row — a resolve that is durable always wakes its workflow, across `resolve()` and `resolveByMetadata()`.
- A wake that arrives inside the awaiter's registration window is now handed off **durably**: the pending marker and its redelivery commit as one unit, so the wake survives a crash at any instant.
- Fail-first coverage locks both windows: `tests/durable/wake-atomicity/` (4 tests), escalations 73, functional 255, durable 418 all green; wake lifecycle and hot-path cost unchanged.

The companion lost-`sleep()` case is excluded — no failing test could be constructed; diagnostic log lines now pinpoint wake-chain breaks in the field.