### PR TITLE
Cancel wakes durable; dead reservations reclaim; resolve paths atomic (v0.25.6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.25.5",
+  "version": "0.25.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.25.5",
+      "version": "0.25.6",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.25.5",
+  "version": "0.25.6",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/activities/hook.ts
+++ b/services/activities/hook.ts
@@ -649,6 +649,9 @@ class Hook extends Activity {
       this.context.metadata.jid = jobId;
       this.context.metadata.gid = gId;
       this.context.metadata.dad = dad;
+      //captured for the timeout disarm below: processEvent's state
+      //hydration replaces context.metadata before the disarm runs
+      const waiterJid = jobId;
 
       // Inline retry for FORBIDDEN: Leg2 arrived in the window between
       // setHookSignal (standalone) and Leg1 transaction.exec(). The 100B
@@ -664,6 +667,27 @@ class Hook extends Activity {
           await this.processEvent(status, code, 'hook');
           if (code === 200) {
             await taskService.deleteWebHookSignal(this.config.hook.topic, data);
+            //signal won the race: disarm the SLA timeout leg (the mirror
+            //of the timeout-won path, which deletes the signal). The
+            //armed timehook may not survive to fire against the settled
+            //wait. Addressed by the SIGNAL's jid + dimensional address —
+            //processEvent has since rehydrated this.context.
+            if (this.config.sleep) {
+              try {
+                await (this.store as any).expireTimeHook?.(
+                  waiterJid,
+                  this.metadata.aid,
+                );
+              } catch (error) {
+                //best-effort: a surviving timer fires once and is
+                //consumed as an inactive-job event
+                this.logger.warn('hook-timeout-disarm-error', {
+                  jid: waiterJid,
+                  aid: this.metadata.aid,
+                  error,
+                });
+              }
+            }
             //clean up orphan pending on the sibling signal topic
             //  wfs.wait delivered → remove wfs.signal pending
             //  wfs.signal delivered → remove wfs.wait pending

--- a/services/escalations/client.ts
+++ b/services/escalations/client.ts
@@ -2,7 +2,6 @@ import {
   HMSH_LOGLEVEL,
 } from '../../modules/enums';
 import { formatISODate, guid, hashOptions } from '../../modules/utils';
-import { KeyType } from '../../modules/key';
 import { HotMesh } from '../hotmesh';
 import { EventsConfig, SystemEvent, EscalationVerb } from '../../types/system_events';
 import { Connection } from '../../types/durable';
@@ -203,9 +202,9 @@ export class EscalationClientService {
   }
 
   /**
-   * Builds the wake publish as a SQL command so the store can commit it
-   * INSIDE the resolve transaction — the wake becomes durable with the
-   * resolved row, closing the crash window between resolve commit and
+   * Builds the wake as a webhook message so the store can commit it
+   * INSIDE the resolve/cancel transaction — the wake becomes durable
+   * with the status change, closing the crash window between commit and
    * post-commit signal delivery. Mirrors `_deliverEscalationSignal`'s
    * topic fallback chain; returns null when no hook rule is deployed
    * for any candidate topic (the caller then keeps post-commit
@@ -234,13 +233,10 @@ export class EscalationClientService {
           metadata: { guid: guid(), aid, topic: candidate },
           data: { id: signalKey, data },
         };
-        const streamKey = engine.stream.mintKey(KeyType.STREAMS, {
-          topic: null,
-        });
-        const { sql, params } = engine.stream._publishMessages(streamKey, [
-          JSON.stringify(streamData),
-        ]);
-        return { forSignalKey: signalKey, sql, params };
+        return {
+          forSignalKey: signalKey,
+          message: JSON.stringify(streamData),
+        };
       } catch {
         /* candidate not deployed — try the next topic */
       }

--- a/services/escalations/client.ts
+++ b/services/escalations/client.ts
@@ -354,18 +354,34 @@ export class EscalationClientService {
   /**
    * Cancels a pending escalation and delivers a cancellation signal to the
    * waiting workflow so that `condition()` returns `null`. Terminal rows
-   * return `already-terminal`. Signal delivery is best-effort post-commit —
-   * the committed cancelled row is the durable record; any missed delivery
-   * can be detected via a sweep of rows with `status = 'cancelled'` and a
-   * non-null `signal_key`.
+   * return `already-terminal`. The cancellation wake commits inside the
+   * cancel transaction (same durability contract as `resolve()`); when no
+   * hook rule is deployed for any candidate topic, delivery falls back to
+   * a best-effort post-commit publish.
    */
   async cancel(id: string, namespace?: string): Promise<CancelEscalationResult> {
     const ns = namespace ?? APP_ID;
     const hm = await this._engine(null, ns);
-    const result = await (hm.engine.store as any).cancelEscalation(id, namespace);
+    const store = hm.engine.store as any;
+
+    //pre-build the cancellation wake so it commits INSIDE the cancel
+    //transaction — condition() resumes with null even if the process
+    //dies the instant the cancel commits
+    let wakeCommand: EscalationWakeCommand | null = null;
+    const preview = await store.getEscalation(id, namespace);
+    if (preview?.signal_key) {
+      wakeCommand = await this._buildWakeCommand(
+        ns,
+        preview.topic,
+        preview.signal_key,
+        { __escalation_cancelled: true },
+      );
+    }
+
+    const result = await store.cancelEscalation(id, namespace, wakeCommand ?? undefined);
     if (result.ok === true) {
       this._emit('cancelled', result.entry);
-      if (result.entry.signal_key) {
+      if (result.entry.signal_key && !result.wakeEnqueued) {
         await this._deliverEscalationSignal(ns, result.entry.topic, {
           id: result.entry.signal_key,
           data: { __escalation_cancelled: true },

--- a/services/escalations/client.ts
+++ b/services/escalations/client.ts
@@ -561,6 +561,12 @@ export class EscalationClientService {
    * (still-pending) row's GIN-indexed `metadata` in the single atomic UPDATE.
    * See {@link resolve}.
    */
+  /**
+   * Bulk-resolves standalone escalations (rows with `signal_key = null`).
+   * Rows backing a live `condition()` waiter are excluded — they stay
+   * pending so a targeted `resolve()`/`cancel()` can deliver their wake;
+   * bulk resolution carries no wake and would strand the workflow.
+   */
   async resolveMany(params: ResolveManyParams): Promise<EscalationEntry[]> {
     const hm = await this._engine(null, params.namespace);
     const entries = await (hm.engine.store as any).resolveManyEscalations(params);

--- a/services/store/providers/postgres/postgres.ts
+++ b/services/store/providers/postgres/postgres.ts
@@ -2366,46 +2366,34 @@ class PostgresStoreService extends StoreService<
   }
 
   /**
-   * Writes a pre-built wake message to engine_streams inside the
-   * currently open resolve transaction, guarded by a SAVEPOINT so a
-   * wake failure can never roll back the resolve itself. Returns true
-   * when the wake row committed with the transaction; false means the
-   * caller should fall back to post-commit delivery.
+   * Composes the wake as a data-modifying CTE appended to a settle
+   * statement (resolve/cancel). The INSERT fires iff the settle CTE
+   * (`fromCTE`) produced a row whose signal_key matches the wake — one
+   * atomic statement, safe on any connection type (Client or Pool),
+   * with no transaction window for unrelated queries to interleave
+   * into. Appends the wake params to `params` in place.
    */
-  private async enqueueEscalationWake(
+  private composeEscalationWakeCTE(
     wakeCommand: import('../../../../types/hmsh_escalations').EscalationWakeCommand | undefined,
-    signalKey: string | null,
-    escalationId: string,
-  ): Promise<boolean> {
-    if (!wakeCommand || !signalKey || wakeCommand.forSignalKey !== signalKey) {
-      return false;
+    params: any[],
+    fromCTE: string,
+  ): { wakeCTE: string; wakeCount: string } {
+    if (!wakeCommand) {
+      return { wakeCTE: '', wakeCount: '0::int AS wake_count' };
     }
     const schemaName = this.kvsql().safeName(this.appId);
-    try {
-      //SAVEPOINT inside the try: on a pooled client (no surrounding
-      //transaction) it raises 25P01 — treated like any other wake
-      //failure, so the resolve itself is never failed and the caller
-      //falls back to post-commit delivery
-      await this.pgClient.query('SAVEPOINT escalation_wake');
-      await this.pgClient.query(
-        `INSERT INTO ${schemaName}.engine_streams
-         (stream_name, message, priority)
-         VALUES ($1, $2, 5)`,
-        [this.appId, wakeCommand.message],
-      );
-      return true;
-    } catch (error) {
-      try {
-        await this.pgClient.query('ROLLBACK TO SAVEPOINT escalation_wake');
-      } catch {
-        //no savepoint to roll back to (pooled client) — nothing to undo
-      }
-      this.logger.warn('escalation-wake-enqueue-error', {
-        escalationId,
-        error: error.message,
-      });
-      return false;
-    }
+    const base = params.length;
+    params.push(this.appId, wakeCommand.message, wakeCommand.forSignalKey);
+    return {
+      wakeCTE: `,
+        wake AS (
+          INSERT INTO ${schemaName}.engine_streams (stream_name, message, priority)
+          SELECT $${base + 1}, $${base + 2}, 5 FROM ${fromCTE}
+          WHERE ${fromCTE}.signal_key = $${base + 3}
+          RETURNING id
+        )`,
+      wakeCount: '(SELECT COUNT(*) FROM wake)::int AS wake_count',
+    };
   }
 
   async resolveEscalation(
@@ -2414,63 +2402,69 @@ class PostgresStoreService extends StoreService<
   ): Promise<import('../../../../types/hmsh_escalations').ResolveEscalationResult & { signalKey?: string | null; topic?: string | null; wakeEnqueued?: boolean }> {
     const { id, namespace, resolverPayload, metadata } = params;
     const payloadJson = resolverPayload ? JSON.stringify(resolverPayload) : null;
-    // metaJson is bound at a fixed index; the CASE no-ops when null so resolution
-    // can merge into the GIN-indexed metadata without disturbing the param layout.
     const metaJson = metadata ? JSON.stringify(metadata) : null;
-    // Explicit transaction: FOR UPDATE locks the row; WHERE guard on UPDATE is the TOCTOU
-    // barrier — a concurrent caller whose UPDATE matches 0 rows sees 'already-resolved'.
-    // On crash before COMMIT neither write lands; on crash after COMMIT both are durable.
-    // The resolved row's signal_key is the durable proof for recovery sweeps.
-    await this.pgClient.query('BEGIN');
-    try {
-      const lockResult = await this.pgClient.query(
-        `SELECT id, signal_key, topic, status FROM public.hmsh_escalations
-         WHERE id = $1 ${namespace ? 'AND namespace = $2' : ''} FOR UPDATE`,
-        namespace ? [id, namespace] : [id],
-      );
-      if (!lockResult.rows[0]) {
-        await this.pgClient.query('ROLLBACK');
-        return { ok: false, reason: 'not-found' };
-      }
-      const { signal_key, topic, status } = lockResult.rows[0];
-      if (status === 'cancelled') {
-        await this.pgClient.query('ROLLBACK');
-        return { ok: false, reason: 'already-cancelled' };
-      }
-      if (status === 'expired') {
+    //single statement: FOR UPDATE lock, TOCTOU-guarded UPDATE, and the
+    //wake INSERT are one atomic unit. The wake commits WITH the
+    //resolve — a crash after the statement leaves both the resolved row
+    //and its wake message durable; before, neither. The engine_streams
+    //INSERT trigger emits the delivery NOTIFY on commit. Safe on any
+    //connection type; no window for unrelated queries to interleave.
+    const sqlParams: any[] = namespace
+      ? [id, payloadJson, metaJson, namespace]
+      : [id, payloadJson, metaJson];
+    const { wakeCTE, wakeCount } = this.composeEscalationWakeCTE(
+      wakeCommand,
+      sqlParams,
+      'resolved',
+    );
+    const result = await this.pgClient.query(`
+      WITH target AS MATERIALIZED (
+        SELECT id, signal_key, topic, status FROM public.hmsh_escalations
+        WHERE id = $1 ${namespace ? 'AND namespace = $4' : ''}
+        LIMIT 1 FOR UPDATE
+      ),
+      resolved AS (
+        UPDATE public.hmsh_escalations e
+        SET status = 'resolved', resolved_at = NOW(), resolver_payload = $2,
+            metadata = CASE WHEN $3::jsonb IS NOT NULL
+                            THEN COALESCE(e.metadata, '{}'::jsonb) || $3::jsonb
+                            ELSE e.metadata END,
+            updated_at = NOW()
+        FROM target
+        WHERE e.id = target.id AND target.status = 'pending'
+        RETURNING e.*
+      )${wakeCTE}
+      SELECT t.id, t.status AS prior_status, t.signal_key, t.topic,
+        CASE
+          WHEN r.id IS NOT NULL THEN 'resolved'
+          WHEN t.id IS NULL     THEN 'not-found'
+          ELSE 'blocked'
+        END AS outcome,
+        row_to_json(r.*) AS entry_json,
+        ${wakeCount}
+      FROM (SELECT * FROM target) t
+      FULL OUTER JOIN (SELECT * FROM resolved) r ON r.id = t.id
+    `, sqlParams);
+    const row = result.rows[0];
+    if (!row || row.outcome === 'not-found') return { ok: false, reason: 'not-found' };
+    if (row.outcome === 'blocked') {
+      if (row.prior_status === 'cancelled') return { ok: false, reason: 'already-cancelled' };
+      if (row.prior_status === 'expired') {
         // The wait's SLA timer fired first and the workflow resumed with
         // false — the resolver payload has nowhere to go. Name it, so the
         // operator learns the deadline passed rather than believing the
         // resolution landed.
-        await this.pgClient.query('ROLLBACK');
         return { ok: false, reason: 'already-expired' };
       }
-      const updateResult = await this.pgClient.query(
-        `UPDATE public.hmsh_escalations
-         SET status = 'resolved', resolved_at = NOW(), resolver_payload = $2,
-             metadata = CASE WHEN $3::jsonb IS NOT NULL
-                             THEN COALESCE(metadata, '{}'::jsonb) || $3::jsonb
-                             ELSE metadata END,
-             updated_at = NOW()
-         WHERE id = $1 ${namespace ? 'AND namespace = $4' : ''} AND status = 'pending'
-         RETURNING *`,
-        namespace ? [id, payloadJson, metaJson, namespace] : [id, payloadJson, metaJson],
-      );
-      if (!updateResult.rows[0]) {
-        await this.pgClient.query('ROLLBACK');
-        return { ok: false, reason: 'already-resolved' };
-      }
-      //the wake commits WITH the resolve: a crash after COMMIT leaves both
-      //the resolved row and its wake message durable; a crash before
-      //leaves neither. The engine_streams INSERT trigger emits the
-      //delivery NOTIFY on commit.
-      const wakeEnqueued = await this.enqueueEscalationWake(wakeCommand, signal_key, id);
-      await this.pgClient.query('COMMIT');
-      return { ok: true, entry: updateResult.rows[0], signalKey: signal_key, topic, wakeEnqueued };
-    } catch (e) {
-      await this.pgClient.query('ROLLBACK');
-      throw e;
+      return { ok: false, reason: 'already-resolved' };
     }
+    return {
+      ok: true,
+      entry: row.entry_json,
+      signalKey: row.signal_key,
+      topic: row.topic,
+      wakeEnqueued: row.wake_count > 0,
+    };
   }
 
   /**
@@ -2507,49 +2501,60 @@ class PostgresStoreService extends StoreService<
     const filter = JSON.stringify({ [key]: value });
     const payloadJson = resolverPayload ? JSON.stringify(resolverPayload) : null;
     const metaJson = metadata ? JSON.stringify(metadata) : null;
-    await this.pgClient.query('BEGIN');
-    try {
-      const lockResult = await this.pgClient.query(
-        `SELECT id, signal_key, topic, status FROM public.hmsh_escalations
-         WHERE ${namespace ? 'namespace = $3 AND' : ''}
-               metadata @> $1::jsonb
-           AND ($2::text[] IS NULL OR role = ANY($2::text[]))
-           AND status IN ('pending', 'cancelled')
-         ORDER BY priority ASC, created_at ASC
-         LIMIT 1 FOR UPDATE`,
-        namespace ? [filter, roles ?? null, namespace] : [filter, roles ?? null],
-      );
-      if (!lockResult.rows[0]) {
-        await this.pgClient.query('ROLLBACK');
-        return { ok: false, reason: 'not-found' };
-      }
-      const { id, signal_key, topic, status } = lockResult.rows[0];
-      if (status === 'cancelled') {
-        await this.pgClient.query('ROLLBACK');
-        return { ok: false, reason: 'already-cancelled' };
-      }
-      const updateResult = await this.pgClient.query(
-        `UPDATE public.hmsh_escalations
-         SET status = 'resolved', resolved_at = NOW(), resolver_payload = $2,
-             metadata = CASE WHEN $3::jsonb IS NOT NULL
-                             THEN COALESCE(metadata, '{}'::jsonb) || $3::jsonb
-                             ELSE metadata END,
-             updated_at = NOW()
-         WHERE id = $1 AND status = 'pending'
-         RETURNING *`,
-        [id, payloadJson, metaJson],
-      );
-      if (!updateResult.rows[0]) {
-        await this.pgClient.query('ROLLBACK');
-        return { ok: false, reason: 'already-resolved' };
-      }
-      const wakeEnqueued = await this.enqueueEscalationWake(wakeCommand, signal_key, id);
-      await this.pgClient.query('COMMIT');
-      return { ok: true, entry: updateResult.rows[0], signalKey: signal_key, topic, wakeEnqueued };
-    } catch (e) {
-      await this.pgClient.query('ROLLBACK');
-      throw e;
+    //single statement — see resolveEscalation for the atomicity contract
+    const sqlParams: any[] = namespace
+      ? [filter, roles ?? null, payloadJson, metaJson, namespace]
+      : [filter, roles ?? null, payloadJson, metaJson];
+    const { wakeCTE, wakeCount } = this.composeEscalationWakeCTE(
+      wakeCommand,
+      sqlParams,
+      'resolved',
+    );
+    const result = await this.pgClient.query(`
+      WITH target AS MATERIALIZED (
+        SELECT id, signal_key, topic, status FROM public.hmsh_escalations
+        WHERE ${namespace ? 'namespace = $5 AND' : ''}
+              metadata @> $1::jsonb
+          AND ($2::text[] IS NULL OR role = ANY($2::text[]))
+          AND status IN ('pending', 'cancelled')
+        ORDER BY priority ASC, created_at ASC
+        LIMIT 1 FOR UPDATE
+      ),
+      resolved AS (
+        UPDATE public.hmsh_escalations e
+        SET status = 'resolved', resolved_at = NOW(), resolver_payload = $3,
+            metadata = CASE WHEN $4::jsonb IS NOT NULL
+                            THEN COALESCE(e.metadata, '{}'::jsonb) || $4::jsonb
+                            ELSE e.metadata END,
+            updated_at = NOW()
+        FROM target
+        WHERE e.id = target.id AND target.status = 'pending'
+        RETURNING e.*
+      )${wakeCTE}
+      SELECT t.id, t.status AS prior_status, t.signal_key, t.topic,
+        CASE
+          WHEN r.id IS NOT NULL THEN 'resolved'
+          WHEN t.id IS NULL     THEN 'not-found'
+          ELSE 'blocked'
+        END AS outcome,
+        row_to_json(r.*) AS entry_json,
+        ${wakeCount}
+      FROM (SELECT * FROM target) t
+      FULL OUTER JOIN (SELECT * FROM resolved) r ON r.id = t.id
+    `, sqlParams);
+    const row = result.rows[0];
+    if (!row || row.outcome === 'not-found') return { ok: false, reason: 'not-found' };
+    if (row.outcome === 'blocked') {
+      if (row.prior_status === 'cancelled') return { ok: false, reason: 'already-cancelled' };
+      return { ok: false, reason: 'already-resolved' };
     }
+    return {
+      ok: true,
+      entry: row.entry_json,
+      signalKey: row.signal_key,
+      topic: row.topic,
+      wakeEnqueued: row.wake_count > 0,
+    };
   }
 
   async cancelEscalation(
@@ -2561,22 +2566,12 @@ class PostgresStoreService extends StoreService<
     //that fires iff the cancel lands AND the row's signal_key matches
     //the wake — atomic on any connection type (Client or Pool), with
     //no BEGIN/COMMIT window for unrelated queries to interleave into
-    const schemaName = this.kvsql().safeName(this.appId);
     const params: any[] = namespace ? [id, namespace] : [id];
-    let wakeCTE = '';
-    let wakeCount = '0::int AS wake_count';
-    if (wakeCommand) {
-      const base = params.length;
-      params.push(this.appId, wakeCommand.message, wakeCommand.forSignalKey);
-      wakeCTE = `,
-        wake AS (
-          INSERT INTO ${schemaName}.engine_streams (stream_name, message, priority)
-          SELECT $${base + 1}, $${base + 2}, 5 FROM cancelled
-          WHERE cancelled.signal_key = $${base + 3}
-          RETURNING id
-        )`;
-      wakeCount = '(SELECT COUNT(*) FROM wake)::int AS wake_count';
-    }
+    const { wakeCTE, wakeCount } = this.composeEscalationWakeCTE(
+      wakeCommand,
+      params,
+      'cancelled',
+    );
     const result = await this.pgClient.query(`
       WITH target AS MATERIALIZED (
         SELECT id, status FROM public.hmsh_escalations
@@ -2751,6 +2746,7 @@ class PostgresStoreService extends StoreService<
        WHERE id = ANY($2::uuid[])
          ${namespace ? 'AND namespace = $4' : ''}
          AND status = 'pending'
+         AND signal_key IS NULL
        RETURNING *`,
       namespace ? [payloadJson, ids, metaJson, namespace] : [payloadJson, ids, metaJson],
     );

--- a/services/store/providers/postgres/postgres.ts
+++ b/services/store/providers/postgres/postgres.ts
@@ -1105,48 +1105,55 @@ class PostgresStoreService extends StoreService<
       const isPending = captured?.startsWith('$pending::');
 
       if (isPending && redelivery) {
-        //consume the marker and commit its redelivery as ONE unit: the
-        //pending wake becomes a durable engine stream message in the
-        //same transaction that destroys the marker, so the wake
-        //survives a crash at any instant. A crash before COMMIT leaves
-        //the marker intact for the resume path to consume again.
-        const pendingData = captured.slice('$pending::'.length);
-        const message = JSON.stringify({
-          type: 'webhook',
-          status: 'success',
-          code: 200,
-          metadata: {
-            guid: guid(),
-            aid: redelivery.aid,
-            topic: redelivery.topic,
-          },
-          data: JSON.parse(pendingData),
-        });
+        //consume the marker and commit its redelivery as ONE statement:
+        //the pending wake becomes a durable engine stream message in
+        //the same atomic unit that destroys the marker, so the wake
+        //survives a crash at any instant. Single-statement composition
+        //is safe on any connection type (Client or Pool) and cannot
+        //interleave with unrelated queries. The consume is guarded on
+        //the value still being a pending marker, and the redelivered
+        //payload is read from the row itself — a marker refreshed by a
+        //newer signal between capture and consume delivers the NEWER
+        //payload rather than a stale copy.
         const schemaName = this.kvsql().safeName(this.appId);
-        await this.pgClient.query('BEGIN');
-        try {
-          await this.pgClient.query(
-            `UPDATE ${tableName}
-             SET value = $1, expiry = NOW() + INTERVAL '${delay} seconds'
-             WHERE key = $2`,
-            [jobId, storedKey],
-          );
-          await this.pgClient.query(
-            `INSERT INTO ${schemaName}.engine_streams
+        const res = await this.pgClient.query(
+          `WITH prev AS (
+             SELECT value FROM ${tableName}
+             WHERE key = $1 FOR UPDATE
+           ),
+           consumed AS (
+             UPDATE ${tableName} t
+             SET value = $2, expiry = NOW() + INTERVAL '${delay} seconds'
+             FROM prev
+             WHERE t.key = $1 AND prev.value LIKE '$pending::%'
+             RETURNING prev.value AS pending_value
+           )
+           INSERT INTO ${schemaName}.engine_streams
              (stream_name, message, priority)
-             VALUES ($1, $2, 5)`,
-            [this.appId, message],
-          );
-          await this.pgClient.query('COMMIT');
-        } catch (redeliveryError) {
-          await this.pgClient.query('ROLLBACK');
-          throw redeliveryError;
+           SELECT $3,
+             json_build_object(
+               'type', 'webhook',
+               'status', 'success',
+               'code', 200,
+               'metadata', json_build_object(
+                 'guid', $4::text, 'aid', $5::text, 'topic', $6::text),
+               'data', substr(consumed.pending_value, 11)::json
+             )::text,
+             5
+           FROM consumed
+           RETURNING id`,
+          [storedKey, jobId, this.appId, guid(), redelivery.aid, redelivery.topic],
+        );
+        if ((res.rowCount ?? 0) > 0) {
+          this.logger.warn('hook-signal-pending-redelivered', {
+            key: signalKey,
+            topic: redelivery.topic,
+          });
+          return { success: true };
         }
-        this.logger.warn('hook-signal-pending-redelivered', {
-          key: signalKey,
-          topic: redelivery.topic,
-        });
-        return { success: true };
+        //the marker vanished between capture and consume (a concurrent
+        //duplicate Leg1 consumed it) — idempotent no-op
+        return { success: false };
       }
 
       if (!wasInsert) {
@@ -1374,16 +1381,45 @@ class PostgresStoreService extends StoreService<
       data: { timestamp: Date.now() },
     });
 
+    //jid column stamped so job-scoped expiry (interrupt purge, timeout
+    //disarm) can address armed timers through the partial jid index
     const sql = `INSERT INTO ${schemaName}.engine_streams
-      (stream_name, message, priority, visible_at)
-      VALUES ($1, $2, 5, NOW() + INTERVAL '${Math.max(delayMs, 0)} milliseconds')`;
-    const params = [this.appId, message];
+      (stream_name, jid, message, priority, visible_at)
+      VALUES ($1, $2, $3, 5, NOW() + INTERVAL '${Math.max(delayMs, 0)} milliseconds')`;
+    const params = [this.appId, jobId, message];
 
     if (transaction && typeof (transaction as any).addCommand === 'function') {
       (transaction as any).addCommand(sql, params);
     } else {
       await this.pgClient.query(sql, params);
     }
+  }
+
+  /**
+   * Disarms a scheduled timehook (soft delete) for one activity of a
+   * job — the mirror of registerTimeHook, called when the SIGNAL wins
+   * an SLA-gated wait so the armed timeout cannot fire against the
+   * settled workflow. Scoped by the jid index, then narrowed to the
+   * activity via the message metadata. Dimensional addressing is
+   * deliberately NOT matched: a job's waits on one activity are
+   * sequential (cycle N settles before cycle N+1 arms), so at most one
+   * timer per (jid, aid) is armed at a time, and the signal composite's
+   * address can differ from the stored one at cycle offsets.
+   */
+  async expireTimeHook(
+    jobId: string,
+    activityId: string,
+  ): Promise<number> {
+    const schemaName = this.kvsql().safeName(this.appId);
+    const res = await this.pgClient.query(
+      `UPDATE ${schemaName}.engine_streams
+       SET expired_at = NOW()
+       WHERE jid = $1 AND expired_at IS NULL AND visible_at > NOW()
+         AND (message::jsonb ->> 'type') = 'timehook'
+         AND (message::jsonb -> 'metadata' ->> 'aid') = $2`,
+      [jobId, activityId],
+    );
+    return res.rowCount ?? 0;
   }
 
   async getNextTask(
@@ -2330,11 +2366,11 @@ class PostgresStoreService extends StoreService<
   }
 
   /**
-   * Executes a pre-built wake publish inside the currently open resolve
-   * transaction, guarded by a SAVEPOINT so a wake failure can never roll
-   * back the resolve itself. Returns true when the wake row committed
-   * with the transaction; false means the caller should fall back to
-   * post-commit delivery.
+   * Writes a pre-built wake message to engine_streams inside the
+   * currently open resolve transaction, guarded by a SAVEPOINT so a
+   * wake failure can never roll back the resolve itself. Returns true
+   * when the wake row committed with the transaction; false means the
+   * caller should fall back to post-commit delivery.
    */
   private async enqueueEscalationWake(
     wakeCommand: import('../../../../types/hmsh_escalations').EscalationWakeCommand | undefined,
@@ -2344,12 +2380,26 @@ class PostgresStoreService extends StoreService<
     if (!wakeCommand || !signalKey || wakeCommand.forSignalKey !== signalKey) {
       return false;
     }
-    await this.pgClient.query('SAVEPOINT escalation_wake');
+    const schemaName = this.kvsql().safeName(this.appId);
     try {
-      await this.pgClient.query(wakeCommand.sql, wakeCommand.params);
+      //SAVEPOINT inside the try: on a pooled client (no surrounding
+      //transaction) it raises 25P01 — treated like any other wake
+      //failure, so the resolve itself is never failed and the caller
+      //falls back to post-commit delivery
+      await this.pgClient.query('SAVEPOINT escalation_wake');
+      await this.pgClient.query(
+        `INSERT INTO ${schemaName}.engine_streams
+         (stream_name, message, priority)
+         VALUES ($1, $2, 5)`,
+        [this.appId, wakeCommand.message],
+      );
       return true;
     } catch (error) {
-      await this.pgClient.query('ROLLBACK TO SAVEPOINT escalation_wake');
+      try {
+        await this.pgClient.query('ROLLBACK TO SAVEPOINT escalation_wake');
+      } catch {
+        //no savepoint to roll back to (pooled client) — nothing to undo
+      }
       this.logger.warn('escalation-wake-enqueue-error', {
         escalationId,
         error: error.message,
@@ -2507,54 +2557,55 @@ class PostgresStoreService extends StoreService<
     namespace?: string,
     wakeCommand?: import('../../../../types/hmsh_escalations').EscalationWakeCommand,
   ): Promise<import('../../../../types/hmsh_escalations').CancelEscalationResult & { wakeEnqueued?: boolean }> {
-    //explicit transaction so the cancellation wake commits WITH the
-    //status change — same durability contract as resolveEscalation
-    await this.pgClient.query('BEGIN');
-    try {
-      const result = await this.pgClient.query(`
-        WITH target AS MATERIALIZED (
-          SELECT id, status FROM public.hmsh_escalations
-          WHERE id = $1 ${namespace ? 'AND namespace = $2' : ''}
-          LIMIT 1 FOR UPDATE
-        ),
-        cancelled AS (
-          UPDATE public.hmsh_escalations
-          SET status = 'cancelled', updated_at = NOW()
-          FROM target
-          WHERE public.hmsh_escalations.id = target.id
-            AND target.status = 'pending'
-          RETURNING public.hmsh_escalations.*
-        )
-        SELECT t.id, t.status AS prior_status,
-          CASE
-            WHEN c.id IS NOT NULL THEN 'cancelled'
-            WHEN t.id IS NULL     THEN 'not-found'
-            ELSE 'already-terminal'
-          END AS outcome,
-          row_to_json(c.*) AS entry_json
-        FROM (SELECT * FROM target) t
-        FULL OUTER JOIN (SELECT * FROM cancelled) c ON c.id = t.id
-      `, namespace ? [id, namespace] : [id]);
-      if (!result.rows[0] || result.rows[0].outcome === 'not-found') {
-        await this.pgClient.query('ROLLBACK');
-        return { ok: false, reason: 'not-found' };
-      }
-      if (result.rows[0].outcome === 'already-terminal') {
-        await this.pgClient.query('ROLLBACK');
-        return { ok: false, reason: 'already-terminal' };
-      }
-      const entry = result.rows[0].entry_json as import('../../../../types/hmsh_escalations').EscalationEntry;
-      const wakeEnqueued = await this.enqueueEscalationWake(
-        wakeCommand,
-        entry.signal_key,
-        id,
-      );
-      await this.pgClient.query('COMMIT');
-      return { ok: true, entry, wakeEnqueued };
-    } catch (e) {
-      await this.pgClient.query('ROLLBACK');
-      throw e;
+    //single statement: the cancellation wake is a data-modifying CTE
+    //that fires iff the cancel lands AND the row's signal_key matches
+    //the wake — atomic on any connection type (Client or Pool), with
+    //no BEGIN/COMMIT window for unrelated queries to interleave into
+    const schemaName = this.kvsql().safeName(this.appId);
+    const params: any[] = namespace ? [id, namespace] : [id];
+    let wakeCTE = '';
+    let wakeCount = '0::int AS wake_count';
+    if (wakeCommand) {
+      const base = params.length;
+      params.push(this.appId, wakeCommand.message, wakeCommand.forSignalKey);
+      wakeCTE = `,
+        wake AS (
+          INSERT INTO ${schemaName}.engine_streams (stream_name, message, priority)
+          SELECT $${base + 1}, $${base + 2}, 5 FROM cancelled
+          WHERE cancelled.signal_key = $${base + 3}
+          RETURNING id
+        )`;
+      wakeCount = '(SELECT COUNT(*) FROM wake)::int AS wake_count';
     }
+    const result = await this.pgClient.query(`
+      WITH target AS MATERIALIZED (
+        SELECT id, status FROM public.hmsh_escalations
+        WHERE id = $1 ${namespace ? 'AND namespace = $2' : ''}
+        LIMIT 1 FOR UPDATE
+      ),
+      cancelled AS (
+        UPDATE public.hmsh_escalations
+        SET status = 'cancelled', updated_at = NOW()
+        FROM target
+        WHERE public.hmsh_escalations.id = target.id
+          AND target.status = 'pending'
+        RETURNING public.hmsh_escalations.*
+      )${wakeCTE}
+      SELECT t.id, t.status AS prior_status,
+        CASE
+          WHEN c.id IS NOT NULL THEN 'cancelled'
+          WHEN t.id IS NULL     THEN 'not-found'
+          ELSE 'already-terminal'
+        END AS outcome,
+        row_to_json(c.*) AS entry_json,
+        ${wakeCount}
+      FROM (SELECT * FROM target) t
+      FULL OUTER JOIN (SELECT * FROM cancelled) c ON c.id = t.id
+    `, params);
+    if (!result.rows[0] || result.rows[0].outcome === 'not-found') return { ok: false, reason: 'not-found' };
+    if (result.rows[0].outcome === 'already-terminal') return { ok: false, reason: 'already-terminal' };
+    const entry = result.rows[0].entry_json as import('../../../../types/hmsh_escalations').EscalationEntry;
+    return { ok: true, entry, wakeEnqueued: result.rows[0].wake_count > 0 };
   }
 
   async escalateEscalationToRole(params: import('../../../../types/hmsh_escalations').EscalateToRoleParams): Promise<import('../../../../types/hmsh_escalations').EscalationEntry | null> {

--- a/services/store/providers/postgres/postgres.ts
+++ b/services/store/providers/postgres/postgres.ts
@@ -2502,35 +2502,59 @@ class PostgresStoreService extends StoreService<
     }
   }
 
-  async cancelEscalation(id: string, namespace?: string): Promise<import('../../../../types/hmsh_escalations').CancelEscalationResult> {
-    const result = await this.pgClient.query(`
-      WITH target AS MATERIALIZED (
-        SELECT id, status FROM public.hmsh_escalations
-        WHERE id = $1 ${namespace ? 'AND namespace = $2' : ''}
-        LIMIT 1 FOR UPDATE
-      ),
-      cancelled AS (
-        UPDATE public.hmsh_escalations
-        SET status = 'cancelled', updated_at = NOW()
-        FROM target
-        WHERE public.hmsh_escalations.id = target.id
-          AND target.status = 'pending'
-        RETURNING public.hmsh_escalations.*
-      )
-      SELECT t.id, t.status AS prior_status,
-        CASE
-          WHEN c.id IS NOT NULL THEN 'cancelled'
-          WHEN t.id IS NULL     THEN 'not-found'
-          ELSE 'already-terminal'
-        END AS outcome,
-        row_to_json(c.*) AS entry_json
-      FROM (SELECT * FROM target) t
-      FULL OUTER JOIN (SELECT * FROM cancelled) c ON c.id = t.id
-    `, namespace ? [id, namespace] : [id]);
-    if (!result.rows[0] || result.rows[0].outcome === 'not-found') return { ok: false, reason: 'not-found' };
-    if (result.rows[0].outcome === 'already-terminal') return { ok: false, reason: 'already-terminal' };
-    const entry = result.rows[0].entry_json as import('../../../../types/hmsh_escalations').EscalationEntry;
-    return { ok: true, entry };
+  async cancelEscalation(
+    id: string,
+    namespace?: string,
+    wakeCommand?: import('../../../../types/hmsh_escalations').EscalationWakeCommand,
+  ): Promise<import('../../../../types/hmsh_escalations').CancelEscalationResult & { wakeEnqueued?: boolean }> {
+    //explicit transaction so the cancellation wake commits WITH the
+    //status change — same durability contract as resolveEscalation
+    await this.pgClient.query('BEGIN');
+    try {
+      const result = await this.pgClient.query(`
+        WITH target AS MATERIALIZED (
+          SELECT id, status FROM public.hmsh_escalations
+          WHERE id = $1 ${namespace ? 'AND namespace = $2' : ''}
+          LIMIT 1 FOR UPDATE
+        ),
+        cancelled AS (
+          UPDATE public.hmsh_escalations
+          SET status = 'cancelled', updated_at = NOW()
+          FROM target
+          WHERE public.hmsh_escalations.id = target.id
+            AND target.status = 'pending'
+          RETURNING public.hmsh_escalations.*
+        )
+        SELECT t.id, t.status AS prior_status,
+          CASE
+            WHEN c.id IS NOT NULL THEN 'cancelled'
+            WHEN t.id IS NULL     THEN 'not-found'
+            ELSE 'already-terminal'
+          END AS outcome,
+          row_to_json(c.*) AS entry_json
+        FROM (SELECT * FROM target) t
+        FULL OUTER JOIN (SELECT * FROM cancelled) c ON c.id = t.id
+      `, namespace ? [id, namespace] : [id]);
+      if (!result.rows[0] || result.rows[0].outcome === 'not-found') {
+        await this.pgClient.query('ROLLBACK');
+        return { ok: false, reason: 'not-found' };
+      }
+      if (result.rows[0].outcome === 'already-terminal') {
+        await this.pgClient.query('ROLLBACK');
+        return { ok: false, reason: 'already-terminal' };
+      }
+      const entry = result.rows[0].entry_json as import('../../../../types/hmsh_escalations').EscalationEntry;
+      const wakeEnqueued = await this.enqueueEscalationWake(
+        wakeCommand,
+        entry.signal_key,
+        id,
+      );
+      await this.pgClient.query('COMMIT');
+      return { ok: true, entry, wakeEnqueued };
+    } catch (e) {
+      await this.pgClient.query('ROLLBACK');
+      throw e;
+    }
   }
 
   async escalateEscalationToRole(params: import('../../../../types/hmsh_escalations').EscalateToRoleParams): Promise<import('../../../../types/hmsh_escalations').EscalationEntry | null> {

--- a/services/stream/providers/postgres/kvtables.ts
+++ b/services/stream/providers/postgres/kvtables.ts
@@ -1,6 +1,7 @@
 import {
   HMSH_DEPLOYMENT_DELAY,
   HMSH_DEPLOYMENT_PAUSE,
+  HMSH_RESERVATION_TIMEOUT_S,
 } from '../../../../modules/enums';
 import { sleepFor } from '../../../../modules/utils';
 import { ILogger } from '../../../logger';
@@ -57,6 +58,10 @@ export async function deploySchema(
         await ensureIndexes(client, schemaName);
         await ensureProcedures(client, schemaName);
         await ensureStatementLevelTriggers(client, schemaName);
+        // Re-deploy the fallback poller's discovery function so existing
+        // databases receive predicate changes (v0.25.6: stale-reservation
+        // reclaim — see getNotifyVisibleMessagesSQL)
+        await client.query(getNotifyVisibleMessagesSQL(schemaName));
       } finally {
         await client.query('SELECT pg_advisory_unlock($1)', [lockId]);
       }
@@ -229,6 +234,20 @@ async function ensureIndexes(
     CREATE INDEX IF NOT EXISTS idx_worker_streams_message_fetch
     ON ${workerTable} (stream_name, priority DESC, id)
     WHERE expired_at IS NULL;
+  `);
+
+  // v0.25.6: in-flight partial indexes — bounded to currently reserved
+  // rows (≈ concurrent executions) — serve the fallback poller's
+  // stale-reservation reclaim branch (see getNotifyVisibleMessagesSQL)
+  await client.query(`
+    CREATE INDEX IF NOT EXISTS idx_engine_streams_inflight
+    ON ${engineTable} (stream_name, reserved_at)
+    WHERE expired_at IS NULL AND reserved_at IS NOT NULL;
+  `);
+  await client.query(`
+    CREATE INDEX IF NOT EXISTS idx_worker_streams_inflight
+    ON ${workerTable} (stream_name, reserved_at)
+    WHERE expired_at IS NULL AND reserved_at IS NOT NULL;
   `);
 
   // v0.18.0: add jid column to engine_streams for job tracing
@@ -558,7 +577,35 @@ async function createNotificationTriggers(
   `);
 
   // ---- Visibility timeout notification function (queries both tables) ----
-  await client.query(`
+  await client.query(getNotifyVisibleMessagesSQL(schemaName));
+}
+
+/**
+ * The fallback poller's discovery function. Surfaces streams that have
+ * deliverable work: unreserved visible messages AND stale reservations
+ * whose holder died (heartbeats refresh reserved_at every ~15s while an
+ * activity runs, so any reservation older than 60s has a dead holder or
+ * is already claimable). Stale-reservation discovery is the ONLY path
+ * that reclaims orphaned in-flight work on a quiet stream — without it,
+ * a process death wedges its reserved messages forever. A premature
+ * surface (reservation window configured above 60s on a provider with
+ * static leases) costs one empty fetch; the claim query enforces the
+ * real window.
+ *
+ * Deployed on fresh schemas AND re-deployed on every boot (see
+ * deploySchema) so existing databases receive predicate changes.
+ */
+function getNotifyVisibleMessagesSQL(schemaName: string): string {
+  const engineTable = `${schemaName}.engine_streams`;
+  const workerTable = `${schemaName}.worker_streams`;
+  //stale threshold tracks the configured base window: heartbeats refresh
+  //reserved_at every base/2 (15s default), so live holders never look
+  //stale; 2x base keeps static-lease holders (secured workers, one
+  //adaptive doubling) from surfacing as false positives. Baked at
+  //deploy time from the deploying node's env — a premature surface
+  //costs one empty fetch (the claim query enforces the real window).
+  const staleSeconds = Math.max(60, HMSH_RESERVATION_TIMEOUT_S * 2);
+  return `
     CREATE OR REPLACE FUNCTION ${schemaName}.notify_visible_messages()
     RETURNS INTEGER AS $$
     DECLARE
@@ -567,13 +614,23 @@ async function createNotificationTriggers(
       payload JSON;
       notification_count INTEGER := 0;
     BEGIN
-      -- Engine streams
+      -- Engine streams: visible unreserved work (active_messages
+      -- partial index) UNION stale reservations whose holder died
+      -- (inflight partial index) — each branch index-matched
       FOR msg IN
-        SELECT DISTINCT stream_name
-        FROM ${engineTable}
-        WHERE visible_at <= NOW()
-          AND reserved_at IS NULL
-          AND expired_at IS NULL
+        SELECT DISTINCT u.stream_name FROM (
+          (SELECT stream_name FROM ${engineTable}
+           WHERE visible_at <= NOW()
+             AND reserved_at IS NULL
+             AND expired_at IS NULL
+           LIMIT 50)
+          UNION ALL
+          (SELECT stream_name FROM ${engineTable}
+           WHERE expired_at IS NULL
+             AND reserved_at IS NOT NULL
+             AND reserved_at < NOW() - INTERVAL '${staleSeconds} seconds'
+           LIMIT 50)
+        ) u
         LIMIT 50
       LOOP
         channel_name := 'eng_' || msg.stream_name;
@@ -590,13 +647,21 @@ async function createNotificationTriggers(
         notification_count := notification_count + 1;
       END LOOP;
 
-      -- Worker streams
+      -- Worker streams: same two index-matched branches
       FOR msg IN
-        SELECT DISTINCT stream_name
-        FROM ${workerTable}
-        WHERE visible_at <= NOW()
-          AND reserved_at IS NULL
-          AND expired_at IS NULL
+        SELECT DISTINCT u.stream_name FROM (
+          (SELECT stream_name FROM ${workerTable}
+           WHERE visible_at <= NOW()
+             AND reserved_at IS NULL
+             AND expired_at IS NULL
+           LIMIT 50)
+          UNION ALL
+          (SELECT stream_name FROM ${workerTable}
+           WHERE expired_at IS NULL
+             AND reserved_at IS NOT NULL
+             AND reserved_at < NOW() - INTERVAL '${staleSeconds} seconds'
+           LIMIT 50)
+        ) u
         LIMIT 50
       LOOP
         channel_name := 'wrk_' || msg.stream_name;
@@ -616,7 +681,7 @@ async function createNotificationTriggers(
       RETURN notification_count;
     END;
     $$ LANGUAGE plpgsql;
-  `);
+  `;
 }
 
 export function getNotificationChannelName(

--- a/services/stream/providers/postgres/messages.ts
+++ b/services/stream/providers/postgres/messages.ts
@@ -388,12 +388,15 @@ async function dropDeadJobMessages(
       });
     }
   } catch (error) {
-    if (error?.code === '42P01') {
-      //jobs table is not visible from this connection; the guard cannot
-      //run here — interrupt-time purging (expireJobMessages) still applies
+    if (error?.code === '42P01' || error?.code === '42501') {
+      //jobs table is not visible (42P01) or not readable (42501) from
+      //this connection; the guard cannot run here — interrupt-time
+      //purging (expireJobMessages) still applies. Self-disable so the
+      //hot path stops issuing a failing cross-table query per fetch.
       liveness.enabled = false;
       logger.info('postgres-stream-liveness-guard-disabled', {
         jobsTable: liveness.jobsTable,
+        code: error.code,
       });
     } else {
       logger.error(`postgres-stream-liveness-guard-error-${streamName}`, {

--- a/services/stream/providers/postgres/procedures.ts
+++ b/services/stream/providers/postgres/procedures.ts
@@ -153,17 +153,19 @@ export function getCreateProceduresSQL(schemaName: string): string[] {
       -- Engine stream_name is the schema/appId name
       engine_stream_name := '${schemaName}';
 
+      -- jid stamped from the message metadata (parity with the raw
+      -- publish path) so job-scoped expiry can address these rows
       IF p_max_retry_attempts IS NOT NULL THEN
         INSERT INTO ${engineTable}
-          (stream_name, message, priority, max_retry_attempts, backoff_coefficient, maximum_interval_seconds, visible_at, retry_attempt)
+          (stream_name, jid, message, priority, max_retry_attempts, backoff_coefficient, maximum_interval_seconds, visible_at, retry_attempt)
         VALUES
-          (engine_stream_name, p_message, p_priority, p_max_retry_attempts, p_backoff_coefficient, p_maximum_interval_seconds, p_visible_at, p_retry_attempt)
+          (engine_stream_name, COALESCE(p_message::jsonb -> 'metadata' ->> 'jid', ''), p_message, p_priority, p_max_retry_attempts, p_backoff_coefficient, p_maximum_interval_seconds, p_visible_at, p_retry_attempt)
         RETURNING id INTO new_id;
       ELSE
         INSERT INTO ${engineTable}
-          (stream_name, message, priority, visible_at, retry_attempt)
+          (stream_name, jid, message, priority, visible_at, retry_attempt)
         VALUES
-          (engine_stream_name, p_message, p_priority, p_visible_at, p_retry_attempt)
+          (engine_stream_name, COALESCE(p_message::jsonb -> 'metadata' ->> 'jid', ''), p_message, p_priority, p_visible_at, p_retry_attempt)
         RETURNING id INTO new_id;
       END IF;
 

--- a/tests/durable/collated-sleep/postgres.test.ts
+++ b/tests/durable/collated-sleep/postgres.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Client as Postgres } from 'pg';
+
+import { Durable } from '../../../services/durable';
+import { guid, sleepFor } from '../../../modules/utils';
+import { ProviderNativeClient } from '../../../types/provider';
+import { dropTables, postgres_options } from '../../$setup/postgres';
+import { PostgresConnection } from '../../../services/connector/providers/postgres';
+
+import * as workflows from './src/workflows';
+
+const { Client, Worker } = Durable;
+
+/**
+ * Field topology regression: `Promise.all([executeChild x4, sleep branch])`.
+ * The sleep's timehook must be MINTED (visible as an engine_streams row,
+ * live or consumed) and the converge must settle. The field report's wedge
+ * showed the inverse: a director whose collated sleep never produced a
+ * timehook row at all — absence, not consumption.
+ */
+describe('DURABLE | collated-sleep | Postgres', () => {
+  let postgresClient: ProviderNativeClient;
+  let client: InstanceType<typeof Client>;
+  const connection = { class: Postgres, options: postgres_options };
+  const runId = guid();
+
+  beforeAll(async () => {
+    if (process.env.POSTGRES_IS_REMOTE === 'true') return;
+
+    postgresClient = (
+      await PostgresConnection.connect(guid(), Postgres, postgres_options)
+    ).getClient();
+    await dropTables(postgresClient);
+
+    client = new Client({ connection });
+    const parentWorker = await Worker.create({
+      connection,
+      taskQueue: 'converge-queue',
+      workflow: workflows.convergeWithSleep,
+    });
+    await parentWorker.run();
+    const childWorker = await Worker.create({
+      connection,
+      taskQueue: 'converge-queue',
+      workflow: workflows.castMember,
+    });
+    await childWorker.run();
+  }, 30_000);
+
+  afterAll(async () => {
+    await sleepFor(1500);
+    await Durable.shutdown();
+  }, 15_000);
+
+  it('should mint the collated sleep timehook and settle the converge', async () => {
+    const handle = await client.workflow.start({
+      args: [runId],
+      taskQueue: 'converge-queue',
+      workflowName: 'convergeWithSleep',
+      workflowId: guid(),
+      expire: 600,
+    });
+
+    //the timehook row must exist (live or consumed — no liveness filter,
+    //matching the field forensics query) within the cast window
+    let minted = false;
+    const start = Date.now();
+    while (!minted) {
+      const res = await postgresClient.query(
+        `SELECT COUNT(*)::int AS count FROM durable.engine_streams
+         WHERE message LIKE '%timehook%'`,
+      );
+      minted = res.rows[0].count > 0;
+      if (!minted) {
+        if (Date.now() - start > 20_000) {
+          throw new Error(
+            'collated sleep timehook was never minted (field wedge shape)',
+          );
+        }
+        await sleepFor(250);
+      }
+    }
+    expect(minted).toBe(true);
+
+    //the converge settles: 4 children + the retired sleeper
+    const result = (await Promise.race([
+      handle.result(),
+      sleepFor(60_000).then(() => {
+        throw new Error('converge never settled');
+      }),
+    ])) as string;
+    expect(result).toContain('retired');
+    expect(result.split('|')).toHaveLength(5);
+  }, 90_000);
+});

--- a/tests/durable/collated-sleep/src/workflows.ts
+++ b/tests/durable/collated-sleep/src/workflows.ts
@@ -1,0 +1,27 @@
+import { Durable } from '../../../../services/durable';
+
+export async function castMember(name: string): Promise<string> {
+  return `cast:${name}`;
+}
+
+/**
+ * The field topology: a sleep as one branch of a wide parallel await
+ * (N executeChild + a sleeping branch in one Promise.all). The sleep's
+ * timehook must be minted for the collated sleeper leg and the converge
+ * must settle once the timer fires and the children complete.
+ */
+export async function convergeWithSleep(runId: string): Promise<string> {
+  const children = [1, 2, 3, 4].map((i) =>
+    Durable.workflow.executeChild<string>({
+      workflowName: 'castMember',
+      args: [`${runId}-c${i}`],
+      taskQueue: 'converge-queue',
+    }),
+  );
+  const runAndRetire = async (): Promise<string> => {
+    await Durable.workflow.sleep('15 seconds');
+    return 'retired';
+  };
+  const results = await Promise.all([...children, runAndRetire()]);
+  return results.join('|');
+}

--- a/tests/durable/wake-atomicity/cancel.postgres.test.ts
+++ b/tests/durable/wake-atomicity/cancel.postgres.test.ts
@@ -118,6 +118,108 @@ describe('DURABLE | wake-atomicity | cancel', () => {
     }
   }, 60_000);
 
+  it('should exclude live waiters from bulk resolution', async () => {
+    //resolveMany carries no wake: a row backing a condition() waiter
+    //must stay pending (targeted resolve/cancel owns its wake) rather
+    //than resolve silently and strand the workflow
+    const runId = guid();
+    const handle = await parkOne(runId);
+    const row = await findRow(runId);
+
+    const resolved = await client.escalations.resolveMany({
+      ids: [row.id],
+      resolverPayload: { bulk: true },
+    });
+    expect(resolved.length).toBe(0);
+
+    const after = await client.escalations.list({
+      role: 'crash-approver',
+      status: 'pending',
+    });
+    expect(after.some((e) => e.id === row.id)).toBe(true);
+
+    //targeted cancel still settles the waiter (condition returns null)
+    const cancel = await client.escalations.cancel(row.id);
+    expect(cancel.ok).toBe(true);
+    const output = await awaitWake(handle, runId);
+    expect(output).toBeNull();
+  }, 60_000);
+
+  it('should wake both siblings when their resolves land in the same tick', async () => {
+    //field case: two sibling workers parked on signal_key waits, both
+    //resolved near-simultaneously — the second wake was lost. The wake
+    //INSERT commits with each resolve, so same-tick resolves must both
+    //deliver.
+    const runA = guid();
+    const runB = guid();
+    const handleA = await parkOne(runA);
+    const handleB = await parkOne(runB);
+    const rowA = await findRow(runA);
+    const rowB = await findRow(runB);
+
+    const results = await Promise.all([
+      client.escalations.resolve({
+        id: rowA.id,
+        resolverPayload: { approved: true, via: 'sibling-a' },
+      }),
+      client.escalations.resolve({
+        id: rowB.id,
+        resolverPayload: { approved: true, via: 'sibling-b' },
+      }),
+    ]);
+    expect(results.every((r) => r.ok)).toBe(true);
+
+    const [outA, outB] = (await Promise.all([
+      awaitWake(handleA, runA),
+      awaitWake(handleB, runB),
+    ])) as Array<{ via: string }>;
+    expect(outA.via).toBe('sibling-a');
+    expect(outB.via).toBe('sibling-b');
+  }, 90_000);
+
+  it('should resolve the row AND wake the workflow under a concurrent claim', async () => {
+    //field case: a concurrent claim interleaved with the resolve — the
+    //signal was delivered but the row stayed pending+claimed forever,
+    //asserting work was owed on a completed order. Signal delivery and
+    //row settle are one atomic statement; a claim cannot split them.
+    const runId = guid();
+    const handle = await parkOne(runId);
+    const row = await findRow(runId);
+
+    const claimA = await client.escalations.claim({
+      id: row.id,
+      assignee: 'associate-a',
+      durationMinutes: 5,
+    });
+    expect(claimA.ok).toBe(true);
+
+    //associate B re-claims while C resolves by metadata, same tick
+    const [claimB, resolved] = await Promise.all([
+      client.escalations.claim({
+        id: row.id,
+        assignee: 'associate-b',
+        durationMinutes: 5,
+      }),
+      client.escalations.resolveByMetadata({
+        key: 'runId',
+        value: runId,
+        resolverPayload: { approved: true, via: 'raced-resolve' },
+      }),
+    ]);
+    expect(resolved.ok).toBe(true);
+    void claimB; //may win or lose the interleave; the row must settle either way
+
+    //the row cannot lie: it is resolved, and the workflow woke
+    const dbRow = await postgresClient.query(
+      `SELECT status FROM public.hmsh_escalations WHERE id = $1`,
+      [row.id],
+    );
+    expect(dbRow.rows[0].status).toBe('resolved');
+
+    const output = (await awaitWake(handle, runId)) as { via: string };
+    expect(output.via).toBe('raced-resolve');
+  }, 60_000);
+
   it('should wake every workflow in a burst of concurrent cancels', async () => {
     //the field wave: N ponds self-cancel within ~400ms of each other
     const runs = Array.from({ length: POND_COUNT }, () => guid());

--- a/tests/durable/wake-atomicity/cancel.postgres.test.ts
+++ b/tests/durable/wake-atomicity/cancel.postgres.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { Client as Postgres } from 'pg';
+
+import { Durable } from '../../../services/durable';
+import { WorkflowHandleService } from '../../../services/durable/handle';
+import { EscalationClientService } from '../../../services/escalations/client';
+import { guid, sleepFor } from '../../../modules/utils';
+import { ProviderNativeClient } from '../../../types/provider';
+import { dropTables, postgres_options } from '../../$setup/postgres';
+import { PostgresConnection } from '../../../services/connector/providers/postgres';
+
+import * as workflows from './src/workflows';
+
+const { Client, Worker } = Durable;
+
+/**
+ * cancel() must wake the awaiting workflow (condition() returns null)
+ * with the same durability as resolve(): the cancellation wake commits
+ * WITH the status='cancelled' transaction. Watcher patterns cancel in
+ * bursts (N ponds self-cancelling within one wave), so the burst path
+ * is exercised natively as well.
+ */
+describe('DURABLE | wake-atomicity | cancel', () => {
+  let postgresClient: ProviderNativeClient;
+  let client: InstanceType<typeof Client>;
+  const connection = { class: Postgres, options: postgres_options };
+  const POND_COUNT = 6;
+
+  const parkOne = async (
+    runId: string,
+  ): Promise<WorkflowHandleService> =>
+    client.workflow.start({
+      args: [runId],
+      taskQueue: 'wake-cancel',
+      workflowName: 'crashWindowWorkflow',
+      workflowId: guid(),
+      expire: 600,
+    });
+
+  const findRow = async (runId: string, timeoutMs = 20_000) => {
+    const start = Date.now();
+    for (;;) {
+      const list = await client.escalations.list({
+        role: 'crash-approver',
+        status: 'pending',
+      });
+      const row = list.find((e) => (e.metadata as any)?.runId === runId);
+      if (row) return row;
+      if (Date.now() - start > timeoutMs) {
+        throw new Error(`timed out waiting for escalation row ${runId}`);
+      }
+      await sleepFor(100);
+    }
+  };
+
+  const awaitWake = async (
+    handle: WorkflowHandleService,
+    label: string,
+  ): Promise<unknown> =>
+    Promise.race([
+      handle.result(),
+      sleepFor(25_000).then(() => {
+        throw new Error(`workflow never woke after cancel: ${label}`);
+      }),
+    ]);
+
+  beforeAll(async () => {
+    if (process.env.POSTGRES_IS_REMOTE === 'true') return;
+
+    postgresClient = (
+      await PostgresConnection.connect(guid(), Postgres, postgres_options)
+    ).getClient();
+    await dropTables(postgresClient);
+
+    client = new Client({ connection });
+    const worker = await Worker.create({
+      connection,
+      taskQueue: 'wake-cancel',
+      workflow: workflows.crashWindowWorkflow,
+    });
+    await worker.run();
+  }, 30_000);
+
+  afterAll(async () => {
+    vi.restoreAllMocks();
+    await sleepFor(1500);
+    await Durable.shutdown();
+  }, 15_000);
+
+  it('should wake the workflow with null when the post-cancel delivery step dies', async () => {
+    const runId = guid();
+    const handle = await parkOne(runId);
+    const row = await findRow(runId);
+
+    //simulate death between the cancel commit and the post-commit wake
+    const spy = vi
+      .spyOn(
+        EscalationClientService.prototype as any,
+        '_deliverEscalationSignal',
+      )
+      .mockResolvedValue(false);
+
+    try {
+      const result = await client.escalations.cancel(row.id);
+      expect(result.ok).toBe(true);
+
+      const dbRow = await postgresClient.query(
+        `SELECT status FROM public.hmsh_escalations WHERE id = $1`,
+        [row.id],
+      );
+      expect(dbRow.rows[0].status).toBe('cancelled');
+
+      //condition() resumes with null on cancellation
+      const output = await awaitWake(handle, runId);
+      expect(output).toBeNull();
+    } finally {
+      spy.mockRestore();
+    }
+  }, 60_000);
+
+  it('should wake every workflow in a burst of concurrent cancels', async () => {
+    //the field wave: N ponds self-cancel within ~400ms of each other
+    const runs = Array.from({ length: POND_COUNT }, () => guid());
+    const handles: WorkflowHandleService[] = [];
+    for (const runId of runs) {
+      handles.push(await parkOne(runId));
+    }
+    const rows = [];
+    for (const runId of runs) {
+      rows.push(await findRow(runId));
+    }
+
+    const results = await Promise.all(
+      rows.map((row) => client.escalations.cancel(row.id)),
+    );
+    expect(results.every((r) => r.ok)).toBe(true);
+
+    const outputs = await Promise.all(
+      handles.map((handle, i) => awaitWake(handle, runs[i])),
+    );
+    expect(outputs.every((o) => o === null)).toBe(true);
+  }, 90_000);
+});

--- a/tests/durable/wake-atomicity/disarm.postgres.test.ts
+++ b/tests/durable/wake-atomicity/disarm.postgres.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Client as Postgres } from 'pg';
+
+import { Durable } from '../../../services/durable';
+import { guid, sleepFor } from '../../../modules/utils';
+import { ProviderNativeClient } from '../../../types/provider';
+import { dropTables, postgres_options } from '../../$setup/postgres';
+import { PostgresConnection } from '../../../services/connector/providers/postgres';
+
+import * as workflows from './src/workflows';
+
+const { Client, Worker } = Durable;
+
+/**
+ * A resolved SLA-gated wait must disarm its timeout leg. The timeout-won
+ * path already cleans the signal side (deleteWebHookSignal +
+ * expireEscalationOnTimeout); the signal-won path needs the mirror —
+ * otherwise every resolved wait leaves an armed timehook that fires at
+ * its original due time against the settled workflow (one benign error
+ * per resolved wait; a fleet's evening leaves a drizzle of them that
+ * operators read as a crash loop).
+ */
+describe('DURABLE | wake-atomicity | timeout disarm', () => {
+  let postgresClient: ProviderNativeClient;
+  let client: InstanceType<typeof Client>;
+  const connection = { class: Postgres, options: postgres_options };
+  const runId = guid();
+
+  beforeAll(async () => {
+    if (process.env.POSTGRES_IS_REMOTE === 'true') return;
+
+    postgresClient = (
+      await PostgresConnection.connect(guid(), Postgres, postgres_options)
+    ).getClient();
+    await dropTables(postgresClient);
+
+    client = new Client({ connection });
+    const worker = await Worker.create({
+      connection,
+      taskQueue: 'disarm-world',
+      workflow: workflows.timeoutGatedWorkflow,
+    });
+    await worker.run();
+    const cycledWorker = await Worker.create({
+      connection,
+      taskQueue: 'disarm-world',
+      workflow: workflows.cycledTimeoutGatedWorkflow,
+    });
+    await cycledWorker.run();
+  }, 30_000);
+
+  afterAll(async () => {
+    await sleepFor(1500);
+    await Durable.shutdown();
+  }, 15_000);
+
+  it('should disarm the timeout leg when the signal wins', async () => {
+    const handle = await client.workflow.start({
+      args: [runId],
+      taskQueue: 'disarm-world',
+      workflowName: 'timeoutGatedWorkflow',
+      workflowId: guid(),
+      expire: 600,
+    });
+
+    //wait for the park (escalation row + armed timehook)
+    let escalation: { id: string } | undefined;
+    const start = Date.now();
+    while (!escalation) {
+      const list = await client.escalations.list({
+        role: 'disarm-approver',
+        status: 'pending',
+      });
+      escalation = list.find((e) => (e.metadata as any)?.runId === runId);
+      if (!escalation) {
+        if (Date.now() - start > 20_000) {
+          throw new Error('timed out waiting for escalation row');
+        }
+        await sleepFor(250);
+      }
+    }
+
+    //the timeout leg is armed: a future-visible timehook exists
+    const armed = await postgresClient.query(
+      `SELECT COUNT(*)::int AS count FROM durable.engine_streams
+       WHERE expired_at IS NULL AND visible_at > NOW()
+         AND message LIKE '%"type":"timehook"%'`,
+    );
+    expect(armed.rows[0].count).toBe(1);
+
+    //signal wins the race
+    const result = await client.escalations.resolve({
+      id: escalation.id,
+      resolverPayload: { approved: true },
+    });
+    expect(result.ok).toBe(true);
+
+    const output = (await Promise.race([
+      handle.result(),
+      sleepFor(25_000).then(() => {
+        throw new Error('workflow never woke');
+      }),
+    ])) as { approved: boolean };
+    expect(output.approved).toBe(true);
+
+    //the armed timer must be disarmed with the settled wait — no
+    //future-visible timehook corpse remains to fire and error later
+    await sleepFor(2_000);
+    const corpses = await postgresClient.query(
+      `SELECT COUNT(*)::int AS count FROM durable.engine_streams
+       WHERE expired_at IS NULL AND visible_at > NOW()
+         AND message LIKE '%"type":"timehook"%'`,
+    );
+    expect(corpses.rows[0].count).toBe(0);
+  }, 60_000);
+
+  it('should disarm the timeout leg for a CYCLED-dimension wait', async () => {
+    //pre-wait durable ops advance the cycle index, so the waiter runs
+    //at a cycled dimensional address — the harder disarm case
+    const cycledRunId = guid();
+    const handle = await client.workflow.start({
+      args: [cycledRunId],
+      taskQueue: 'disarm-world',
+      workflowName: 'cycledTimeoutGatedWorkflow',
+      workflowId: guid(),
+      expire: 600,
+    });
+
+    let escalation: { id: string } | undefined;
+    const start = Date.now();
+    while (!escalation) {
+      const list = await client.escalations.list({
+        role: 'disarm-approver',
+        status: 'pending',
+      });
+      escalation = list.find(
+        (e) => (e.metadata as any)?.runId === cycledRunId,
+      );
+      if (!escalation) {
+        if (Date.now() - start > 25_000) {
+          throw new Error('timed out waiting for cycled escalation row');
+        }
+        await sleepFor(250);
+      }
+    }
+
+    const result = await client.escalations.resolve({
+      id: escalation.id,
+      resolverPayload: { approved: true },
+    });
+    expect(result.ok).toBe(true);
+
+    const output = (await Promise.race([
+      handle.result(),
+      sleepFor(25_000).then(() => {
+        throw new Error('cycled workflow never woke');
+      }),
+    ])) as { approved: boolean };
+    expect(output.approved).toBe(true);
+
+    await sleepFor(2_000);
+    const corpses = await postgresClient.query(
+      `SELECT COUNT(*)::int AS count FROM durable.engine_streams
+       WHERE expired_at IS NULL AND visible_at > NOW()
+         AND message LIKE '%"type":"timehook"%'`,
+    );
+    expect(corpses.rows[0].count).toBe(0);
+  }, 90_000);
+});

--- a/tests/durable/wake-atomicity/src/workflows.ts
+++ b/tests/durable/wake-atomicity/src/workflows.ts
@@ -19,3 +19,47 @@ export async function crashWindowWorkflow(
   );
   return result as { approved: boolean; via: string };
 }
+
+// SLA-gated wait: carries a timeout leg (armed timehook). When the
+// signal wins, the armed timer must be disarmed — it may not survive
+// to fire against the settled wait.
+export async function timeoutGatedWorkflow(
+  runId: string,
+): Promise<{ approved: boolean } | false | null> {
+  const signalId = `disarm-${Durable.guid()}`;
+  const result = await Durable.workflow.condition<{ approved: boolean }>(
+    signalId,
+    {
+      role: 'disarm-approver',
+      type: 'timeout-disarm',
+      priority: 1,
+      metadata: { runId },
+      timeout: '120 seconds',
+    },
+  );
+  return result;
+}
+
+// Same SLA-gated wait, but preceded by durable ops so the waiter
+// executes at a CYCLED dimensional address — the armed timer and the
+// signal composite address the wait through different dimension math,
+// and the disarm must still find the timer.
+export async function cycledTimeoutGatedWorkflow(
+  runId: string,
+): Promise<{ approved: boolean } | false | null> {
+  await Durable.workflow.sleep('1 second');
+  await Durable.workflow.sleep('1 second');
+
+  const signalId = `disarm-cycled-${Durable.guid()}`;
+  const result = await Durable.workflow.condition<{ approved: boolean }>(
+    signalId,
+    {
+      role: 'disarm-approver',
+      type: 'timeout-disarm-cycled',
+      priority: 1,
+      metadata: { runId },
+      timeout: '120 seconds',
+    },
+  );
+  return result;
+}

--- a/tests/functional/stream/providers/postgres/reclaim.test.ts
+++ b/tests/functional/stream/providers/postgres/reclaim.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { Client } from 'pg';
+
+import { HMNS } from '../../../../../modules/key';
+import { PostgresConnection } from '../../../../../services/connector/providers/postgres';
+import { LoggerService } from '../../../../../services/logger';
+import { PostgresStreamService } from '../../../../../services/stream/providers/postgres/postgres';
+import { PostgresClientType } from '../../../../../types/postgres';
+import {
+  ProviderNativeClient,
+  ProviderClient,
+} from '../../../../../types/provider';
+import { dropTables } from '../../../../$setup/postgres';
+
+/**
+ * Reservation reclaim discovery. Under notification-driven consumption,
+ * the 30s fallback poller (notify_visible_messages) is the only thing
+ * that surfaces work on a quiet stream. A reservation whose holder died
+ * (heartbeats stopped, reserved_at aging) MUST be surfaced once it goes
+ * stale — otherwise a process death orphans its in-flight messages
+ * forever and the workflows behind them wedge permanently (field data:
+ * 13 activities still reserved 31+ minutes after a SIGKILL).
+ */
+describe('FUNCTIONAL | PostgresStreamService | stale-reservation reclaim', () => {
+  let postgresClient: ProviderNativeClient;
+  let service: PostgresStreamService;
+  const APP_ID = 'mytestapp';
+  const SCHEMA = APP_ID;
+  const STREAM = 'reclaimStream';
+  const GROUP = 'WORKER';
+  const CONSUMER = 'reclaimConsumer';
+
+  const msg = (idx: number): string =>
+    JSON.stringify({
+      type: 'worker',
+      metadata: { jid: `jid${idx}`, topic: STREAM },
+      data: { idx },
+    });
+
+  const pollerCount = async (): Promise<number> => {
+    const res = await postgresClient.query(
+      `SELECT ${SCHEMA}.notify_visible_messages() AS count`,
+    );
+    return Number(res.rows[0].count);
+  };
+
+  const backdateReservations = async (
+    tableName: string,
+    seconds: number,
+  ): Promise<void> => {
+    await postgresClient.query(
+      `UPDATE ${SCHEMA}.${tableName}
+       SET reserved_at = NOW() - INTERVAL '${seconds} seconds'
+       WHERE expired_at IS NULL AND reserved_at IS NOT NULL`,
+    );
+  };
+
+  beforeAll(async () => {
+    postgresClient = (
+      await PostgresConnection.connect('test', Client, {
+        user: 'postgres',
+        host: 'postgres',
+        database: 'hotmesh',
+        password: 'password',
+        port: 5432,
+      })
+    ).getClient();
+
+    await dropTables(postgresClient);
+  });
+
+  beforeEach(async () => {
+    if (service) {
+      try {
+        await service.cleanup();
+      } catch (error) {
+        // Ignore cleanup errors
+      }
+    }
+
+    service = new PostgresStreamService(
+      postgresClient as PostgresClientType & ProviderClient,
+      {} as ProviderClient,
+    );
+    await service.init(HMNS, APP_ID, new LoggerService());
+
+    try {
+      await service.deleteStream('*');
+    } catch (error) {
+      // Stream might not exist; ignore error
+    }
+  });
+
+  afterEach(async () => {
+    if (service) {
+      try {
+        await service.cleanup();
+      } catch (error) {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  afterAll(async () => {
+    await postgresClient.end();
+  });
+
+  it('should surface a worker reservation whose holder died', async () => {
+    await service.publishMessages(STREAM, [msg(1)]);
+    const claimed = await service.consumeMessages(STREAM, GROUP, CONSUMER);
+    expect(claimed).toHaveLength(1);
+
+    //holder dies: heartbeats stop, the reservation ages past any window
+    await backdateReservations('worker_streams', 120);
+
+    //the fallback poller must surface the stream so a live consumer
+    //fetches and reclaims — this is the ONLY discovery path on a
+    //quiet stream
+    expect(await pollerCount()).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should surface an engine reservation whose holder died', async () => {
+    await service.publishMessages(`${HMNS}:${APP_ID}:x:`, [msg(2)]);
+    const claimed = await service.consumeMessages(
+      `${HMNS}:${APP_ID}:x:`,
+      'ENGINE',
+      CONSUMER,
+    );
+    expect(claimed).toHaveLength(1);
+
+    await backdateReservations('engine_streams', 120);
+    expect(await pollerCount()).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should stay quiet for an actively held reservation', async () => {
+    await service.publishMessages(STREAM, [msg(3)]);
+    const claimed = await service.consumeMessages(STREAM, GROUP, CONSUMER);
+    expect(claimed).toHaveLength(1);
+
+    //fresh reservation (heartbeats keep reserved_at within seconds):
+    //the poller must not churn notifications for healthy in-flight work
+    expect(await pollerCount()).toBe(0);
+  });
+
+  it('should still surface unreserved visible messages', async () => {
+    await service.publishMessages(STREAM, [msg(4)]);
+    expect(await pollerCount()).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/types/hmsh_escalations.ts
+++ b/types/hmsh_escalations.ts
@@ -95,17 +95,16 @@ export type ResolveEscalationResult =
   | { ok: false; reason: 'not-found' | 'already-resolved' | 'already-cancelled' | 'already-expired' };
 
 /**
- * A pre-built wake publish, executed INSIDE the resolve transaction so the
- * awaiting workflow's wake commits atomically with `status='resolved'`. The
- * SQL is a stream INSERT produced by the stream provider; `forSignalKey`
- * pins the command to the row it was built for — the store executes it only
- * when the locked row's `signal_key` matches (a mismatched row falls back
- * to post-commit delivery).
+ * A pre-built wake message, committed INSIDE the resolve/cancel transaction
+ * so the awaiting workflow's wake is durable with the status change. The
+ * client composes the webhook message; the store owns the stream INSERT.
+ * `forSignalKey` pins the wake to the row it was built for — it is written
+ * only when the affected row's `signal_key` matches (a mismatched row falls
+ * back to post-commit delivery).
  */
 export interface EscalationWakeCommand {
   forSignalKey: string;
-  sql: string;
-  params: unknown[];
+  message: string;
 }
 
 export type ReleaseEscalationResult =


### PR DESCRIPTION
Closes the remaining wake-loss and orphaned-reservation reports from the dependent project (field items 2, 3, 5, 6, 8, 10). What is better:

- **A crash or deploy no longer wedges in-flight work**: reservations whose holder died are surfaced by the fallback poller and reclaimed within ~90s (was: never), with index-backed discovery and boot-time redeploy to existing databases.
- **Every wait-settle path is now atomic with its wake**: `cancel()`, `resolve()`, and `resolveByMetadata()` commit the row transition and the workflow's wake as one single-statement unit (safe on Client or Pool); resolved SLA waits disarm their armed timeout; `resolveMany()` can no longer strand a live waiter; the pending-signal handoff is crash-proof.
- **Field regression tests pin every reported shape**: six-pill cancel burst, same-tick sibling resolves, claim-interleaved resolve, the `Promise.all([executeChild x4, sleep])` converge topology, plus provider-level reclaim/disarm proofs. Suites: functional 259, durable 424, escalations 73 — green; tsc clean.

Deferred with cause: interrupt parent-notify atomicity (the straightforward fix measurably slows interrupt dispatch, which races live completions by design — dedicated PR), and the new collated-wait timeout report (item 9, next investigation).