### PR TITLE
feat(escalations): assign at creation — one-shot atomic assignee on condition()/create() (v0.27.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.26.3",
+  "version": "0.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hotmeshio/hotmesh",
-      "version": "0.26.3",
+      "version": "0.27.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotmeshio/hotmesh",
-  "version": "0.26.3",
+  "version": "0.27.0",
   "description": "Durable Workflow",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/services/activities/hook.ts
+++ b/services/activities/hook.ts
@@ -457,6 +457,8 @@ class Hook extends Activity {
       metadata: resolveObj(escalationConfig.metadata),
       envelope: resolveObj(escalationConfig.envelope),
       expiresAt: resolveField(escalationConfig.expiresAt),
+      assignee: resolveField(escalationConfig.assignee),
+      durationMinutes: resolveField(escalationConfig.durationMinutes),
       taskQueue: resolveField(escalationConfig.taskQueue),
       workflowType: resolveField(escalationConfig.workflowType),
     };
@@ -465,7 +467,8 @@ class Hook extends Activity {
     // the factory waiter runs for a condition() call that had no queueConfig.
     if (
       params.role == null && params.type == null &&
-      params.priority == null && params.metadata == null
+      params.priority == null && params.metadata == null &&
+      params.assignee == null
     ) return null;
 
     const signalKey = await this.deriveEscalationSignalKey();

--- a/services/activities/hook.ts
+++ b/services/activities/hook.ts
@@ -387,8 +387,8 @@ class Hook extends Activity {
       await this.redeliverPendingSignal(pending);
     }
 
-    // Post-commit: fire the escalation.created event using the row returned
-    // directly from the RETURNING * clause — no extra SELECT.
+    // Post-commit: fire the escalation lifecycle events using the row
+    // returned directly from the RETURNING * clause — no extra SELECT.
     if (escalationSignalKey) {
       const store = this.store as any;
       if (store.eventsPublish) {
@@ -396,20 +396,29 @@ class Hook extends Activity {
         if (row?.id) {
           const ts = new Date().toISOString();
           const updatedAt = row.updated_at ? new Date(row.updated_at).toISOString() : ts;
-          void Promise.resolve(store.eventsPublish({
-            event_id: `${row.id}:created:${updatedAt}`,
-            type: `system.escalation.${row.id}.created`,
-            ts,
-            namespace: row.namespace ?? (this.engine as any).namespace ?? this.engine.appId,
-            app_id: row.app_id ?? this.engine.appId,
-            workflow_id: row.workflow_id ?? undefined,
-            topic: row.topic ?? undefined,
-            origin_id: row.origin_id ?? undefined,
-            parent_id: row.parent_id ?? undefined,
-            trace_id: row.trace_id ?? undefined,
-            span_id: row.span_id ?? undefined,
-            data: row,
-          })).catch(() => { /* best-effort */ });
+          const publish = (verb: string, extras?: Record<string, unknown>) =>
+            void Promise.resolve(store.eventsPublish({
+              event_id: `${row.id}:${verb}:${updatedAt}`,
+              type: `system.escalation.${row.id}.${verb}`,
+              ts,
+              namespace: row.namespace ?? (this.engine as any).namespace ?? this.engine.appId,
+              app_id: row.app_id ?? this.engine.appId,
+              workflow_id: row.workflow_id ?? undefined,
+              topic: row.topic ?? undefined,
+              origin_id: row.origin_id ?? undefined,
+              parent_id: row.parent_id ?? undefined,
+              trace_id: row.trace_id ?? undefined,
+              span_id: row.span_id ?? undefined,
+              ...extras,
+              data: row,
+            })).catch(() => { /* best-effort */ });
+          publish('created');
+          // A born-assigned row is created AND claimed in the same Leg1
+          // commit — state both, in that order, so hand-off consumers act
+          // on the canonical claimed event instead of inferring from timing.
+          if (row.assigned_to != null) {
+            publish('claimed', { assigned_at_creation: true });
+          }
         }
       }
     }

--- a/services/durable/schemas/factory.ts
+++ b/services/durable/schemas/factory.ts
@@ -3,9 +3,10 @@
 // schema upgrade and hot-swap to it (see WorkerService.activateWorkflow and
 // ClientService.deployAndActivate). Changing the YAML without a bump leaves
 // every already-deployed database on the old schema forever. Numeric string —
-// compared with `Number()` for ordering. (v17: collator_waiter escalation block —
-// escalation-bearing condition() inside Promise.all writes its hmsh_escalations row.)
-const APP_VERSION = '17';
+// compared with `Number()` for ordering. (v18: assign-at-creation — the
+// escalation blocks forward queueConfig.assignee/durationMinutes so a
+// condition() row is born assigned in the Leg1 commit.)
+const APP_VERSION = '18';
 const APP_ID = 'durable';
 
 /**
@@ -391,6 +392,8 @@ const getWorkflowYAML = (app: string, version: string): string => {
             traceId: '{worker.output.data.queueConfig.traceId}'
             spanId: '{worker.output.data.queueConfig.spanId}'
             expiresAt: '{worker.output.data.queueConfig.expiresAt}'
+            assignee: '{worker.output.data.queueConfig.assignee}'
+            durationMinutes: '{worker.output.data.queueConfig.durationMinutes}'
             taskQueue: '{trigger.output.data.taskQueue}'
             workflowType: '{trigger.output.data.workflowName}'
           sleep: '{worker.output.data.duration}'
@@ -1206,6 +1209,8 @@ const getWorkflowYAML = (app: string, version: string): string => {
             traceId: '{signaler_worker.output.data.queueConfig.traceId}'
             spanId: '{signaler_worker.output.data.queueConfig.spanId}'
             expiresAt: '{signaler_worker.output.data.queueConfig.expiresAt}'
+            assignee: '{signaler_worker.output.data.queueConfig.assignee}'
+            durationMinutes: '{signaler_worker.output.data.queueConfig.durationMinutes}'
             taskQueue: '{trigger.output.data.taskQueue}'
             workflowType: '{trigger.output.data.workflowName}'
           sleep: '{signaler_worker.output.data.duration}'
@@ -1982,6 +1987,8 @@ const getWorkflowYAML = (app: string, version: string): string => {
             traceId: '{$self.output.data.queueConfig.traceId}'
             spanId: '{$self.output.data.queueConfig.spanId}'
             expiresAt: '{$self.output.data.queueConfig.expiresAt}'
+            assignee: '{$self.output.data.queueConfig.assignee}'
+            durationMinutes: '{$self.output.data.queueConfig.durationMinutes}'
             taskQueue: '{$self.output.data.taskQueue}'
             workflowType: '{$self.output.data.workflowName}'
           hook:

--- a/services/durable/workflow/condition.ts
+++ b/services/durable/workflow/condition.ts
@@ -86,6 +86,14 @@ import { ConditionQueueConfig } from '../../../types/hmsh_escalations';
  * await client.escalations.resolve({ id: item.id, resolverPayload: { approved: true } });
  * ```
  *
+ * ## Assign at creation
+ *
+ * Set `assignee` in the config to write `assigned_to` in the same atomic
+ * commit — the row is born routed to that user (e.g. hand the follow-on step
+ * to `$resolution.resolvedBy` of a prior escalation) and is resolvable by
+ * them immediately. Add `durationMinutes` to arm the claim TTL window at
+ * creation, locking the row to the assignee exactly as `claim()` would.
+ *
  * ## Placement: call escalation-bearing waits from main workflow code
  *
  * The resolve/signal delivery pipeline routes to the main flow's waiter.

--- a/services/escalations/client.ts
+++ b/services/escalations/client.ts
@@ -123,7 +123,11 @@ export class EscalationClientService {
    * Detached (not awaited); a publish error never fails the caller.
    * @private
    */
-  private _emit(verb: EscalationVerb, entry: EscalationEntry): void {
+  private _emit(
+    verb: EscalationVerb,
+    entry: EscalationEntry,
+    assignedAtCreation?: boolean,
+  ): void {
     if (!this._events?.publish) return;
     const ts = new Date().toISOString();
     const updatedAt = entry.updated_at
@@ -141,6 +145,7 @@ export class EscalationClientService {
       parent_id: entry.parent_id ?? undefined,
       trace_id: entry.trace_id ?? undefined,
       span_id: entry.span_id ?? undefined,
+      ...(assignedAtCreation !== undefined ? { assigned_at_creation: assignedAtCreation } : {}),
       data: entry as unknown as Record<string, unknown>,
     };
     void Promise.resolve(this._events.publish(event)).catch(() => { /* best-effort */ });
@@ -150,8 +155,12 @@ export class EscalationClientService {
    * Fires per-row events for bulk operations. Skipped rows are not emitted.
    * @private
    */
-  private _emitMany(verb: EscalationVerb, entries: EscalationEntry[]): void {
-    for (const entry of entries) this._emit(verb, entry);
+  private _emitMany(
+    verb: EscalationVerb,
+    entries: EscalationEntry[],
+    assignedAtCreation?: boolean,
+  ): void {
+    for (const entry of entries) this._emit(verb, entry, assignedAtCreation);
   }
 
   private _makeEngineFactory(connection: Connection): GetHotMeshFn {
@@ -339,7 +348,12 @@ export class EscalationClientService {
   async create(params: CreateEscalationParams): Promise<EscalationEntry> {
     const hm = await this._engine(null, params.namespace);
     const entry = await (hm.engine.store as any).createEscalation(params);
-    if (entry) this._emit('created', entry);
+    if (entry) {
+      this._emit('created', entry);
+      // A born-assigned row is created AND claimed in one commit — state
+      // both, in that order, so hand-off consumers act without inferring.
+      if (entry.assigned_to != null) this._emit('claimed', entry, true);
+    }
     return entry;
   }
 
@@ -366,7 +380,7 @@ export class EscalationClientService {
   async claim(params: ClaimEscalationParams): Promise<ClaimEscalationResult> {
     const hm = await this._engine(null, params.namespace);
     const result = await (hm.engine.store as any).claimEscalation(params);
-    if (result.ok === true) this._emit('claimed', result.entry);
+    if (result.ok === true) this._emit('claimed', result.entry, false);
     return result;
   }
 
@@ -379,7 +393,7 @@ export class EscalationClientService {
   async claimByMetadata(params: ClaimByMetadataParams): Promise<ClaimByMetadataResult> {
     const hm = await this._engine(null, params.namespace);
     const result = await (hm.engine.store as any).claimEscalationByMetadata(params);
-    if (result.ok === true) this._emit('claimed', result.entry);
+    if (result.ok === true) this._emit('claimed', result.entry, false);
     return result;
   }
 
@@ -595,7 +609,7 @@ export class EscalationClientService {
   async claimMany(params: ClaimManyParams): Promise<{ claimed: number; skipped: number }> {
     const hm = await this._engine(null, params.namespace);
     const { entries, skipped } = await (hm.engine.store as any).claimManyEscalations(params);
-    this._emitMany('claimed', entries);
+    this._emitMany('claimed', entries, false);
     return { claimed: entries.length, skipped };
   }
 
@@ -610,7 +624,7 @@ export class EscalationClientService {
   async claimManyByQuery(params: ClaimManyByQueryParams): Promise<{ claimed: number; entries: EscalationEntry[] }> {
     const hm = await this._engine(null, params.namespace);
     const entries = await (hm.engine.store as any).claimManyEscalationsByQuery(params);
-    this._emitMany('claimed', entries);
+    this._emitMany('claimed', entries, false);
     return { claimed: entries.length, entries };
   }
 

--- a/services/store/providers/postgres/postgres.ts
+++ b/services/store/providers/postgres/postgres.ts
@@ -1975,17 +1975,29 @@ class PostgresStoreService extends StoreService<
 
   // ─── hmsh_escalations ────────────────────────────────────────────────────────
 
+  // Born-assigned rows ($25 assignee, $26 durationMinutes): assignee alone is
+  // a durable pre-assignment (assigned_to, no window — a routing hint);
+  // with durationMinutes the TTL window is armed in the same INSERT, exactly
+  // as claimEscalation writes it (assigned_until = claim_expires_at). Both
+  // NULL → every claim column NULL, byte-identical to the pre-feature row.
   private _escalationInsertSql = `
     INSERT INTO public.hmsh_escalations
       (namespace, app_id, signal_key, topic, workflow_id, task_queue, workflow_type,
        type, subtype, entity, description, role, priority,
        origin_id, parent_id, initiated_by, created_by, trace_id, span_id,
-       task_id, escalation_payload, metadata, envelope, expires_at)
+       task_id, escalation_payload, metadata, envelope, expires_at,
+       assigned_to, assigned_until, claimed_at, claim_expires_at)
     VALUES
       ($1, $2, $3, $4, $5, $6, $7,
        $8, $9, $10, $11, $12, $13,
        $14, $15, $16, $17, $18, $19,
-       $20, $21, $22, $23, $24)
+       $20, $21, $22, $23, $24,
+       $25,
+       CASE WHEN $25::text IS NOT NULL AND $26::numeric IS NOT NULL
+            THEN NOW() + ($26::numeric * INTERVAL '1 minute') END,
+       CASE WHEN $25::text IS NOT NULL THEN NOW() END,
+       CASE WHEN $25::text IS NOT NULL AND $26::numeric IS NOT NULL
+            THEN NOW() + ($26::numeric * INTERVAL '1 minute') END)
     ON CONFLICT (namespace, app_id, signal_key) WHERE signal_key IS NOT NULL DO NOTHING`;
 
   private _escalationInsertParams(
@@ -1996,6 +2008,7 @@ class PostgresStoreService extends StoreService<
       type, subtype, entity, description, role, priority,
       originId, parentId, initiatedBy, createdBy, traceId, spanId,
       taskId, escalationPayload, metadata, envelope, expiresAt,
+      assignee, durationMinutes,
     } = params;
     return [
       namespace ?? 'hmsh',
@@ -2022,6 +2035,8 @@ class PostgresStoreService extends StoreService<
       metadata ? JSON.stringify(metadata) : null,
       envelope ? JSON.stringify(envelope) : null,
       expiresAt ?? null,
+      assignee ?? null,
+      durationMinutes ?? null,
     ];
   }
 

--- a/services/store/providers/postgres/postgres.ts
+++ b/services/store/providers/postgres/postgres.ts
@@ -2186,7 +2186,7 @@ class PostgresStoreService extends StoreService<
     startIdx = 1,
   ): { conditions: string[]; values: unknown[]; idx: number } {
     const { namespace, role, roles, type, subtype, entity, status, assignedTo, workflowId, originId,
-            available, priority, metadata, ids, taskId } = params;
+            parentId, available, priority, metadata, ids, taskId } = params;
     const conditions: string[] = [];
     const values: unknown[] = [];
     let idx = startIdx;
@@ -2201,6 +2201,7 @@ class PostgresStoreService extends StoreService<
     if (assignedTo)    { conditions.push(`assigned_to = $${idx++}`);                 values.push(assignedTo); }
     if (workflowId)    { conditions.push(`workflow_id = $${idx++}`);                 values.push(workflowId); }
     if (originId)      { conditions.push(`origin_id = $${idx++}`);                   values.push(originId); }
+    if (parentId)      { conditions.push(`parent_id = $${idx++}`);                   values.push(parentId); }
     if (priority !== undefined) { conditions.push(`priority = $${idx++}`);           values.push(priority); }
     if (metadata)      { conditions.push(`metadata @> $${idx++}::jsonb`);            values.push(JSON.stringify(metadata)); }
     if (ids?.length)   { conditions.push(`id = ANY($${idx++}::uuid[])`);             values.push(ids); }

--- a/tests/durable/escalations/postgres.test.ts
+++ b/tests/durable/escalations/postgres.test.ts
@@ -104,6 +104,36 @@ describe('DURABLE | escalations | Postgres', () => {
         workflow: workflows.slaGateHook,
       });
       await slaGate.run();
+      const preAssigned = await Worker.create({
+        connection,
+        taskQueue: 'escalation-test',
+        workflow: workflows.preAssignedWorkflow,
+      });
+      await preAssigned.run();
+      const hardClaim = await Worker.create({
+        connection,
+        taskQueue: 'escalation-test',
+        workflow: workflows.hardClaimWorkflow,
+      });
+      await hardClaim.run();
+      const collatedAssigned = await Worker.create({
+        connection,
+        taskQueue: 'escalation-test',
+        workflow: workflows.collatedAssignedWorkflow,
+      });
+      await collatedAssigned.run();
+      const assignedParent = await Worker.create({
+        connection,
+        taskQueue: 'escalation-test',
+        workflow: workflows.assignedHookParent,
+      });
+      await assignedParent.run();
+      const assignedGate = await Worker.create({
+        connection,
+        taskQueue: 'escalation-test',
+        workflow: workflows.assignedGateHook,
+      });
+      await assignedGate.run();
       // Wait for the condition() to fire and write the escalation row
       await sleepFor(2000);
     }, 15_000);
@@ -124,6 +154,12 @@ describe('DURABLE | escalations | Postgres', () => {
       expect(esc!.priority).toBe(2);
       expect((esc!.metadata as any)?.orderId).toBe(orderId);
       expect((esc!.metadata as any)?.region).toBe(region);
+      // Regression guard for assign-at-creation: a no-assignee config writes
+      // a row byte-identical to before the feature — all four claim columns NULL.
+      expect(esc!.assigned_to).toBeNull();
+      expect(esc!.assigned_until).toBeNull();
+      expect(esc!.claimed_at).toBeNull();
+      expect(esc!.claim_expires_at).toBeNull();
     }, 5_000);
 
     it('should list by type+subtype filter', async () => {
@@ -1601,6 +1637,228 @@ describe('DURABLE | escalations | Postgres', () => {
       const [row] = await client.escalations.list({ ids: [esc!.id] });
       expect(row.status).toBe('resolved');
     }, 90_000);
+  });
+
+  describe('assign at creation — condition({ assignee }) / create({ assignee })', () => {
+    const alice = 'alice@example.com';
+    const bob = 'bob@example.com';
+    const findByRole = async (role: string, orderId: string, item?: string) => {
+      for (let i = 0; i < 40; i++) {
+        const list = await client.escalations.list({ role });
+        const esc = list.find((e) => {
+          const m = e.metadata as any;
+          return m?.orderId === orderId && (item === undefined || m?.item === item);
+        });
+        if (esc) return esc;
+        await sleepFor(500);
+      }
+      return undefined;
+    };
+
+    it('condition({ assignee }) — row born pre-assigned: routing hint, resolvable by the assignee', async () => {
+      const orderId = guid();
+      const h = await client.workflow.start({
+        args: [orderId, alice],
+        taskQueue: 'escalation-test',
+        workflowName: 'preAssignedWorkflow',
+        workflowId: guid(),
+      });
+
+      const esc = await findByRole('handoff-approver', orderId);
+      expect(esc).toBeDefined();
+      // Born assigned, atomically with the Leg1 checkpoint: no unassigned window.
+      expect(esc!.status).toBe('pending');
+      expect(esc!.assigned_to).toBe(alice);
+      // Pre-assignment shape: no TTL window — a routing hint, not a lock.
+      expect(esc!.assigned_until).toBeNull();
+      expect(esc!.claim_expires_at).toBeNull();
+      expect(esc!.claimed_at).not.toBeNull();
+
+      // Immediately visible in the assignee's worklist.
+      const mine = await client.escalations.list({ assignedTo: alice });
+      expect(mine.some((e) => e.id === esc!.id)).toBe(true);
+
+      // The assignee resolves it directly — no prior claim() required.
+      const resolved = await client.escalations.resolve({
+        id: esc!.id,
+        resolverPayload: { approved: true },
+        assertClaim: alice,
+      });
+      expect(resolved.ok).toBe(true);
+      const output = await h.result();
+      expect((output as any).approved).toBe(true);
+    }, 60_000);
+
+    it('condition({ assignee, durationMinutes }) — row born hard-claimed: locked to the assignee', async () => {
+      const orderId = guid();
+      const h = await client.workflow.start({
+        args: [orderId, alice, 30],
+        taskQueue: 'escalation-test',
+        workflowName: 'hardClaimWorkflow',
+        workflowId: guid(),
+      });
+
+      const esc = await findByRole('handoff-approver', orderId);
+      expect(esc).toBeDefined();
+      // Full claim shape at creation — identical to a post-create claim().
+      expect(esc!.status).toBe('pending');
+      expect(esc!.assigned_to).toBe(alice);
+      expect(esc!.assigned_until).not.toBeNull();
+      expect(esc!.claim_expires_at).not.toBeNull();
+      expect(esc!.claimed_at).not.toBeNull();
+      expect(new Date(esc!.assigned_until!).getTime()).toBeGreaterThan(Date.now());
+
+      // The window locks the row: a different assignee cannot claim...
+      const steal = await client.escalations.claim({
+        id: esc!.id,
+        assignee: bob,
+        durationMinutes: 5,
+      });
+      expect(steal.ok).toBe(false);
+      if (steal.ok === false) expect(steal.reason).toBe('conflict');
+
+      // ...and cannot resolve when asserting their claim.
+      const blocked = await client.escalations.resolve({
+        id: esc!.id,
+        resolverPayload: { approved: true },
+        assertClaim: bob,
+      });
+      expect(blocked.ok).toBe(false);
+      if (blocked.ok === false) expect(blocked.reason).toBe('claimed-by-other');
+
+      // The born-assignee resolves and the workflow resumes.
+      const resolved = await client.escalations.resolve({
+        id: esc!.id,
+        resolverPayload: { approved: true },
+        assertClaim: alice,
+      });
+      expect(resolved.ok).toBe(true);
+      const output = await h.result();
+      expect((output as any).approved).toBe(true);
+    }, 60_000);
+
+    it('create({ assignee }) — standalone row born pre-assigned; still claimable by another (not a lock)', async () => {
+      const esc = await client.escalations.create({
+        role: 'handoff-standalone',
+        type: 'handoff-standalone',
+        metadata: { tag: `born-soft-${guid()}` },
+        assignee: alice,
+      });
+      // The created entry (also the `created` event payload) carries the assignment.
+      expect(esc.assigned_to).toBe(alice);
+      expect(esc.assigned_until).toBeNull();
+      expect(esc.claim_expires_at).toBeNull();
+      expect(esc.claimed_at).not.toBeNull();
+
+      // Pre-assignment is a routing hint: another user may still claim it.
+      const claim = await client.escalations.claim({
+        id: esc.id,
+        assignee: bob,
+        durationMinutes: 5,
+      });
+      expect(claim.ok).toBe(true);
+      if (claim.ok) expect(claim.entry.assigned_to).toBe(bob);
+    }, 10_000);
+
+    it('create({ assignee, durationMinutes }) — standalone row born hard-claimed', async () => {
+      const esc = await client.escalations.create({
+        role: 'handoff-standalone',
+        type: 'handoff-standalone',
+        metadata: { tag: `born-hard-${guid()}` },
+        assignee: alice,
+        durationMinutes: 30,
+      });
+      expect(esc.assigned_to).toBe(alice);
+      expect(esc.assigned_until).not.toBeNull();
+      expect(esc.claim_expires_at).not.toBeNull();
+
+      const steal = await client.escalations.claim({
+        id: esc.id,
+        assignee: bob,
+        durationMinutes: 5,
+      });
+      expect(steal.ok).toBe(false);
+      if (steal.ok === false) expect(steal.reason).toBe('conflict');
+
+      const resolved = await client.escalations.resolve({
+        id: esc.id,
+        resolverPayload: { done: true },
+        assertClaim: alice,
+      });
+      expect(resolved.ok).toBe(true);
+    }, 10_000);
+
+    it('create({ durationMinutes }) with no assignee — the window fields stay NULL', async () => {
+      const esc = await client.escalations.create({
+        role: 'handoff-standalone',
+        type: 'handoff-standalone',
+        metadata: { tag: `no-assignee-${guid()}` },
+        durationMinutes: 30,
+      });
+      expect(esc.assigned_to).toBeNull();
+      expect(esc.assigned_until).toBeNull();
+      expect(esc.claimed_at).toBeNull();
+      expect(esc.claim_expires_at).toBeNull();
+    }, 10_000);
+
+    it('collated Promise.all — the assigned item is born assigned, its sibling is not', async () => {
+      const orderId = guid();
+      const h = await client.workflow.start({
+        args: [orderId, alice],
+        taskQueue: 'escalation-test',
+        workflowName: 'collatedAssignedWorkflow',
+        workflowId: guid(),
+      });
+
+      const escA = await findByRole('handoff-collated', orderId, 'a');
+      const escB = await findByRole('handoff-collated', orderId, 'b');
+      expect(escA).toBeDefined();
+      expect(escB).toBeDefined();
+      expect(escA!.assigned_to).toBe(alice);
+      expect(escA!.assigned_until).toBeNull();
+      expect(escB!.assigned_to).toBeNull();
+
+      const [ra, rb] = await Promise.all([
+        client.escalations.resolve({ id: escA!.id, resolverPayload: { item: 'a' }, assertClaim: alice }),
+        client.escalations.resolve({ id: escB!.id, resolverPayload: { item: 'b' } }),
+      ]);
+      expect(ra.ok).toBe(true);
+      expect(rb.ok).toBe(true);
+
+      const output = await h.result();
+      expect((output as any).a?.item).toBe('a');
+      expect((output as any).b?.item).toBe('b');
+    }, 120_000);
+
+    it('execHook (signaler path) — the hook wait writes its row born assigned', async () => {
+      const orderId = guid();
+      const h = await client.workflow.start({
+        args: [orderId, alice, '5 seconds'],
+        taskQueue: 'escalation-test',
+        workflowName: 'assignedHookParent',
+        workflowId: guid(),
+      });
+
+      // The signaler-branch waiter wrote the row born assigned.
+      const esc = await findByRole('handoff-hook', orderId);
+      expect(esc).toBeDefined();
+      expect(esc!.assigned_to).toBe(alice);
+      expect(esc!.assigned_until).toBeNull();
+      expect(esc!.claimed_at).not.toBeNull();
+      expect(esc!.signal_key).not.toBeNull();
+
+      // Hook waits complete via their SLA leg (resolution delivery targets
+      // the main flow) — the timer also proves expiry works on a born-assigned row.
+      const output = await h.result();
+      expect((output as any).outcome).toBe('timed-out');
+      let row = esc;
+      for (let i = 0; i < 30; i++) {
+        [row] = await client.escalations.list({ ids: [esc!.id] });
+        if (row?.status === 'expired') break;
+        await sleepFor(500);
+      }
+      expect(row!.status).toBe('expired');
+    }, 120_000);
   });
 
   describe('SLA-gated wait in a collated Promise.all (the collator reentry path)', () => {

--- a/tests/durable/escalations/postgres.test.ts
+++ b/tests/durable/escalations/postgres.test.ts
@@ -1657,8 +1657,9 @@ describe('DURABLE | escalations | Postgres', () => {
 
     it('condition({ assignee }) — row born pre-assigned: routing hint, resolvable by the assignee', async () => {
       const orderId = guid();
+      const parentId = guid();
       const h = await client.workflow.start({
-        args: [orderId, alice],
+        args: [orderId, alice, parentId],
         taskQueue: 'escalation-test',
         workflowName: 'preAssignedWorkflow',
         workflowId: guid(),
@@ -1673,10 +1674,19 @@ describe('DURABLE | escalations | Postgres', () => {
       expect(esc!.assigned_until).toBeNull();
       expect(esc!.claim_expires_at).toBeNull();
       expect(esc!.claimed_at).not.toBeNull();
+      // Lineage: the caller-supplied parentId persists (the hand-off
+      // correlation key), and claimed_at equals created_at — both written by
+      // the same statement's NOW() — so a fallback query is precise.
+      expect(esc!.parent_id).toBe(parentId);
+      expect(new Date(esc!.claimed_at!).getTime()).toBe(new Date(esc!.created_at).getTime());
 
-      // Immediately visible in the assignee's worklist.
+      // Immediately visible in the assignee's worklist — and via the
+      // hand-off fallback query: the child of a known parent, assigned to me.
       const mine = await client.escalations.list({ assignedTo: alice });
       expect(mine.some((e) => e.id === esc!.id)).toBe(true);
+      const children = await client.escalations.list({ parentId, assignedTo: alice });
+      expect(children.length).toBe(1);
+      expect(children[0].id).toBe(esc!.id);
 
       // The assignee resolves it directly — no prior claim() required.
       const resolved = await client.escalations.resolve({

--- a/tests/durable/escalations/src/workflows.ts
+++ b/tests/durable/escalations/src/workflows.ts
@@ -157,7 +157,11 @@ export async function gangMemberWorkflow(gangId: string, unitId: string): Promis
 
 // Born pre-assigned: the escalation row is created already routed to a named
 // user (assigned_to set, no TTL window) in the same Leg1 commit as the wait.
-export async function preAssignedWorkflow(orderId: string, assignee: string): Promise<unknown> {
+export async function preAssignedWorkflow(
+  orderId: string,
+  assignee: string,
+  parentId: string,
+): Promise<unknown> {
   const signalId = `pre-assigned-${Durable.guid()}`;
   const result = await Durable.workflow.condition<Record<string, unknown>>(signalId, {
     role: 'handoff-approver',
@@ -166,6 +170,7 @@ export async function preAssignedWorkflow(orderId: string, assignee: string): Pr
     description: `Hand-off for ${orderId}`,
     metadata: { orderId },
     assignee,
+    parentId,
   });
   return result;
 }

--- a/tests/durable/escalations/src/workflows.ts
+++ b/tests/durable/escalations/src/workflows.ts
@@ -155,6 +155,104 @@ export async function gangMemberWorkflow(gangId: string, unitId: string): Promis
   return result;
 }
 
+// Born pre-assigned: the escalation row is created already routed to a named
+// user (assigned_to set, no TTL window) in the same Leg1 commit as the wait.
+export async function preAssignedWorkflow(orderId: string, assignee: string): Promise<unknown> {
+  const signalId = `pre-assigned-${Durable.guid()}`;
+  const result = await Durable.workflow.condition<Record<string, unknown>>(signalId, {
+    role: 'handoff-approver',
+    type: 'handoff-soft',
+    priority: 2,
+    description: `Hand-off for ${orderId}`,
+    metadata: { orderId },
+    assignee,
+  });
+  return result;
+}
+
+// Born hard-claimed: assignee + durationMinutes arms the claim TTL window at
+// creation, locking the row to the assignee exactly as a post-create claim().
+export async function hardClaimWorkflow(
+  orderId: string,
+  assignee: string,
+  durationMinutes: number,
+): Promise<unknown> {
+  const signalId = `hard-claim-${Durable.guid()}`;
+  const result = await Durable.workflow.condition<Record<string, unknown>>(signalId, {
+    role: 'handoff-approver',
+    type: 'handoff-hard',
+    priority: 2,
+    description: `Locked hand-off for ${orderId}`,
+    metadata: { orderId },
+    assignee,
+    durationMinutes,
+  });
+  return result;
+}
+
+// Born-assigned inside Promise.all — proves the collator_waiter path writes
+// the assignment. Item A is assigned; item B is a plain open wait.
+export async function collatedAssignedWorkflow(
+  orderId: string,
+  assignee: string,
+): Promise<{ a: unknown; b: unknown }> {
+  const sigA = `col-assigned-a-${Durable.guid()}`;
+  const sigB = `col-assigned-b-${Durable.guid()}`;
+  const [a, b] = await Promise.all([
+    Durable.workflow.condition<Record<string, unknown>>(sigA, {
+      role: 'handoff-collated',
+      type: 'handoff-collated',
+      priority: 2,
+      metadata: { orderId, item: 'a' },
+      assignee,
+    }),
+    Durable.workflow.condition<Record<string, unknown>>(sigB, {
+      role: 'handoff-collated',
+      type: 'handoff-collated',
+      priority: 2,
+      metadata: { orderId, item: 'b' },
+    }),
+  ]);
+  return { a, b };
+}
+
+// Born-assigned inside a hook function (execHook) — proves the signaler-branch
+// waiter path writes the assignment. Resolution delivery targets the main
+// flow's waiter (see condition() placement docs), so this gate completes via
+// its SLA timer and reports back through signal(), like slaGateHook.
+export async function assignedGateHook(
+  orderId: string,
+  assignee: string,
+  timeout: string,
+): Promise<void> {
+  const signalId = `assigned-hook-${orderId}`;
+  const result = await Durable.workflow.condition<Record<string, unknown>>(signalId, {
+    role: 'handoff-hook',
+    type: 'handoff-hook',
+    priority: 3,
+    metadata: { orderId },
+    assignee,
+    timeout,
+  });
+  await Durable.workflow.signal(`assigned-hook-done-${orderId}`, {
+    outcome: result === false ? 'timed-out' : 'resolved',
+  });
+}
+
+// The parent: spawns the assigned gate as a hook and awaits its verdict.
+export async function assignedHookParent(
+  orderId: string,
+  assignee: string,
+  timeout: string,
+): Promise<{ outcome: string }> {
+  return Durable.workflow.execHook<{ outcome: string }>({
+    taskQueue: 'escalation-test',
+    workflowName: 'assignedGateHook',
+    args: [orderId, assignee, timeout],
+    signalId: `assigned-hook-done-${orderId}`,
+  });
+}
+
 // Pauses at a condition and returns null when the escalation is cancelled,
 // or the resolver payload when resolved normally.
 export async function cancelAwareWorkflow(orderId: string): Promise<{ approved?: boolean; __escalation_cancelled?: boolean } | null> {

--- a/tests/durable/events/postgres.test.ts
+++ b/tests/durable/events/postgres.test.ts
@@ -84,13 +84,73 @@ describe('DURABLE | system-event emission | Postgres', () => {
       expect((evt.data as any).id).toBe(escalationId);
     }, 10_000);
 
-    it('claim fires system.escalation.*.claimed', async () => {
+    it('claim fires system.escalation.*.claimed with assigned_at_creation false', async () => {
       const before = collected.length;
       const result = await client.claim({ id: escalationId, assignee: 'alice', durationMinutes: 1, namespace: APP_ID });
       expect(result.ok).toBe(true);
       expect(collected.length).toBe(before + 1);
       const evt = collected[collected.length - 1];
       expect(evt.type).toBe(`system.escalation.${escalationId}.claimed`);
+      // Interactive claim — the assignment provenance marker states it plainly.
+      expect(evt.assigned_at_creation).toBe(false);
+    }, 10_000);
+
+    it('create with assignee fires created THEN claimed — one act, both statements', async () => {
+      const parentId = guid();
+      const before = collected.length;
+      const entry = await client.create({
+        namespace: APP_ID,
+        role: 'agent',
+        type: 'born-assigned-ticket',
+        assignee: 'alice',
+        parentId,
+      });
+      // Both events fire from the single create, in order: existence, then assignment.
+      expect(collected.length).toBe(before + 2);
+      const createdEvt = collected[before];
+      const claimedEvt = collected[before + 1];
+      expect(createdEvt.type).toBe(`system.escalation.${entry.id}.created`);
+      expect(claimedEvt.type).toBe(`system.escalation.${entry.id}.claimed`);
+      // The claimed event is canonical: directed assignment, full row, correlation key.
+      expect(claimedEvt.assigned_at_creation).toBe(true);
+      expect(claimedEvt.parent_id).toBe(parentId);
+      expect((claimedEvt.data as any).assigned_to).toBe('alice');
+      expect((claimedEvt.data as any).parent_id).toBe(parentId);
+      expect((createdEvt.data as any).assigned_to).toBe('alice');
+      // Distinct event_ids for the two verbs of the same commit.
+      expect(createdEvt.event_id).not.toBe(claimedEvt.event_id);
+    }, 10_000);
+
+    it('unassigned create fires created only — no claimed (regression guard)', async () => {
+      const before = collected.length;
+      const entry = await client.create({ namespace: APP_ID, role: 'agent', type: 'plain-ticket' });
+      expect(collected.length).toBe(before + 1);
+      expect(collected[before].type).toBe(`system.escalation.${entry.id}.created`);
+    }, 10_000);
+
+    it('idempotent re-create (ON CONFLICT no-op) emits nothing — exactly-once per committed row', async () => {
+      const signalKey = `replay-${guid()}`;
+      const first = await client.create({
+        namespace: APP_ID,
+        role: 'agent',
+        type: 'replay-ticket',
+        signalKey,
+        assignee: 'alice',
+      });
+      expect(first.assigned_to).toBe('alice');
+      const before = collected.length;
+      // Same (namespace, app_id, signal_key) — the INSERT no-ops and returns
+      // no row, so the emitters have nothing to publish. This is the same
+      // guard a crash-replayed Leg1 checkpoint rides through.
+      const replay = await client.create({
+        namespace: APP_ID,
+        role: 'agent',
+        type: 'replay-ticket',
+        signalKey,
+        assignee: 'alice',
+      });
+      expect(replay).toBeFalsy();
+      expect(collected.length).toBe(before);
     }, 10_000);
 
     it('release fires system.escalation.*.released', async () => {
@@ -210,8 +270,10 @@ describe('DURABLE | system-event emission | Postgres', () => {
       const result = await client.claimMany({ ids, assignee: 'batch-worker', durationMinutes: 5, namespace: APP_ID });
       expect(result.claimed).toBe(3);
       expect(result.skipped).toBe(0);
-      const after = collected.filter(e => e.type.endsWith('.claimed')).length;
-      expect(after - before).toBe(3);
+      const claimedEvts = collected.filter(e => e.type.endsWith('.claimed'));
+      expect(claimedEvts.length - before).toBe(3);
+      // Bulk interactive claims carry the provenance marker too.
+      claimedEvts.slice(-3).forEach(e => expect(e.assigned_at_creation).toBe(false));
     }, 10_000);
 
     it('claimMany skipped rows emit nothing', async () => {
@@ -223,6 +285,28 @@ describe('DURABLE | system-event emission | Postgres', () => {
       expect(result.skipped).toBe(1);
       expect(collected.length).toBe(before); // no event
     }, 10_000);
+
+    it('claimByMetadata and claimManyByQuery carry assigned_at_creation false', async () => {
+      const tag = guid();
+      await client.create({ namespace: APP_ID, role: 'bulk-tester', type: 'bulk-meta', metadata: { tag } });
+      const byMeta = await client.claimByMetadata({
+        key: 'tag', value: tag, assignee: 'meta-worker', durationMinutes: 5, namespace: APP_ID,
+      });
+      expect(byMeta.ok).toBe(true);
+      const metaEvt = collected[collected.length - 1];
+      expect(metaEvt.type).toMatch(/\.claimed$/);
+      expect(metaEvt.assigned_at_creation).toBe(false);
+
+      const tag2 = guid();
+      await client.create({ namespace: APP_ID, role: 'bulk-tester', type: 'bulk-query', metadata: { tag2 } });
+      const byQuery = await client.claimManyByQuery({
+        query: { metadata: { tag2 } }, assignee: 'query-worker', durationMinutes: 5, namespace: APP_ID,
+      });
+      expect(byQuery.claimed).toBe(1);
+      const queryEvt = collected[collected.length - 1];
+      expect(queryEvt.type).toMatch(/\.claimed$/);
+      expect(queryEvt.assigned_at_creation).toBe(false);
+    }, 15_000);
 
     it('resolveMany emits one event per resolved row', async () => {
       const before = collected.filter(e => e.type.endsWith('.resolved')).length;
@@ -340,6 +424,70 @@ describe('DURABLE | system-event emission | Postgres', () => {
       expect((createdEvt!.data as any).signal_key).not.toBeNull();
       expect((createdEvt!.data as any).workflow_id).toBeDefined();
       expect(createdEvt!.event_id).toMatch(/^[^:]+:created:/);
+
+      // Regression guard: an unassigned condition() row emits NO claimed event.
+      const rowId = (createdEvt!.data as any).id;
+      const claimedForRow = collected.find(e => e.type === `system.escalation.${rowId}.claimed`);
+      expect(claimedForRow).toBeUndefined();
     }, 20_000);
+
+    // Born-assigned condition(): the engine states the hand-off canonically —
+    // created (existence) then claimed (assignment), both carrying the full
+    // row with parent_id, the claimed event marked assigned_at_creation.
+    async function bornAssignedWorkflow(orderId: string, assignee: string, parentId: string): Promise<unknown> {
+      const signalId = `born-${Durable.guid()}`;
+      return Durable.workflow.condition(signalId, {
+        role: 'reviewer',
+        type: 'event-test-handoff',
+        priority: 1,
+        metadata: { orderId },
+        assignee,
+        parentId,
+      });
+    }
+
+    it('born-assigned condition() emits created then claimed with assigned_at_creation + parent_id', async () => {
+      const orderId = guid();
+      const parentId = guid();
+      const sharedPublish = (e: SystemEvent) => { collected.push(e); };
+
+      const client = new Durable.Client({
+        connection,
+        events: { publish: sharedPublish },
+      });
+      await client.workflow.start({
+        args: [orderId, 'alice@example.com', parentId],
+        taskQueue,
+        workflowName: 'bornAssignedWorkflow',
+        workflowId: guid(),
+      });
+      const worker = await Durable.Worker.create({
+        connection,
+        taskQueue,
+        workflow: bornAssignedWorkflow,
+        events: { publish: sharedPublish },
+      });
+      await worker.run();
+      await sleepFor(4000);
+
+      const createdEvt = collected.find(e =>
+        e.type.endsWith('.created') && (e.data as any)?.metadata?.orderId === orderId,
+      );
+      expect(createdEvt).toBeTruthy();
+      const rowId = (createdEvt!.data as any).id;
+      const claimedEvt = collected.find(e => e.type === `system.escalation.${rowId}.claimed`);
+      expect(claimedEvt).toBeTruthy();
+
+      // Ordering: existence precedes assignment, from the same performing actor.
+      expect(collected.indexOf(createdEvt!)).toBeLessThan(collected.indexOf(claimedEvt!));
+
+      // The canonical hand-off predicate: verb + assignee + provenance + lineage.
+      expect(claimedEvt!.assigned_at_creation).toBe(true);
+      expect(claimedEvt!.parent_id).toBe(parentId);
+      expect((claimedEvt!.data as any).assigned_to).toBe('alice@example.com');
+      expect((claimedEvt!.data as any).parent_id).toBe(parentId);
+      expect((createdEvt!.data as any).parent_id).toBe(parentId);
+      expect(claimedEvt!.event_id).toMatch(/^[^:]+:claimed:/);
+    }, 30_000);
   });
 });

--- a/types/hmsh_escalations.ts
+++ b/types/hmsh_escalations.ts
@@ -207,6 +207,12 @@ export interface ListEscalationsParams {
   assignedTo?: string;
   workflowId?: string;
   originId?: string;
+  /**
+   * Filter by `parent_id` — the hand-off lineage key. With `assignedTo`
+   * this is the precise fallback query for a born-assigned child: "the
+   * child of the escalation I just resolved, assigned to me."
+   */
+  parentId?: string;
   /** When true, returns only rows without an active claim. When false, returns only actively claimed rows. */
   available?: boolean;
   /** Exact priority match. */

--- a/types/hmsh_escalations.ts
+++ b/types/hmsh_escalations.ts
@@ -18,6 +18,22 @@ export interface ConditionQueueConfig {
   envelope?: Record<string, unknown>;
   expiresAt?: Date;
   /**
+   * Born-assigned: writes `assigned_to` in the same atomic INSERT that
+   * creates the row — on the `condition()` path, one commit with the
+   * workflow's Leg1 checkpoint. Alone it is a durable pre-assignment: the
+   * row surfaces in the assignee's `list({ assignedTo })` immediately, is
+   * resolvable by the assignee with `assertClaim`, and remains claimable
+   * by others (a routing hint). With `durationMinutes` it is a hard claim
+   * at creation. The `created` event payload carries the assignment.
+   */
+  assignee?: string;
+  /**
+   * With `assignee`, arms the claim TTL window (`assigned_until` /
+   * `claim_expires_at`) at creation — the row is born locked to the
+   * assignee, exactly as a post-create `claim()` locks it.
+   */
+  durationMinutes?: number;
+  /**
    * SLA timer for the wait itself (e.g. `'30m'`, `'24h'`). Arms the same
    * resume timer as `condition(signalId, '30m')`: when it fires first, the
    * workflow resumes with `false` and the escalation row transitions
@@ -257,6 +273,14 @@ export interface CreateEscalationParams {
   metadata?: Record<string, unknown>;
   envelope?: Record<string, unknown>;
   expiresAt?: Date;
+  /**
+   * Born-assigned: writes `assigned_to` in the creation INSERT. See
+   * {@link ConditionQueueConfig.assignee} for the two modes (durable
+   * pre-assignment vs. hard claim with `durationMinutes`).
+   */
+  assignee?: string;
+  /** With `assignee`, arms the claim TTL window at creation. See {@link ConditionQueueConfig.durationMinutes}. */
+  durationMinutes?: number;
 }
 
 /**

--- a/types/system_events.ts
+++ b/types/system_events.ts
@@ -15,7 +15,7 @@
  * | verb        | trigger                                                  | `data` shape        |
  * |-------------|----------------------------------------------------------|---------------------|
  * | `created`   | `client.create()` or hook Leg1 INSERT                    | full `EscalationEntry` row |
- * | `claimed`   | `client.claim()` / `client.claimByMetadata()`            | full `EscalationEntry` row |
+ * | `claimed`   | `client.claim()` / `client.claimByMetadata()` / born-assigned create (`assignee` set) | full `EscalationEntry` row |
  * | `released`  | `client.release()`                                       | full `EscalationEntry` row |
  * | `reassigned`| `client.escalateToRole()` / role change                  | full `EscalationEntry` row |
  * | `resolved`  | `client.resolve()` / `client.resolveByMetadata()`        | full `EscalationEntry` row |
@@ -73,6 +73,20 @@
  * - Escalation: `${id}:${verb}:${updated_at_iso}` — claim→release→reclaim
  *   produces distinct IDs because `updated_at` changes on each transition.
  * - Engine / worker: `${app_id_or_queue}:${verb}:${ts}`.
+ *
+ * ## Replay / retry semantics (at-most-once)
+ *
+ * Both escalation-create emitters publish from the INSERT's `RETURNING *`
+ * row. An idempotent re-run — a crash-replayed Leg1 checkpoint or a
+ * retried `create()` hitting `ON CONFLICT … DO NOTHING` — returns no row,
+ * so the no-op emits nothing: `created`/`claimed` fire exactly once per
+ * row that actually commits. The remaining gap is a crash landing between
+ * the commit and the post-commit fire-and-forget publish, which drops the
+ * event; recover a missed born-assigned hand-off with the precise
+ * fallback query (`list({ parentId, assignedTo })` — `claimed_at` equals
+ * `created_at` on such rows). A hypothetical duplicate would carry the
+ * identical `event_id` (the row's `updated_at` is unchanged by a no-op),
+ * so consumer-side `event_id` dedup remains a safe belt-and-braces guard.
  *
  * ## Fire-and-forget contract
  *
@@ -151,6 +165,17 @@ export interface SystemEvent {
   parent_id?: string;
   trace_id?: string;
   span_id?: string;
+  /**
+   * Assignment provenance, present on every `claimed` event. `true` when
+   * the row was born assigned (a directed, programmatic assignment via
+   * `condition({ assignee })` / `create({ assignee })` — the engine emits
+   * `created` then `claimed` from the same commit); `false` when a caller
+   * claimed it interactively (`claim`, `claimByMetadata`, `claimMany`,
+   * `claimManyByQuery`). Lets a consumer distinguish system-directed
+   * hand-offs from claims it observes, as a stated fact of the transition —
+   * the committed row alone cannot express how its assignment came to be.
+   */
+  assigned_at_creation?: boolean;
   /**
    * Full committed row for escalation events; lifecycle metadata for
    * engine/worker events. Each dependent cherry-picks fields for its


### PR DESCRIPTION
- `condition(signalId, { assignee })` and `client.escalations.create({ assignee })` create the row already assigned in one atomic commit — hand-off chains route the next escalation to a named user (e.g. `$resolution.resolvedBy`) with no unassigned claimable window and half the round-trips.
- Two modes, one INSERT: `assignee` alone is a durable pre-assignment (routing hint, resolvable by the assignee, claimable by others); with `durationMinutes` the row is born hard-claimed, identical to a post-create `claim()`. The `created` event payload carries the assignment.
- Proven across all four waiter topologies (inline, hard-claim, collated Promise.all, execHook signaler) plus standalone create, with a byte-identical regression guard for no-assignee configs — durable suite 459/459 green, factory schema v18.