### PR TITLE
feat: resolver identity in resolution payload + claimManyByQuery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.26.2",
+      "version": "0.26.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",
@@ -1480,9 +1480,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2904,16 +2904,16 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
@@ -3641,9 +3641,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -3969,9 +3969,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
       "funding": [
         {
@@ -4278,9 +4278,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.14",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.14.tgz",
-      "integrity": "sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -4827,9 +4827,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -4847,7 +4847,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6047,9 +6047,9 @@
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/escalations/client.ts
+++ b/services/escalations/client.ts
@@ -36,8 +36,17 @@ import {
   ResolveAllOrNoneResult,
   PruneEscalationsParams,
   PruneEscalationsResult,
+  ResolvedByIdentity,
+  ClaimManyByQueryParams,
 } from '../../types/hmsh_escalations';
 import { APP_ID } from '../durable/schemas/factory';
+
+/**
+ * Reserved signal-payload key carrying resolution provenance
+ * (`EscalationResolution`) to the waiting workflow. The `$` prefix marks the
+ * control-key namespace — consumer payload fields never collide with it.
+ */
+export const ESCALATION_RESOLUTION_KEY = '$resolution';
 
 export type GetHotMeshFn = (topic: string | null, namespace?: string) => Promise<HotMesh>;
 
@@ -178,6 +187,32 @@ export class EscalationClientService {
   }
 
   // ─── Signal delivery ───────────────────────────────────────────────────────
+
+  /**
+   * Composes the signal `data` delivered to the waiting workflow. When the
+   * resolving caller supplies `resolvedBy`, resolution provenance (escalation
+   * id + resolver identity) rides under the reserved `$resolution` key —
+   * making the waiter's payload contract deterministic per call site. Without
+   * `resolvedBy` the payload passes through byte-identical, so callers that
+   * exact-match on payloads are unaffected. The enrichment rides the SIGNAL
+   * only — the stored `resolver_payload` column receives the caller's payload
+   * untouched.
+   */
+  private _signalData(
+    payload: Record<string, unknown> | undefined,
+    escalationId: string,
+    resolvedBy?: ResolvedByIdentity,
+  ): Record<string, unknown> {
+    if (!resolvedBy) return payload ?? {};
+    return {
+      ...(payload ?? {}),
+      [ESCALATION_RESOLUTION_KEY]: {
+        escalationId,
+        resolvedBy: resolvedBy.id,
+        ...(resolvedBy.email ? { resolvedByEmail: resolvedBy.email } : {}),
+      },
+    };
+  }
 
   private async _deliverEscalationSignal(
     ns: string,
@@ -455,7 +490,7 @@ export class EscalationClientService {
         ns,
         preview.topic,
         preview.signal_key,
-        params.resolverPayload ?? {},
+        this._signalData(params.resolverPayload, params.id, params.resolvedBy),
       );
     }
 
@@ -469,7 +504,7 @@ export class EscalationClientService {
       //enqueue was rolled back to its savepoint) — deliver post-commit
       await this._deliverEscalationSignal(ns, dbResult.topic, {
         id: dbResult.signalKey,
-        data: params.resolverPayload ?? {},
+        data: this._signalData(params.resolverPayload, params.id, params.resolvedBy),
       });
     }
     this._emit('resolved', dbResult.entry);
@@ -502,11 +537,14 @@ export class EscalationClientService {
       namespace: params.namespace,
     });
     if (preview?.signalKey) {
+      //the wake embeds the previewed row's id; forSignalKey pins it to that
+      //row, so a different row winning the race falls through to post-commit
+      //delivery where the winner's own id is used
       wakeCommand = await this._buildWakeCommand(
         ns,
         preview.topic,
         preview.signalKey,
-        params.resolverPayload ?? {},
+        this._signalData(params.resolverPayload, preview.id, params.resolvedBy),
       );
     }
 
@@ -518,7 +556,7 @@ export class EscalationClientService {
     if (dbResult.signalKey && !dbResult.wakeEnqueued) {
       await this._deliverEscalationSignal(ns, dbResult.topic, {
         id: dbResult.signalKey,
-        data: params.resolverPayload ?? {},
+        data: this._signalData(params.resolverPayload, dbResult.entry.id, params.resolvedBy),
       });
     }
     this._emit('resolved', dbResult.entry);
@@ -559,6 +597,21 @@ export class EscalationClientService {
     const { entries, skipped } = await (hm.engine.store as any).claimManyEscalations(params);
     this._emitMany('claimed', entries);
     return { claimed: entries.length, skipped };
+  }
+
+  /**
+   * Atomic query-form bulk claim: one UPDATE selects and claims every pending,
+   * claimable row matching the selector (role/type/priority equality, metadata
+   * `@>` containment). Prefer this over `list()` + `claimMany({ids})` when the
+   * population is describable by filter — a row that re-parks between a search
+   * and an ids-claim is invisible to the ids form but claimed by this one.
+   * Returns the claimed rows.
+   */
+  async claimManyByQuery(params: ClaimManyByQueryParams): Promise<{ claimed: number; entries: EscalationEntry[] }> {
+    const hm = await this._engine(null, params.namespace);
+    const entries = await (hm.engine.store as any).claimManyEscalationsByQuery(params);
+    this._emitMany('claimed', entries);
+    return { claimed: entries.length, entries };
   }
 
   /**
@@ -648,7 +701,7 @@ export class EscalationClientService {
         ns,
         row.topic,
         row.signal_key,
-        payloadById.get(row.id) ?? {},
+        this._signalData(payloadById.get(row.id), row.id, params.resolvedBy),
       );
       if (cmd) wakeCommands.push(cmd);
     }
@@ -671,7 +724,7 @@ export class EscalationClientService {
       if (entry.signal_key && !enqueuedKeys.has(entry.signal_key)) {
         await this._deliverEscalationSignal(ns, entry.topic, {
           id: entry.signal_key,
-          data: payloadById.get(entry.id) ?? {},
+          data: this._signalData(payloadById.get(entry.id), entry.id, params.resolvedBy),
         });
       }
     }

--- a/services/escalations/index.ts
+++ b/services/escalations/index.ts
@@ -72,3 +72,4 @@ class EscalationsClass {
 
 export { EscalationsClass as Escalations };
 export { EscalationClientService };
+export { ESCALATION_RESOLUTION_KEY } from './client';

--- a/services/store/providers/postgres/postgres.ts
+++ b/services/store/providers/postgres/postgres.ts
@@ -2716,6 +2716,56 @@ class PostgresStoreService extends StoreService<
     return { entries, skipped: ids.length - entries.length };
   }
 
+  /**
+   * Atomic query-form bulk claim: the selector composes into the UPDATE's own
+   * WHERE via `_escalationFilterConditions`, so selection and claim are one
+   * statement — no SELECT-then-claim window. `status='pending'` and the
+   * claimability guard are forced regardless of the selector.
+   */
+  async claimManyEscalationsByQuery(
+    params: import('../../../../types/hmsh_escalations').ClaimManyByQueryParams,
+  ): Promise<import('../../../../types/hmsh_escalations').EscalationEntry[]> {
+    const { query, namespace, assignee, durationMinutes = 1 } = params;
+    const selectorIsEmpty =
+      !query.role && !query.roles?.length && !query.type && !query.subtype &&
+      !query.entity && query.priority === undefined &&
+      !(query.metadata && Object.keys(query.metadata).length);
+    if (selectorIsEmpty) {
+      throw new Error(
+        'claimManyEscalationsByQuery: empty selector — an unbounded bulk claim is not allowed',
+      );
+    }
+    const { conditions, values, idx } = this._escalationFilterConditions(
+      {
+        namespace,
+        role: query.role,
+        roles: query.roles,
+        type: query.type,
+        subtype: query.subtype,
+        entity: query.entity,
+        priority: query.priority,
+        metadata: query.metadata,
+      },
+      1,
+    );
+    const assigneeIdx = idx;
+    const durationIdx = idx + 1;
+    const result = await this.pgClient.query(
+      `UPDATE public.hmsh_escalations
+       SET assigned_to      = $${assigneeIdx},
+           claimed_at       = NOW(),
+           claim_expires_at = NOW() + ($${durationIdx} * INTERVAL '1 minute'),
+           assigned_until   = NOW() + ($${durationIdx} * INTERVAL '1 minute'),
+           updated_at       = NOW()
+       WHERE ${conditions.join(' AND ')}
+         AND status = 'pending'
+         AND (assigned_to IS NULL OR assigned_until IS NULL OR assigned_until <= NOW() OR assigned_to = $${assigneeIdx})
+       RETURNING *`,
+      [...values, assignee, durationMinutes],
+    );
+    return result.rows as import('../../../../types/hmsh_escalations').EscalationEntry[];
+  }
+
   async escalateManyEscalationsToRole(
     params: import('../../../../types/hmsh_escalations').EscalateManyToRoleParams,
   ): Promise<number> {

--- a/tests/durable/escalations/postgres.test.ts
+++ b/tests/durable/escalations/postgres.test.ts
@@ -261,12 +261,24 @@ describe('DURABLE | escalations | Postgres', () => {
       const result = await client.escalations.resolve({
         id: escalationId,
         resolverPayload: { approved: true, approvedBy: 'reviewer-1' },
+        resolvedBy: { id: 'reviewer-1', email: 'reviewer-1@example.com' },
       });
       expect(result.ok).toBe(true);
 
       const output = await resultPromise;
       expect((output as any).approved).toBe(true);
       expect((output as any).approvedBy).toBe('reviewer-1');
+
+      // resolution provenance rides the signal under the reserved $resolution key
+      const resolution = (output as any).$resolution;
+      expect(resolution.escalationId).toBe(escalationId);
+      expect(resolution.resolvedBy).toBe('reviewer-1');
+      expect(resolution.resolvedByEmail).toBe('reviewer-1@example.com');
+
+      // ...but never pollutes the stored resolver_payload audit column
+      const row = await client.escalations.get(escalationId);
+      expect((row!.resolver_payload as any).$resolution).toBeUndefined();
+      expect((row!.resolver_payload as any).approved).toBe(true);
     }, 15_000);
 
     it('should return already-resolved when resolving again', async () => {
@@ -838,6 +850,27 @@ describe('DURABLE | escalations | Postgres', () => {
       expect((result.entry.metadata as any).outcome).toBe('resolved-by-metadata');
     }, 5_000);
 
+    it('resolveByMetadata with resolvedBy keeps the stored resolver_payload clean', async () => {
+      const sel = `rbm-id-${guid()}`;
+      const esc = await client.escalations.create({
+        type: 'order-approval',
+        role: 'rbm-approver',
+        metadata: { selector: sel },
+      });
+      const result = await client.escalations.resolveByMetadata({
+        key: 'selector',
+        value: sel,
+        resolverPayload: { approved: true },
+        resolvedBy: { id: 'rbm-user', email: 'rbm-user@example.com' },
+      });
+      expect(result.ok).toBe(true);
+      // $resolution rides the signal only — the audit column stores the
+      // caller's payload untouched
+      const row = await client.escalations.get(esc.id);
+      expect((row!.resolver_payload as any).approved).toBe(true);
+      expect((row!.resolver_payload as any).$resolution).toBeUndefined();
+    }, 5_000);
+
     it('resolveMany merges metadata into every winning row', async () => {
       const tag = `bulkmeta-${guid()}`;
       const created = await Promise.all([
@@ -1190,6 +1223,59 @@ describe('DURABLE | escalations | Postgres', () => {
       expect(result.claimed).toBe(0);
       expect(result.skipped).toBe(1);
     }, 5_000);
+
+    it('claimManyByQuery: one atomic UPDATE claims exactly the matching pending, claimable rows', async () => {
+      const walkType = `walk-${guid()}`;
+      const walkId = `walk-${guid()}`;
+      // three in the walk, one outside it (different facet), one in the walk
+      // but already claimed by someone else
+      const inWalk = await Promise.all([
+        client.escalations.create({ type: walkType, role: 'harvester', metadata: { walkId } }),
+        client.escalations.create({ type: walkType, role: 'harvester', metadata: { walkId } }),
+        client.escalations.create({ type: walkType, role: 'harvester', metadata: { walkId } }),
+      ]);
+      await client.escalations.create({ type: walkType, role: 'harvester', metadata: { walkId: 'other-walk' } });
+      const held = await client.escalations.create({ type: walkType, role: 'harvester', metadata: { walkId } });
+      await client.escalations.claim({ id: held.id, assignee: 'someone-else', durationMinutes: 5 });
+
+      const result = await client.escalations.claimManyByQuery({
+        query: { role: 'harvester', metadata: { walkId } },
+        assignee: 'harvester-1',
+        durationMinutes: 5,
+      });
+      expect(result.claimed).toBe(3);
+      const claimedIds = result.entries.map((e) => e.id).sort();
+      expect(claimedIds).toEqual(inWalk.map((e) => e.id).sort());
+      result.entries.forEach((e) => expect(e.assigned_to).toBe('harvester-1'));
+
+      // the foreign-claimed row was untouched
+      const heldRow = await client.escalations.get(held.id);
+      expect(heldRow?.assigned_to).toBe('someone-else');
+    }, 10_000);
+
+    it('claimManyByQuery: an empty selector throws — unbounded bulk claims are not allowed', async () => {
+      await expect(
+        client.escalations.claimManyByQuery({
+          query: {},
+          assignee: 'harvester-1',
+        }),
+      ).rejects.toThrow(/unbounded/);
+    }, 5_000);
+
+    it('claimManyByQuery: resolved rows are excluded even when the selector matches', async () => {
+      const walkId = `walk-done-${guid()}`;
+      const open = await client.escalations.create({ role: 'harvester', metadata: { walkId } });
+      const done = await client.escalations.create({ role: 'harvester', metadata: { walkId } });
+      await client.escalations.resolve({ id: done.id, resolverPayload: { approved: true } });
+
+      const result = await client.escalations.claimManyByQuery({
+        query: { role: 'harvester', metadata: { walkId } },
+        assignee: 'harvester-1',
+        durationMinutes: 5,
+      });
+      expect(result.claimed).toBe(1);
+      expect(result.entries[0].id).toBe(open.id);
+    }, 10_000);
 
     it('updateManyPriority: updates only pending rows', async () => {
       const count = await client.escalations.updateManyPriority({

--- a/types/hmsh_escalations.ts
+++ b/types/hmsh_escalations.ts
@@ -107,6 +107,45 @@ export interface EscalationWakeCommand {
   message: string;
 }
 
+/**
+ * Resolution provenance delivered to the waiting workflow alongside the
+ * resolver payload, under the reserved `$resolution` key. Present exactly when
+ * the resolving caller supplied `resolvedBy` — without it the signal payload
+ * passes through byte-identical, so existing waiters are unaffected. The
+ * `$`-prefixed key namespace is reserved for control data riding the signal
+ * (like `$escalation_id` on the legacy routing path); consumer payload fields
+ * never collide with it. The stored `resolver_payload` row column stays clean —
+ * provenance rides the signal only.
+ *
+ * A waiting workflow declares the key in its `condition()` payload generic:
+ *
+ * ```typescript
+ * const decision = await Durable.workflow.condition<{
+ *   approved: boolean;
+ *   $resolution?: EscalationResolution;
+ * }>(signalId, config);
+ * decision.$resolution?.resolvedBy; // who resolved it
+ * ```
+ */
+export interface EscalationResolution {
+  /** The id of the escalation row whose resolve delivered this signal. */
+  escalationId: string;
+  /** Resolver's user id. */
+  resolvedBy: string;
+  /** Resolver's email — present when supplied alongside the id. */
+  resolvedByEmail?: string;
+}
+
+/**
+ * Resolver identity, supplied by the resolving caller (the API layer that
+ * authenticated the human or agent). Delivered to the waiting workflow inside
+ * `$resolution`; never written to the stored `resolver_payload`.
+ */
+export interface ResolvedByIdentity {
+  id: string;
+  email?: string;
+}
+
 export type ReleaseEscalationResult =
   | { ok: true; entry: EscalationEntry }
   | { ok: false; reason: 'not-found' | 'wrong-assignee' };
@@ -301,6 +340,12 @@ export interface ResolveEscalationParams {
    * claim-race window for interactive claim-then-resolve flows.
    */
   assertClaim?: string;
+  /**
+   * Resolver identity, delivered to the waiting workflow under the reserved
+   * `$resolution` signal key (see {@link EscalationResolution}). Never written
+   * to the stored `resolver_payload`.
+   */
+  resolvedBy?: ResolvedByIdentity;
 }
 
 export interface ResolveByMetadataParams {
@@ -315,12 +360,44 @@ export interface ResolveByMetadataParams {
    * `key`/`value` selector used to find the row. See {@link ResolveEscalationParams.metadata}.
    */
   metadata?: Record<string, unknown>;
+  /** Resolver identity delivered under `$resolution`. See {@link ResolveEscalationParams.resolvedBy}. */
+  resolvedBy?: ResolvedByIdentity;
 }
 
 export interface EscalateToRoleParams {
   id: string;
   targetRole: string;
   namespace?: string;
+}
+
+/**
+ * Query selector for `claimManyByQuery()` — the filterable subset of
+ * `ListEscalationsParams` that describes a claimable population. `status` is
+ * not accepted: the claim targets pending rows by definition, enforced in SQL.
+ */
+export interface ClaimManyQuerySelector {
+  role?: string;
+  roles?: string[];
+  type?: string;
+  subtype?: string;
+  entity?: string;
+  priority?: number;
+  /** GIN-indexed `@>` containment against row metadata — the facet filter. */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Atomic query-form bulk claim: one UPDATE selects and claims every matching
+ * pending, claimable row — no SELECT-then-claim window. Prefer this over
+ * `list()` + `claimMany({ids})` whenever the population is describable by
+ * filter: a row that re-parks between a search and an ids-claim is invisible
+ * to the ids form but claimed by this one.
+ */
+export interface ClaimManyByQueryParams {
+  query: ClaimManyQuerySelector;
+  namespace?: string;
+  assignee: string;
+  durationMinutes?: number;
 }
 
 export interface ClaimManyParams {
@@ -377,6 +454,11 @@ export interface ResolveAllOrNoneParams {
    * principal between the caller's claim and this resolve blocks the batch.
    */
   assertAssignee?: string;
+  /**
+   * Resolver identity delivered to EVERY item's waiting workflow under
+   * `$resolution` (one resolver per batch). See {@link ResolveEscalationParams.resolvedBy}.
+   */
+  resolvedBy?: ResolvedByIdentity;
 }
 
 /** Why a specific row blocked a `resolveAllOrNone()` batch. */

--- a/types/index.ts
+++ b/types/index.ts
@@ -334,5 +334,9 @@ export {
   ResolveAllOrNoneResult,
   EscalateToRoleParams,
   MigrateEscalationParams,
+  EscalationResolution,
+  ResolvedByIdentity,
+  ClaimManyQuerySelector,
+  ClaimManyByQueryParams,
 } from './hmsh_escalations';
 export { EscalationVerb, EngineVerb, WorkerVerb, SystemEvent, EventsConfig } from './system_events';


### PR DESCRIPTION
## Summary

- **Resolver identity in the resolution payload.** All resolve variants (`resolve`, `resolveByMetadata`, `resolveAllOrNone`) accept an optional `resolvedBy: { id, email? }`. When supplied, the signal delivered to the waiting workflow carries a reserved `$resolution: { escalationId, resolvedBy, resolvedByEmail }` key alongside the resolver payload — following the existing `$`-prefixed control-key convention (`$escalation_id`). The stored `resolver_payload` column stays clean; provenance rides the signal only. Enrichment is opt-in: without `resolvedBy` the payload passes through byte-identical, so existing waiters and exact-match consumers are unaffected.

- **`claimManyByQuery` — atomic query-form bulk claim.** One UPDATE selects and claims every matching pending, claimable row (role/type/priority equality, GIN-indexed `metadata @>` containment) — no SELECT-then-claim window, closing the search-then-assign race. Empty selectors throw rather than claim unbounded. Returns the claimed rows.

## Usage

```typescript
// deliver identity to the waiting workflow
await client.escalations.resolve({
  id,
  resolverPayload: { approved: true },
  resolvedBy: { id: 'user-1', email: 'user-1@example.com' },
});

// the waiter declares the reserved key in its condition() generic
const decision = await Durable.workflow.condition<{
  approved: boolean;
  $resolution?: EscalationResolution;
}>(signalId, config);
decision.$resolution?.resolvedBy;   // who resolved it
decision.$resolution?.escalationId; // which row delivered it

// claim a describable population atomically
const { claimed, entries } = await client.escalations.claimManyByQuery({
  query: { role: 'harvester', metadata: { walkId } },
  assignee: 'harvester-1',
  durationMinutes: 30,
});
```

## Test plan

- [x] Full durable suite: 42 files, 452 passed, 8 skipped, 0 failures
- [x] Escalations suite: 93 tests including 5 new — `$resolution` waiter delivery + clean stored payload (resolve + resolveByMetadata), claimManyByQuery matching / resolved-row exclusion / foreign-claim exclusion / unbounded-selector guard
- [x] Opt-out contract proven by the pre-existing deep-equality waiter test in `tests/durable/basic` (passes unchanged)
- [x] `tsc --noEmit` clean