### PR TITLE
Escalation retention API + published durability contracts (v0.26.0)

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1005,3 +1005,39 @@ console.log(resolved.status); // resolved
 ```
 
 The escalation table (`public.hmsh_escalations`) is global — all apps share it. Rows from different apps are distinguished by `namespace` and `app_id`. The `Durable.workflow.condition(signalId, queueConfig)` primitive on the Durable layer provides the same suspension behavior without writing YAML, and `Escalations.Client` / `Durable.Client.escalations` expose the full claim-and-resolve API with TypeScript types.
+
+### Escalation retention
+
+An escalation row is live while `status = 'pending'`; the terminal statuses
+(`resolved`, `cancelled`, `expired`) are audit history. Every engine state
+transition guards on `status = 'pending'`, so terminal rows are inert — the
+engine reads them only for `list()`, `get()`, and `stats()`. Age them out
+with `prune()`, the engine-owned retention call:
+
+```typescript
+// Delete terminal rows older than 90 days, at most 10,000 per call.
+// Loop until deleted === 0 to drain a large backlog.
+let deleted: number;
+do {
+  ({ deleted } = await client.escalations.prune({ olderThan: '90 days' }));
+} while (deleted > 0);
+```
+
+Each call is one atomic statement (`FOR UPDATE SKIP LOCKED` under the
+delete), so concurrent pruners cooperate and live waiters, claims, and
+signal delivery proceed untouched — a workflow parked on `condition()` for
+longer than the horizon keeps its pending row and still resolves. Pass
+`statuses` to prune a subset of terminal states and `namespace` to scope to
+one app. Reads over windows older than the pruning horizon (`stats()`
+created/resolved counts, `get()` by id) reflect only the rows retained, so
+choose a horizon at least as long as your reporting window.
+
+### Table stewardship for application indexes
+
+Engine migrations on `public.hmsh_escalations` are strictly additive —
+`CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`,
+`CREATE INDEX IF NOT EXISTS` under an advisory lock. The table persists in
+place across upgrades, and the engine manages only its own indexes (the
+`idx_hmsh_esc_*` prefix). Application-owned indexes under any other name
+survive engine migrations; add them with
+`CREATE INDEX CONCURRENTLY IF NOT EXISTS` and they remain yours to evolve.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.25.6",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.25.6",
+      "version": "0.26.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.25.6",
+  "version": "0.26.0",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/durable/workflow/condition.ts
+++ b/services/durable/workflow/condition.ts
@@ -57,9 +57,12 @@ import { ConditionQueueConfig } from '../../../types/hmsh_escalations';
  * ## With escalation queue config
  *
  * Pass a {@link ConditionQueueConfig} as the second argument to surface the
- * pause as a claimable row in `public.hmsh_escalations`. The INSERT is
- * committed atomically with the workflow checkpoint — one write, no
- * enrichment step, no secondary round-trip.
+ * pause as a claimable row in `public.hmsh_escalations`. The INSERT — every
+ * field of the config, including `metadata` facets — is committed atomically
+ * with the workflow checkpoint: one write, one commit, crash-safe. From the
+ * row's first visible moment it carries its complete routing context and
+ * metadata, so claim-by-metadata routing and version-pinned facets (e.g. a
+ * `schema_version` the resolver UI renders) can trust every row they read.
  *
  * ```typescript
  * const decision = await Durable.workflow.condition<{ approved: boolean }>(
@@ -92,6 +95,14 @@ import { ConditionQueueConfig } from '../../../types/hmsh_escalations';
  * SLA-gated human waits in the workflow body and let hook functions report
  * back via `signal()`.
  *
+ * ## Early signals are buffered
+ *
+ * A signal delivered before its `condition()` registers — a fast signaler,
+ * or a payload deposited before the workflow starts — is buffered as a
+ * pending signal and delivered when the wait registers. The buffer holds a
+ * signal for 10 minutes by default; pass `expire` to `signal()` (e.g.
+ * `'1h'`, `'30d'`) to hold it longer when signaling early on purpose.
+ *
  * ## Fan-in: wait for multiple signals in parallel
  *
  * ```typescript
@@ -100,6 +111,12 @@ import { ConditionQueueConfig } from '../../../types/hmsh_escalations';
  *   Durable.workflow.condition<number>('score-signal'),
  * ]);
  * ```
+ *
+ * Harvest fan-out scales the same way: open N waits with `Promise.all` and
+ * signal all of them at once. Buffering covers every signal that races
+ * ahead of registration, so size fan-out by the pending-signal TTL — how
+ * long a racing signal may wait for its condition to register — with no
+ * separate bound on the number of concurrent waits.
  *
  * ## Paired with hook: spawn work, wait for its signal
  *

--- a/services/durable/workflow/proxyActivities.ts
+++ b/services/durable/workflow/proxyActivities.ts
@@ -282,6 +282,20 @@ function wrapActivity<T>(activityName: string, options?: ActivityConfig): T {
  * }
  * ```
  *
+ * ## Long-running activities execute exactly once
+ *
+ * `startToCloseTimeout` bounds an activity's run and is honored for long
+ * work (a 30–120s batch loop is a supported shape: poll → reconcile → act,
+ * one durable checkpoint per call). While the activity runs, the consumer
+ * heartbeats its stream reservation at half the base window, so the message
+ * stays leased for the full run — however long — and is redelivered to
+ * another worker only when the owning consumer crashes and stops
+ * heartbeating. The collation ledger then guarantees any redelivered
+ * message settles as a duplicate before re-executing the activity. With a
+ * `securedWorker` connection (SECURITY DEFINER stored-proc mode), lease
+ * extension is unavailable and an activity must finish within the adaptive
+ * reservation window instead.
+ *
  * @template ACT - The activity type map (use `typeof activities` for inline registration).
  * @param {ActivityConfig} [options] - Activity configuration including retry policy and routing.
  * @returns {ProxyType<ACT>} A typed proxy object mapping activity names to their durable wrappers.

--- a/services/escalations/client.ts
+++ b/services/escalations/client.ts
@@ -32,6 +32,8 @@ import {
   EscalateManyToRoleParams,
   UpdateManyPriorityParams,
   ResolveManyParams,
+  PruneEscalationsParams,
+  PruneEscalationsResult,
 } from '../../types/hmsh_escalations';
 import { APP_ID } from '../durable/schemas/factory';
 
@@ -263,6 +265,22 @@ export class EscalationClientService {
   async count(params?: ListEscalationsParams): Promise<number> {
     const hm = await this._engine(null, params?.namespace);
     return (hm.engine.store as any).countEscalations(params ?? {});
+  }
+
+  /**
+   * Retention: deletes terminal escalation rows (`resolved`/`cancelled`/`expired`)
+   * whose `updated_at` is older than the horizon (a Postgres interval string,
+   * e.g. `'90 days'`). Terminal rows are inert — every engine state transition
+   * guards on `status = 'pending'` — so pruning them is safe for live waiters,
+   * claims, and signal delivery; this call is the engine-blessed way to age
+   * out the audit backlog. Each call deletes at most `limit` rows (default
+   * 10,000) in one atomic statement; loop until `deleted` is 0 to drain a
+   * large backlog. `list()`/`get()`/`stats()` reads over windows older than
+   * the pruning horizon reflect only the rows retained.
+   */
+  async prune(params: PruneEscalationsParams): Promise<PruneEscalationsResult> {
+    const hm = await this._engine(null, params.namespace);
+    return (hm.engine.store as any).pruneEscalations(params);
   }
 
   /** Returns a single escalation row by UUID. Returns `null` if not found. */

--- a/services/store/providers/postgres/postgres.ts
+++ b/services/store/providers/postgres/postgres.ts
@@ -2855,6 +2855,51 @@ class PostgresStoreService extends StoreService<
     // assigned_until, so no background sweep is needed to release expired claims.
     return 0;
   }
+
+  /**
+   * Deletes terminal escalation rows (`resolved`/`cancelled`/`expired`) whose
+   * `updated_at` is older than the given horizon. Terminal rows are inert —
+   * every state transition guards `status = 'pending'` — so pruning them is
+   * the engine-blessed retention path for the audit backlog.
+   *
+   * Single statement: the candidate SELECT (`FOR UPDATE SKIP LOCKED`) and the
+   * DELETE are one atomic unit, so concurrent pruners and readers never block
+   * each other and a row is either fully gone or fully present. `limit` bounds
+   * rows per call to keep vacuum pressure flat; callers loop until `deleted`
+   * returns 0.
+   */
+  async pruneEscalations(
+    params: import('../../../../types/hmsh_escalations').PruneEscalationsParams,
+  ): Promise<import('../../../../types/hmsh_escalations').PruneEscalationsResult> {
+    const TERMINAL = ['resolved', 'cancelled', 'expired'] as const;
+    const statuses = params.statuses?.length
+      ? params.statuses.filter((s): s is (typeof TERMINAL)[number] =>
+          (TERMINAL as readonly string[]).includes(s))
+      : [...TERMINAL];
+    if (!statuses.length) return { deleted: 0 };
+    const limit = Math.max(1, Math.min(params.limit ?? 10_000, 100_000));
+    const values: unknown[] = [statuses, params.olderThan, limit];
+    let nsClause = '';
+    if (params.namespace) {
+      values.push(params.namespace);
+      nsClause = `AND namespace = $${values.length}`;
+    }
+    const result = await this.pgClient.query(
+      `WITH doomed AS (
+         SELECT ctid FROM public.hmsh_escalations
+         WHERE status = ANY($1::text[])
+           AND status IN ('resolved', 'cancelled', 'expired')
+           AND updated_at < NOW() - $2::interval
+           ${nsClause}
+         LIMIT $3
+         FOR UPDATE SKIP LOCKED
+       )
+       DELETE FROM public.hmsh_escalations e
+       USING doomed WHERE e.ctid = doomed.ctid`,
+      values,
+    );
+    return { deleted: result.rowCount ?? 0 };
+  }
 }
 
 export { PostgresStoreService };

--- a/tests/durable/escalations/postgres.test.ts
+++ b/tests/durable/escalations/postgres.test.ts
@@ -133,6 +133,49 @@ describe('DURABLE | escalations | Postgres', () => {
     }, 5_000);
   });
 
+  describe('Leg1 metadata atomicity contract', () => {
+    it('should expose config.metadata on the row from its first visible moment', async () => {
+      // The escalation INSERT (metadata included) commits inside the Leg1
+      // checkpoint transaction. A tight poll from workflow start therefore
+      // always sees a COMPLETE row: the first sighting carries metadata and
+      // full routing context. A two-commit write (row first, facets later)
+      // would hand this poller a metadata-less row.
+      const probeOrderId = guid();
+      const probe = await client.workflow.start({
+        args: [probeOrderId, region],
+        taskQueue: 'escalation-test',
+        workflowName: 'approvalWorkflow',
+        workflowId: guid(),
+      });
+
+      let first: Awaited<ReturnType<typeof client.escalations.list>>[number] | undefined;
+      const deadline = Date.now() + 10_000;
+      while (!first && Date.now() < deadline) {
+        const rows = await client.escalations.list({ role: 'approver', status: 'pending' });
+        first = rows.find((e) => (e.metadata as any)?.orderId === probeOrderId
+          || (e.description ?? '').includes(probeOrderId));
+        if (!first) await sleepFor(25);
+      }
+      expect(first).toBeDefined();
+      // First sighting is already complete — metadata facets AND routing.
+      expect((first!.metadata as any)?.orderId).toBe(probeOrderId);
+      expect((first!.metadata as any)?.region).toBe(region);
+      expect(first!.signal_key).not.toBeNull();
+      expect(first!.topic).toBeDefined();
+      expect(first!.workflow_id).toBeDefined();
+      expect(first!.task_queue).toBe('escalation-test');
+
+      // Leave no parked probe behind: resolve it and confirm completion.
+      const resolved = await client.escalations.resolve({
+        id: first!.id,
+        resolverPayload: { approved: true, approvedBy: 'atomicity-probe' },
+      });
+      expect(resolved.ok).toBe(true);
+      const output = await probe.result();
+      expect((output as any).approvedBy).toBe('atomicity-probe');
+    }, 20_000);
+  });
+
   describe('claim lifecycle', () => {
     let escalationId: string;
 

--- a/tests/durable/fanout/postgres.test.ts
+++ b/tests/durable/fanout/postgres.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Proves the concurrent-condition contract for harvest fan-out: one
+ * workflow opens N condition() waits via Promise.all while signalers
+ * fire at ALL of them immediately — before any wait has registered.
+ * Every signal that races ahead of registration is buffered as a
+ * pending signal (default TTL 10 minutes, extensible per signal) and
+ * delivered when its condition registers. No signal is lost and every
+ * wait resumes with its own payload, so fan-out is sized by the
+ * pending-signal TTL, not by a registration-count bound.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Client as Postgres } from 'pg';
+
+import { Durable } from '../../../services/durable';
+import { guid, sleepFor } from '../../../modules/utils';
+import { ProviderNativeClient } from '../../../types/provider';
+import { dropTables, postgres_options } from '../../$setup/postgres';
+import { PostgresConnection } from '../../../services/connector/providers/postgres';
+
+import * as workflows from './src/workflows';
+
+const { Connection, Client, Worker } = Durable;
+
+const FANOUT = 25;
+
+describe('DURABLE | fanout | Postgres', () => {
+  let postgresClient: ProviderNativeClient;
+  const connection = { class: Postgres, options: postgres_options };
+
+  beforeAll(async () => {
+    if (process.env.POSTGRES_IS_REMOTE === 'true') return;
+
+    postgresClient = (
+      await PostgresConnection.connect(guid(), Postgres, postgres_options)
+    ).getClient();
+    await dropTables(postgresClient);
+    await Connection.connect(connection);
+
+    const worker = await Worker.create({
+      connection,
+      taskQueue: 'fanout',
+      workflow: workflows.fanout,
+    });
+    await worker.run();
+  }, 30_000);
+
+  afterAll(async () => {
+    await sleepFor(1500);
+    await Durable.shutdown();
+  }, 15_000);
+
+  it(`should harvest ${FANOUT} concurrent conditions with signalers racing ahead of registration`, async () => {
+    const client = new Client({ connection });
+    const caseId = guid();
+
+    const handle = await client.workflow.start({
+      args: [caseId, FANOUT],
+      taskQueue: 'fanout',
+      workflowName: 'fanout',
+      workflowId: `fanout-${caseId}`,
+      expire: 120,
+    });
+
+    // Fire every signal NOW — the workflow's first tick may not have run,
+    // so most (often all) land before their condition registers and take
+    // the pending-signal buffering path.
+    await Promise.all(
+      Array.from({ length: FANOUT }, (_, i) =>
+        handle.signal(`fanout-${caseId}-${i}`, { v: `payload-${i}` }),
+      ),
+    );
+
+    const results = (await handle.result()) as string[];
+    expect(results).toHaveLength(FANOUT);
+    // Promise.all preserves order: each wait resumed with its own payload.
+    expect(results).toEqual(
+      Array.from({ length: FANOUT }, (_, i) => `payload-${i}`),
+    );
+  }, 120_000);
+});

--- a/tests/durable/fanout/src/workflows.ts
+++ b/tests/durable/fanout/src/workflows.ts
@@ -1,0 +1,14 @@
+import { Durable } from '../../../../services/durable';
+
+/**
+ * Harvest fan-out: opens `count` condition() waits at once and harvests
+ * them with Promise.all — the market-maker shape. Signal IDs are
+ * deterministic so a signaler can fire before any wait registers.
+ */
+export async function fanout(caseId: string, count: number): Promise<string[]> {
+  const ids = Array.from({ length: count }, (_, i) => `fanout-${caseId}-${i}`);
+  const results = await Promise.all(
+    ids.map((id) => Durable.workflow.condition<{ v: string }>(id)),
+  );
+  return results.map((r) => (r === false ? 'timed_out' : (r as { v: string }).v));
+}

--- a/tests/durable/heartbeat/postgres.test.ts
+++ b/tests/durable/heartbeat/postgres.test.ts
@@ -16,11 +16,14 @@ const { Connection, Client, Worker } = Durable;
 
 /**
  * An activity that runs longer than the base reservation window (30s)
- * must execute exactly once and deliver its result. The consumer
- * heartbeats the reservation (reserved_at refresh) while the activity
- * callback runs, so the message never becomes claimable mid-execution.
- * A crashed consumer stops heartbeating and its message is rescued
- * within one window (proven at the provider layer in
+ * must execute exactly once and deliver its result — with a SECOND
+ * worker actively polling the same task queue, so a lapsed lease would
+ * be reclaimed and re-dispatched for real. The consumer heartbeats the
+ * reservation (reserved_at refresh) while the activity callback runs,
+ * so the message never becomes claimable mid-execution; the declared
+ * startToCloseTimeout (120s) bounds the run without affecting the
+ * lease. A crashed consumer stops heartbeating and its message is
+ * rescued within one window (proven at the provider layer in
  * tests/functional/stream/providers/postgres/extension.test.ts).
  */
 describe('DURABLE | heartbeat | Postgres', () => {
@@ -45,7 +48,7 @@ describe('DURABLE | heartbeat | Postgres', () => {
   }, 15_000);
 
   describe('Worker and Client', () => {
-    it('should run the worker and start the workflow', async () => {
+    it('should run two competing workers and start the workflow', async () => {
       const worker = await Worker.create({
         connection,
         taskQueue,
@@ -55,6 +58,18 @@ describe('DURABLE | heartbeat | Postgres', () => {
         },
       });
       await worker.run();
+
+      // A rival consumer on the same queue: if the lease lapsed mid-run,
+      // this worker would reclaim the message and execute a duplicate.
+      const rival = await Worker.create({
+        connection,
+        taskQueue,
+        workflow: workflows.heartbeatExample,
+        options: {
+          logLevel: HMSH_LOGLEVEL,
+        },
+      });
+      await rival.run();
 
       activities.resetExecutionCount();
       const client = new Client({ connection });

--- a/tests/durable/heartbeat/src/workflows.ts
+++ b/tests/durable/heartbeat/src/workflows.ts
@@ -2,8 +2,14 @@ import { Durable } from '../../../../services/durable';
 
 import * as activities from './activities';
 
+// The long-batch shape: one activity that outlives the base reservation
+// window, declared with a startToCloseTimeout sized to the work. The
+// reservation heartbeat holds the lease for the full run, independent of
+// the declared timeout.
 const { outliveTheLease } = Durable.workflow.proxyActivities<typeof activities>({
   activities,
+  startToCloseTimeout: '120 seconds',
+  retry: { maximumAttempts: 1 },
 });
 
 export async function heartbeatExample(runId: string): Promise<string> {

--- a/tests/durable/retention/postgres.test.ts
+++ b/tests/durable/retention/postgres.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Proves the escalation retention contract: pruneEscalations deletes ONLY
+ * terminal rows (resolved/cancelled/expired) older than the horizon.
+ *
+ * The contract the dependent platform builds on:
+ * - old terminal rows are deleted (audit backlog ages out);
+ * - pending rows survive regardless of age — a live waiter parked on
+ *   condition() for months keeps its row and still resolves;
+ * - fresh terminal rows inside the horizon survive;
+ * - `limit` batches the delete and looping until 0 drains the backlog;
+ * - `statuses` narrows which terminal states are pruned.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Client as Postgres } from 'pg';
+
+import { Durable } from '../../../services/durable';
+import { WorkflowHandleService } from '../../../services/durable/handle';
+import { guid, sleepFor } from '../../../modules/utils';
+import { ProviderNativeClient } from '../../../types/provider';
+import { dropTables, postgres_options } from '../../$setup/postgres';
+import { PostgresConnection } from '../../../services/connector/providers/postgres';
+
+import * as workflows from './src/workflows';
+
+const { Connection, Client, Worker } = Durable;
+
+describe('DURABLE | retention | Postgres', () => {
+  let handle: WorkflowHandleService;
+  let postgresClient: ProviderNativeClient;
+  let client: InstanceType<typeof Client>;
+  const connection = { class: Postgres, options: postgres_options };
+  const caseId = guid();
+
+  const OLD = `NOW() - INTERVAL '120 days'`;
+
+  const seedTerminal = async (status: string, count: number, backdated = true) => {
+    const ids: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const esc = await client.escalations.create({
+        role: 'retention-seed',
+        type: 'retention-audit',
+        description: `${status} seed ${i}`,
+        metadata: { seed: true },
+      });
+      ids.push(esc.id);
+    }
+    await postgresClient.query(
+      `UPDATE public.hmsh_escalations
+       SET status = $1, updated_at = ${backdated ? OLD : 'NOW()'}
+       WHERE id = ANY($2::uuid[])`,
+      [status, ids],
+    );
+    return ids;
+  };
+
+  beforeAll(async () => {
+    postgresClient = (
+      await PostgresConnection.connect(guid(), Postgres, postgres_options)
+    ).getClient();
+    await dropTables(postgresClient);
+  });
+
+  afterAll(async () => {
+    await sleepFor(1500);
+    await Durable.shutdown();
+  }, 10_000);
+
+  describe('setup', () => {
+    it('should connect, start a live waiter, and process it to suspension', async () => {
+      const conn = await Connection.connect(connection);
+      expect(conn).toBeDefined();
+      client = new Client({ connection });
+      handle = await client.workflow.start({
+        args: [caseId],
+        taskQueue: 'retention-test',
+        workflowName: 'retentionWaiter',
+        workflowId: guid(),
+      });
+      const worker = await Worker.create({
+        connection,
+        taskQueue: 'retention-test',
+        workflow: workflows.retentionWaiter,
+      });
+      await worker.run();
+      await sleepFor(2000);
+      const rows = await client.escalations.list({ role: 'retention-waiter', status: 'pending' });
+      expect(rows.find((e) => (e.metadata as any)?.caseId === caseId)).toBeDefined();
+    }, 20_000);
+  });
+
+  describe('prune contract', () => {
+    it('should delete only terminal rows older than the horizon, batched by limit', async () => {
+      // Backlog: 18 old terminal rows across all three terminal states.
+      await seedTerminal('resolved', 8);
+      await seedTerminal('cancelled', 5);
+      await seedTerminal('expired', 5);
+      // Survivors: old pending rows, fresh terminal rows, and the live waiter
+      // (its pending row backdated past the horizon).
+      const oldPending = await seedTerminal('pending', 4);
+      const freshResolved = await seedTerminal('resolved', 3, false);
+      await postgresClient.query(
+        `UPDATE public.hmsh_escalations SET updated_at = ${OLD}
+         WHERE role = 'retention-waiter' AND metadata @> $1::jsonb`,
+        [JSON.stringify({ caseId })],
+      );
+
+      // A namespace that owns no rows deletes nothing.
+      const other = await client.escalations.prune({ olderThan: '90 days', namespace: 'no-such-ns' });
+      expect(other.deleted).toBe(0);
+
+      // Drain with a limit smaller than the backlog: 18 rows / 7 per call
+      // → 7, 7, 4, 0. The loop must terminate.
+      let total = 0;
+      let calls = 0;
+      for (;;) {
+        const { deleted } = await client.escalations.prune({ olderThan: '90 days', limit: 7 });
+        total += deleted;
+        calls += 1;
+        expect(calls).toBeLessThanOrEqual(10);
+        if (deleted === 0) break;
+      }
+      expect(total).toBe(18);
+      expect(calls).toBe(4);
+
+      // Old pending rows survive regardless of age.
+      const pendingLeft = await client.escalations.list({ role: 'retention-seed', status: 'pending' });
+      expect(pendingLeft.map((e) => e.id).sort()).toEqual([...oldPending].sort());
+      // Terminal rows inside the horizon survive.
+      const resolvedLeft = await client.escalations.list({ role: 'retention-seed', status: 'resolved' });
+      expect(resolvedLeft.map((e) => e.id).sort()).toEqual([...freshResolved].sort());
+      // No old terminal rows remain.
+      const staleTerminal = await postgresClient.query(
+        `SELECT COUNT(*)::int AS total FROM public.hmsh_escalations
+         WHERE role = 'retention-seed'
+           AND status IN ('resolved','cancelled','expired')
+           AND updated_at < NOW() - INTERVAL '90 days'`,
+      );
+      expect(staleTerminal.rows[0].total).toBe(0);
+    }, 30_000);
+
+    it('should prune only the requested terminal statuses', async () => {
+      const resolvedIds = await seedTerminal('resolved', 2);
+      const cancelledIds = await seedTerminal('cancelled', 2);
+
+      const { deleted } = await client.escalations.prune({
+        olderThan: '90 days',
+        statuses: ['resolved'],
+      });
+      expect(deleted).toBe(resolvedIds.length);
+
+      const left = await client.escalations.list({ role: 'retention-seed', status: 'cancelled' });
+      expect(left.map((e) => e.id).sort()).toEqual([...cancelledIds].sort());
+
+      const drained = await client.escalations.prune({ olderThan: '90 days', statuses: ['cancelled'] });
+      expect(drained.deleted).toBe(cancelledIds.length);
+    }, 15_000);
+
+    it('should ignore non-terminal statuses passed to the filter', async () => {
+      const { deleted } = await client.escalations.prune({
+        olderThan: '90 days',
+        statuses: ['pending' as any],
+      });
+      expect(deleted).toBe(0);
+      const waiter = await client.escalations.list({ role: 'retention-waiter', status: 'pending' });
+      expect(waiter.find((e) => (e.metadata as any)?.caseId === caseId)).toBeDefined();
+    }, 10_000);
+
+    it('should leave the aged live waiter resolvable — the workflow completes after pruning', async () => {
+      const rows = await client.escalations.list({ role: 'retention-waiter', status: 'pending' });
+      const esc = rows.find((e) => (e.metadata as any)?.caseId === caseId);
+      expect(esc).toBeDefined();
+
+      const resultPromise = handle.result();
+      const result = await client.escalations.resolve({
+        id: esc!.id,
+        resolverPayload: { resolved: true, resolvedBy: 'auditor-1' },
+      });
+      expect(result.ok).toBe(true);
+
+      const output = await resultPromise;
+      expect((output as any).resolved).toBe(true);
+      expect((output as any).resolvedBy).toBe('auditor-1');
+    }, 20_000);
+  });
+});

--- a/tests/durable/retention/src/workflows.ts
+++ b/tests/durable/retention/src/workflows.ts
@@ -1,0 +1,19 @@
+import { Durable } from '../../../../services/durable';
+
+// Parks on condition() with metadata. The pending row must survive pruning
+// even when its updated_at is older than the retention horizon — pending is
+// live state, terminal is audit history.
+export async function retentionWaiter(caseId: string): Promise<{ resolved: boolean; resolvedBy: string }> {
+  const signalId = `retention-${Durable.guid()}`;
+  const result = await Durable.workflow.condition<{ resolved: boolean; resolvedBy: string }>(
+    signalId,
+    {
+      role: 'retention-waiter',
+      type: 'retention-gate',
+      priority: 3,
+      description: `Retention live waiter for ${caseId}`,
+      metadata: { caseId },
+    },
+  );
+  return result as { resolved: boolean; resolvedBy: string };
+}

--- a/types/hmsh_escalations.ts
+++ b/types/hmsh_escalations.ts
@@ -115,6 +115,31 @@ export type CancelEscalationResult =
   | { ok: true; entry: EscalationEntry }
   | { ok: false; reason: 'not-found' | 'already-terminal' };
 
+/**
+ * Retention parameters for `pruneEscalations`. Prunes only terminal rows
+ * (`resolved`/`cancelled`/`expired`) — the statuses every engine state
+ * transition treats as final — older than the given horizon.
+ */
+export interface PruneEscalationsParams {
+  /**
+   * Age horizon as a Postgres interval string (e.g. `'90 days'`, `'12 hours'`).
+   * Rows qualify when `updated_at < NOW() - olderThan`.
+   */
+  olderThan: string;
+  /** Terminal statuses to prune. Defaults to all three; non-terminal values are ignored. */
+  statuses?: Array<'resolved' | 'cancelled' | 'expired'>;
+  namespace?: string;
+  /**
+   * Max rows deleted per call (bounds lock time and vacuum pressure).
+   * Default 10,000, capped at 100,000. Loop until `deleted` is 0 to drain.
+   */
+  limit?: number;
+}
+
+export interface PruneEscalationsResult {
+  deleted: number;
+}
+
 export interface ListEscalationsParams {
   namespace?: string;
   role?: string;


### PR DESCRIPTION
- Terminal escalation rows (resolved/cancelled/expired) can now be aged out with `client.escalations.prune()` — one atomic batched statement that leaves pending rows, live waiters, and in-horizon audit rows untouched.
- Four behaviors dependents build on are now published contracts with proving tests: additive-only migrations (app-added indexes survive upgrades), Leg1 metadata atomicity on `condition()`, early-signal buffering with per-signal TTL, and exactly-once execution for long activities under competing workers.
- Full durable suite green (433 passed), fail-first verified on the retention guard, tsc clean.